### PR TITLE
[App Service] `az appservice plan`: Remove preview flag for managed instance app service plans and add Premium V3 SKU support

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -111,7 +111,7 @@ def load_arguments(self, _):
                    help='get regions which support hosting web apps on Windows Container workers')
         c.argument('linux_workers_enabled', action='store_true',
                    help='get regions which support hosting web apps on Linux workers')
-        c.argument('managed_instance_enabled', action='store_true', is_preview=True,
+        c.argument('managed_instance_enabled', action='store_true',
                    help='get regions which support hosting web apps on Managed Instance workers')
         c.argument('sku', arg_type=sku_arg_type)
 
@@ -145,24 +145,24 @@ subscription than the app service environment, please use the resource ID for --
         c.argument('zone_redundant', options_list=['--zone-redundant', '-z'], help='Enable zone redundancy for high availability. Minimum instance count is 2.')
         c.argument('tags', arg_type=tags_type)
         c.argument('async_scaling_enabled', arg_type=get_three_state_flag(), help='Enables async scaling for the app service plan. Set to "true" to create an async operation if there are insufficient workers to scale synchronously. The SKU must be Dedicated.')
-        c.argument('is_managed_instance', action='store_true', is_preview=True, help='host web app on managed instance')
-        c.argument('mi_system_assigned', is_preview=True,
+        c.argument('is_managed_instance', action='store_true', help='host web app on managed instance')
+        c.argument('mi_system_assigned',
                    arg_type=get_three_state_flag(),
                    help="Enable system-assigned managed identity for this app service plan.")
-        c.argument('mi_user_assigned', is_preview=True,
+        c.argument('mi_user_assigned',
                    nargs='+', help="Enable user-assigned managed identities for this app service plan. "
                    "Accepts space-separated list of identity resource IDs.")
-        c.argument('default_identity', is_preview=True,
+        c.argument('default_identity',
                    help='accept system or user assigned identity separated. Use \'[system]\' to refer system assigned identity, or a resource id to refer user assigned identity.')
-        c.argument('rdp_enabled', arg_type=get_three_state_flag(), is_preview=True,
+        c.argument('rdp_enabled', arg_type=get_three_state_flag(),
                    help='Enable RDP. Requires is-custom-mode to be true.')
-        c.argument('vnet', is_preview=True, help="Name or resource ID of the regional virtual network. If there are multiple vnets of the same name across different resource groups, use vnet resource id to specify which vnet to use. If vnet name is used, by default, the vnet in the same resource group as the webapp will be used. Must be used with --subnet argument.")
-        c.argument('subnet', is_preview=True, help="Name or resource ID of the pre-existing subnet to have the app service plan join. The --vnet is argument also needed if specifying subnet by name.")
-        c.argument('registry_adapters', options_list=['--registry-adapter'], is_preview=True, action=RegistryAdapterAddAction, nargs='+',
+        c.argument('vnet', help="Name or resource ID of the regional virtual network. If there are multiple vnets of the same name across different resource groups, use vnet resource id to specify which vnet to use. If vnet name is used, by default, the vnet in the same resource group as the webapp will be used. Must be used with --subnet argument.")
+        c.argument('subnet', help="Name or resource ID of the pre-existing subnet to have the app service plan join. The --vnet is argument also needed if specifying subnet by name.")
+        c.argument('registry_adapters', options_list=['--registry-adapter'], action=RegistryAdapterAddAction, nargs='+',
                    help="Registry adapter configurations. Provide key-value pairs for `registry-key=<key> type=<type> secret-uri=<uri>`.")
-        c.argument('install_scripts', options_list=['--install-script'], is_preview=True, action=InstallScriptAddAction, nargs='+',
+        c.argument('install_scripts', options_list=['--install-script'], action=InstallScriptAddAction, nargs='+',
                    help="Install script configurations. Provide key-value pairs for `name=<name> source-uri=<uri> type=<type>`.")
-        c.argument('storage_mounts', options_list=['--storage-mount'], is_preview=True, action=StorageMountAddAction, nargs='+',
+        c.argument('storage_mounts', options_list=['--storage-mount'], action=StorageMountAddAction, nargs='+',
                    help="Storage mount configurations. Provide key-value pairs for `name=<name> source=<source> type=<type> destination-path=<path> credentials-secret-uri=<uri>`.")
         c.argument('enriched_errors', options_list=['--enriched-errors'],
                    help='If true, Linux App Service plan creation failures will show context-enriched diagnostics with error codes, suggested fixes, and Copilot prompts. This flag only applies to Linux plans and has no effect on Windows or Hyper-V plans.',
@@ -176,17 +176,17 @@ subscription than the app service environment, please use the resource ID for --
         c.argument('number_of_workers', type=int, help='Number of workers to be allocated. Use this to scale out/in (add or remove instances), e.g. --number-of-workers 3.')
         c.ignore('allow_pending_state')
         c.argument('async_scaling_enabled', arg_type=get_three_state_flag(), help='Enables async scaling for the app service plan. Set to "true" to create an async operation if there are insufficient workers to scale synchronously. The SKU must be Dedicated.')
-        c.argument('default_identity', is_preview=True,
+        c.argument('default_identity',
                    help='accept system or user assigned identity separated. Use \'[system]\' to refer system assigned identity, or a resource id to refer user assigned identity.')
-        c.argument('rdp_enabled', arg_type=get_three_state_flag(), is_preview=True,
+        c.argument('rdp_enabled', arg_type=get_three_state_flag(),
                    help='Enable RDP. Requires is-custom-mode to be true.')
-        c.argument('vnet', is_preview=True, help="Name or resource ID of the regional virtual network. If there are multiple vnets of the same name across different resource groups, use vnet resource id to specify which vnet to use. If vnet name is used, by default, the vnet in the same resource group as the webapp will be used. Must be used with --subnet argument.")
-        c.argument('subnet', is_preview=True, help="Name or resource ID of the pre-existing subnet to have the app service plan join. The --vnet is argument also needed if specifying subnet by name.")
-        c.argument('registry_adapters', options_list=['--registry-adapter'], is_preview=True, action=RegistryAdapterAddAction, nargs='+',
+        c.argument('vnet', help="Name or resource ID of the regional virtual network. If there are multiple vnets of the same name across different resource groups, use vnet resource id to specify which vnet to use. If vnet name is used, by default, the vnet in the same resource group as the webapp will be used. Must be used with --subnet argument.")
+        c.argument('subnet', help="Name or resource ID of the pre-existing subnet to have the app service plan join. The --vnet is argument also needed if specifying subnet by name.")
+        c.argument('registry_adapters', options_list=['--registry-adapter'], action=RegistryAdapterAddAction, nargs='+',
                    help="Registry adapter configurations. Provide key-value pairs for `registry-key=<key> type=<type> secret-uri=<uri>`.")
-        c.argument('install_scripts', options_list=['--install-script'], is_preview=True, action=InstallScriptAddAction, nargs='+',
+        c.argument('install_scripts', options_list=['--install-script'], action=InstallScriptAddAction, nargs='+',
                    help="Install script configurations. Provide key-value pairs for `name=<name> source-uri=<uri> type=<type>`.")
-        c.argument('storage_mounts', options_list=['--storage-mount'], is_preview=True, action=StorageMountAddAction, nargs='+',
+        c.argument('storage_mounts', options_list=['--storage-mount'], action=StorageMountAddAction, nargs='+',
                    help="Storage mount configurations. Provide key-value pairs for `name=<name> source=<source> type=<type> destination-path=<path> credentials-secret-uri=<uri>`.")
 
     with self.argument_context('appservice plan delete') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/aaz/latest/appservice/plan/managed_instance/__cmd_group.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/aaz/latest/appservice/plan/managed_instance/__cmd_group.py
@@ -13,7 +13,6 @@ from azure.cli.core.aaz import *
 
 @register_command_group(
     "appservice plan managed-instance",
-    is_preview=True,
 )
 class __CMDGroup(AAZCommandGroup):
     """Manage Managed Instance

--- a/src/azure-cli/azure/cli/command_modules/appservice/aaz/latest/appservice/plan/managed_instance/instance/__cmd_group.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/aaz/latest/appservice/plan/managed_instance/instance/__cmd_group.py
@@ -13,7 +13,6 @@ from azure.cli.core.aaz import *
 
 @register_command_group(
     "appservice plan managed-instance instance",
-    is_preview=True,
 )
 class __CMDGroup(AAZCommandGroup):
     """Manage Instance

--- a/src/azure-cli/azure/cli/command_modules/appservice/aaz/latest/appservice/plan/managed_instance/instance/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/aaz/latest/appservice/plan/managed_instance/instance/_list.py
@@ -13,7 +13,6 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "appservice plan managed-instance instance list",
-    is_preview=True,
 )
 class List(AAZCommand):
     """List instances for a managed instance App Service plan.

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -351,11 +351,11 @@ def load_command_table(self, _):
         g.custom_command('add', 'add_plan_managed_instance_network')
         g.custom_command('remove', 'remove_plan_managed_instance_network')
 
-    with self.command_group('appservice plan managed-instance instance', custom_command_type=appservice_custom, is_preview=True) as g:
+    with self.command_group('appservice plan managed-instance instance', custom_command_type=appservice_custom) as g:
         g.custom_command('connect', 'connect_to_plan_instance')
         g.custom_command('recycle', 'recycle_plan_managed_instance')
 
-    with self.command_group('appservice plan identity', is_preview=True) as g:
+    with self.command_group('appservice plan identity') as g:
         g.custom_show_command('show', 'show_plan_identity')
         g.custom_command('assign', 'assign_plan_identity')
         g.custom_command('remove', 'remove_plan_identity')

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_list_locations_managed_instance_enabled.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_list_locations_managed_instance_enabled.yaml
@@ -13,35 +13,39 @@ interactions:
       ParameterSetName:
       - --sku --managed-instance-enabled
       User-Agent:
-      - AZURECLI/2.80.0 (MSI) azsdk-python-core/1.35.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?customModeWorkersEnabled=true&api-version=2025-03-01
   response:
     body:
       string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/North
         Europe","name":"North Europe","type":"Microsoft.Web/geoRegions","properties":{"name":"North
-        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"northeurope-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"northeurope-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
         Asia","name":"East Asia","type":"Microsoft.Web/geoRegions","properties":{"name":"East
-        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSP0V3;LINUXP0V3;WINDOWSMV3;LINUXMV3;FLEXCONSUMPTION;XENONMV3;MANAGEDAPP;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastasia-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSP0V3;LINUXP0V3;WINDOWSMV3;LINUXMV3;FLEXCONSUMPTION;XENONMV3;MANAGEDAPP;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastasia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
         East","name":"Australia East","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
-        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"ZONEREDUNDANCY;FCZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXMV3;LINUXP0V3;WINDOWSMV3;WINDOWSP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"australiaeast-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"ZONEREDUNDANCY;FCZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXMV3;LINUXP0V3;WINDOWSMV3;WINDOWSP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"australiaeast-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
         US","name":"East US","type":"Microsoft.Web/geoRegions","properties":{"name":"East
-        US","description":null,"sortOrder":2147483647,"displayName":"East US","orgDomain":"FCZONEREDUNDANCY;ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastus-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        US","description":null,"sortOrder":2147483647,"displayName":"East US","orgDomain":"FCZONEREDUNDANCY;ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastus-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        India","name":"Central India","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        India","description":null,"sortOrder":2147483647,"displayName":"Central India","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;XENONMV3;FLEXCONSUMPTION;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"centralindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        India","name":"South India","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        India","description":null,"sortOrder":2147483647,"displayName":"South India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSP0V3;WINDOWSMV3;LINUXMV3;LINUXP0V3;FLEXCONSUMPTION;MAVICSERIES","subDomains":"southindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
         Central US","name":"West Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"West
         Central US","description":null,"sortOrder":2147483647,"displayName":"West
-        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"westcentralus-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"westcentralus-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
         US 2 EUAP","name":"East US 2 EUAP","type":"Microsoft.Web/geoRegions","properties":{"name":"East
         US 2 EUAP","description":null,"sortOrder":2147483647,"displayName":"East US
-        2 EUAP","orgDomain":"EUAP;XENON;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;LINUXDYNAMIC;DSERIES;ZONEREDUNDANCY;FCZONEREDUNDANCY;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"eastus2euap-01.azurewebsites.net"}}],"nextLink":null,"id":null}'
+        2 EUAP","orgDomain":"EUAP;XENON;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;LINUXDYNAMIC;DSERIES;ZONEREDUNDANCY;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"eastus2euap-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}}],"nextLink":null,"id":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3773'
+      - '5474'
       content-type:
       - application/json
       date:
-      - Tue, 02 Dec 2025 21:06:09 GMT
+      - Wed, 01 Jul 2026 16:48:20 GMT
       expires:
       - '-1'
       pragma:
@@ -55,11 +59,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=d1dbc388-1013-482b-b171-79f4269ea689/westus/8e02ec0c-1691-4272-978d-45a5cf308eac
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=d1dbc388-1013-482b-b171-79f4269ea689/southcentralus/25f78215-38c1-4c32-a776-22fefa7312d3
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 7BCA295CDAE04B60BAE0B4ADDDF7D658 Ref B: SN4AA2022303049 Ref C: 2025-12-02T21:06:09Z'
+      - 'Ref A: 5B79FF431AFB4444817EF303557C3592 Ref B: SN4AA2022303045 Ref C: 2026-07-01T16:48:20Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -79,12 +83,12 @@ interactions:
       ParameterSetName:
       - --sku --managed-instance-enabled
       User-Agent:
-      - AZURECLI/2.80.0 (MSI) azsdk-python-core/1.35.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web","namespace":"Microsoft.Web","authorizations":[{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735","managedByRoleDefinitionId":"c29dde9f-14fa-40fb-9fe8-5a07be183f1e"}],"resourceTypes":[{"resourceType":"publishingUsers","locations":["Central
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web","namespace":"Microsoft.Web","authorizations":[{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735","managedByRoleDefinitionId":"c29dde9f-14fa-40fb-9fe8-5a07be183f1e"},{"applicationId":"a7d8f84e-510b-46d6-8f59-77e581db63bc","roleDefinitionId":"213f590f-d0be-4560-836d-7db7e2a32cca"}],"resourceTypes":[{"resourceType":"publishingUsers","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -95,10 +99,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostnameavailable","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostnameavailable","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -109,10 +114,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"validate","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"validate","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -123,10 +129,10 @@ interactions:
         Central","Switzerland North","Germany West Central","UAE North","Jio India
         West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
-        Central","Malaysia West","Austria East","Belgium Central","Taiwan North","Taiwan
-        Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway West","Norway
-        East","UAE Central","Germany North","Australia Central 2","East US 2 EUAP","Central
-        US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"isusernameavailable","locations":["Central
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","East
+        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"isusernameavailable","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -137,10 +143,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"generateGithubAccessTokenForAppserviceCLI","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"generateGithubAccessTokenForAppserviceCLI","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
         Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
@@ -150,11 +157,11 @@ interactions:
         South","Canada Central","West Europe","South India","West Central US","West
         US 3","East Asia","Japan East","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
-        Asia (Stage)","North Central US (Stage)","France South","South Africa West","Taiwan
-        North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sourceControls","locations":["Central
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","France
+        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sourceControls","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -165,10 +172,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"availableStacks","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"availableStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -179,10 +187,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"webAppStacks","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"webAppStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -193,10 +202,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","West US","Australia
         East","Brazil South","Southeast Asia","Japan West","Central India","UK South","Canada
@@ -206,11 +216,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","Jio India
         West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
         Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","Central
-        US","West US 2","Norway West","Norway East","UAE Central","Germany North","Brazil
-        Southeast","Sweden South","Switzerland West","Australia Central 2","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
+        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -221,10 +231,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -234,31 +245,35 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","West
-        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
-        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"staticSites","locations":["West
-        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2024-04-01","capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"staticSites","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-11-preview","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2024-04-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"locations/previewStaticSiteWorkflowFile","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"locations/staticSitesOperationStatuses","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/linkedBackends","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"locations/staticSitesOperationResults","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/linkedBackends","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/databaseConnections","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/linkedBackends","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/databaseConnections","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/linkedBackends","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/databaseConnections","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/databaseConnections","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSiteRegions","locations":["Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSiteRegions","locations":["Central
         US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
         US 2 EUAP","Central US EUAP"],"apiVersions":["2024-04-01"],"capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
@@ -271,10 +286,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/getNetworkPolicies","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/getNetworkPolicies","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -282,7 +298,7 @@ interactions:
         South","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
         Europe","East US 2 (Stage)","Central US (Stage)","France Central","West Central
         US","Jio India West","France South","East Asia (Stage)","North Central US
-        (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operations","locations":["MSFT
+        (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operations","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
         Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
@@ -292,11 +308,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","South
         India","West Central US","West US 3","Jio India West","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Malaysia West","Chile Central","Austria East","Belgium Central","East
-        US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
         Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
         South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["MSFT
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
         Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
@@ -306,11 +322,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","South
         India","West Central US","West US 3","Jio India West","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Malaysia West","Chile Central","Austria East","Belgium Central","East
-        US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
         Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
         South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["MSFT
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -320,11 +336,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -334,11 +350,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -348,11 +364,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -362,11 +378,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -377,10 +393,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -390,11 +407,12 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","Norway West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
-        South","Switzerland West","North Central US","East Asia (Stage)","North Central
-        US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
         SupportsTags, SupportsLocation"},{"resourceType":"sites/certificates","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
@@ -405,10 +423,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
-        West","Austria East","Belgium Central","France South","South Africa West","East
-        US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"sites/slots/certificates","locations":["MSFT
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"sites/slots/certificates","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
         US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
@@ -418,10 +437,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
-        West","Austria East","Belgium Central","France South","South Africa West","East
-        US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"serverFarms","locations":["MSFT
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"serverFarms","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -431,11 +451,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"sites","locations":["MSFT West US","MSFT
         East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
@@ -447,11 +467,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"sites/slots","locations":["MSFT West US","MSFT
         East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
@@ -463,14 +483,26 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"runtimes","locations":["France South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":["France
-        South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"aseregions","locations":["South
+        SupportsLocation"},{"resourceType":"runtimes","locations":["France South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"recommendations","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"aseregions","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
         East","West US","Australia East","Brazil South","Southeast Asia","Central
@@ -481,16 +513,22 @@ interactions:
         Central","West Europe","South India","West Central US","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
         Central","Chile Central","Malaysia West","Austria East","Belgium Central","West
-        US 3","Jio India West","France South","South Africa West","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","Australia Central 2","Taiwan North","Taiwan Northwest","East Asia (Stage)","North
-        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2023-12-01","capabilities":"None"},{"resourceType":"georegions","locations":["West
+        US 3","Jio India West","Denmark East","France South","South Africa West","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","Australia Central 2","Taiwan North","Taiwan Northwest","East
+        Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2023-12-01","capabilities":"None"},{"resourceType":"georegions","locations":["West
         Europe","West US","East US","West India","North Central US","West Central
         US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","East US 2","France Central","Japan East","Korea Central","Korea South","South
         Africa North","South Central US","Southeast Asia","South India","UK South","UK
-        West","West US 3","France South","East US 2 EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["MSFT
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -500,11 +538,12 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","Norway West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
-        South","Switzerland West","North Central US","East Asia (Stage)","North Central
-        US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East US 2","East US","UK South","Southeast
@@ -515,29 +554,29 @@ interactions:
         South","Canada Central","South India","West Central US","West US 3","Jio India
         West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
         Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"Australia
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["1","2","3"]},{"location":"Austria East","zones":[]},{"location":"Belgium
         Central","zones":[]},{"location":"Brazil South","zones":["1","2","3"]},{"location":"Canada
         Central","zones":["1","2","3"]},{"location":"Central India","zones":[]},{"location":"Central
         US","zones":["1","2","3"]},{"location":"Central US EUAP","zones":[]},{"location":"Chile
-        Central","zones":[]},{"location":"East Asia","zones":[]},{"location":"East
-        US","zones":["1","2","3"]},{"location":"East US 2","zones":["1","2","3"]},{"location":"East
-        US 2 EUAP","zones":["1","2","3"]},{"location":"France Central","zones":["1","2","3"]},{"location":"Germany
-        West Central","zones":["1","2","3"]},{"location":"Indonesia Central","zones":[]},{"location":"Israel
-        Central","zones":[]},{"location":"Italy North","zones":[]},{"location":"Japan
-        East","zones":["1","2","3"]},{"location":"Japan West","zones":[]},{"location":"Korea
-        Central","zones":[]},{"location":"Malaysia West","zones":[]},{"location":"Mexico
-        Central","zones":[]},{"location":"New Zealand North","zones":[]},{"location":"North
-        Europe","zones":["1","2","3"]},{"location":"Norway East","zones":[]},{"location":"Poland
-        Central","zones":[]},{"location":"Qatar Central","zones":[]},{"location":"South
-        Africa North","zones":["1","2","3"]},{"location":"South Central US","zones":["1","2","3"]},{"location":"Southeast
-        Asia","zones":["1","2","3"]},{"location":"Spain Central","zones":[]},{"location":"Sweden
-        Central","zones":[]},{"location":"Switzerland North","zones":[]},{"location":"UAE
-        North","zones":[]},{"location":"UK South","zones":["1","2","3"]},{"location":"West
+        Central","zones":[]},{"location":"Denmark East","zones":[]},{"location":"East
+        Asia","zones":[]},{"location":"East US","zones":["1","2","3"]},{"location":"East
+        US 2","zones":["1","2","3"]},{"location":"East US 2 EUAP","zones":["1","2","3"]},{"location":"France
+        Central","zones":["1","2","3"]},{"location":"Germany West Central","zones":["1","2","3"]},{"location":"Indonesia
+        Central","zones":[]},{"location":"Israel Central","zones":[]},{"location":"Italy
+        North","zones":[]},{"location":"Japan East","zones":["1","2","3"]},{"location":"Japan
+        West","zones":[]},{"location":"Korea Central","zones":[]},{"location":"Malaysia
+        West","zones":[]},{"location":"Mexico Central","zones":[]},{"location":"New
+        Zealand North","zones":[]},{"location":"North Europe","zones":["1","2","3"]},{"location":"Norway
+        East","zones":[]},{"location":"Poland Central","zones":[]},{"location":"Qatar
+        Central","zones":[]},{"location":"South Africa North","zones":["1","2","3"]},{"location":"South
+        Central US","zones":["1","2","3"]},{"location":"Southeast Asia","zones":["1","2","3"]},{"location":"Spain
+        Central","zones":[]},{"location":"Sweden Central","zones":[]},{"location":"Switzerland
+        North","zones":[]},{"location":"UAE North","zones":[]},{"location":"UK South","zones":["1","2","3"]},{"location":"West
         Europe","zones":["1","2","3"]},{"location":"West US 2","zones":["1","2","3"]},{"location":"West
         US 3","zones":[]}],"capabilities":"SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["MSFT
@@ -550,11 +589,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -564,13 +603,13 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["West
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["West
         Central US","East US","West Europe","Jio India West","North Europe","Canada
-        Central","East US 2","North Central US (Stage)","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2021-03-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","East US 2","North Central US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2021-03-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"deploymentLocations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
@@ -582,10 +621,10 @@ interactions:
         Central","Switzerland North","Germany West Central","UAE North","Jio India
         West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
-        Central","Malaysia West","Austria East","Belgium Central","Taiwan North","Taiwan
-        Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway West","Norway
-        East","UAE Central","Germany North","Australia Central 2","France South","South
-        Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["MSFT
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -595,11 +634,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","West
-        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
-        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -609,12 +648,12 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","West
-        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
-        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":["France
-        South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -624,11 +663,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/validateDeleteVirtualNetworkOrSubnets","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/validateDeleteVirtualNetworkOrSubnets","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -638,11 +677,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/listVirtualNetworkIntegrations","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/listVirtualNetworkIntegrations","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -652,11 +691,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/purgeUnusedVirtualNetworkIntegration","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/purgeUnusedVirtualNetworkIntegration","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -666,11 +705,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"connections","locations":["North
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"connections","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -681,21 +720,29 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"customApis","locations":["North
-        Central US","Central US","South Central US","North Europe","West Europe","East
-        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
-        India","Central India","West India","West US 2","West US 3","Jio India West","West
-        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
-        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
-        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
-        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
-        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
-        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectorgateways","locations":["West
+        Central US","Central US","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","West US","East US","East US 2","Japan
+        East","Brazil South","Australia East","South India","Central India","West
+        US 2","West US 3","Canada Central","Canada East","UK South","France Central","Korea
+        Central","South Africa North","UAE North","Switzerland North","Norway East","Germany
+        West Central","Italy North","Spain Central","Sweden Central","Poland Central","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-05-01-preview"],"defaultApiVersion":"2026-05-01-preview","apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"customApis","locations":["North Central
+        US","Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","East US 2","Japan West","Japan East","Brazil South","Australia
+        East","Brazil Southeast","Australia Southeast","South India","Central India","West
+        India","West US 2","West US 3","Jio India West","West Central US","Canada
+        Central","Canada East","UK South","UK West","France Central","France South","Korea
+        Central","Korea South","South Africa West","South Africa North","UAE Central","UAE
+        North","Switzerland North","Switzerland West","Norway East","Norway West","Germany
+        North","Germany West Central","Israel Central","Italy North","Mexico Central","Spain
+        Central","Sweden Central","Poland Central","Qatar Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/listWsdlInterfaces","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -707,8 +754,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
@@ -719,8 +766,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/managedApis","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -731,8 +778,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/runtimes","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/runtimes","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
@@ -743,8 +790,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/apiOperations","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/apiOperations","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -755,8 +802,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"connectionGateways","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"connectionGateways","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
@@ -767,8 +814,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -780,8 +827,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["Central
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -792,10 +839,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["Central
         US","East Asia","Japan East","West US","Australia East","Brazil South","Japan
         West","Southeast Asia","Central India","UK South","Canada East","Korea Central","France
         Central","North Europe","West US 2","East US","West India","East US 2","Australia
@@ -805,10 +853,10 @@ interactions:
         India West","South Africa North","Israel Central","Mexico Central","Poland
         Central","Italy North","New Zealand North","Indonesia Central","Malaysia West","Chile
         Central","Central US (Stage)","Spain Central","Sweden Central","Austria East","Belgium
-        Central","Brazil Southeast","Sweden South","Switzerland West","Norway West","Norway
-        East","UAE Central","Germany North","Australia Central 2","France South","East
-        US 2 EUAP","Central US EUAP","East Asia (Stage)","North Central US (Stage)","South
-        Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"billingMeters","locations":["Central
+        Central","Denmark East","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","East US 2 EUAP","Central US EUAP","East Asia (Stage)","North Central
+        US (Stage)","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"billingMeters","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -819,10 +867,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"verifyHostingEnvironmentVnet","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"verifyHostingEnvironmentVnet","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -833,10 +882,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -846,11 +896,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
         East","South Africa West","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["MSFT
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -860,11 +910,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
         East","South Africa West","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["MSFT
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -874,11 +924,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
         East","South Africa West","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["Brazil
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["Brazil
         South","Canada East","UK West","MSFT West US","MSFT East US","MSFT East Asia","MSFT
         North Europe","East US 2 (Stage)","Central US (Stage)","South Africa North","East
         US 2","East US","UK South","Southeast Asia","North Europe","Japan East","West
@@ -888,11 +938,11 @@ interactions:
         South","Canada Central","South India","West Central US","West US 3","Jio India
         West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
         Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
         Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
@@ -903,10 +953,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","South Africa
         West","Jio India West","Poland Central","Italy North","Israel Central","Spain
         Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","UAE Central","Germany North","Brazil
-        Southeast","Sweden South","Switzerland West","East Asia (Stage)","North Central
-        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps/keyVaultSettings","locations":["MSFT
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps/keyVaultSettings","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
         Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
@@ -917,12 +968,13 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","South Africa
         West","Jio India West","Poland Central","Italy North","Israel Central","Spain
         Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","UAE Central","Germany North","Brazil
-        Southeast","Sweden South","Switzerland West","East Asia (Stage)","North Central
-        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"containerApps","locations":["East
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"containerApps","locations":["East
         US","North Europe","Canada Central","East US 2","West Europe","North Central
-        US (Stage)","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2021-03-01"],"defaultApiVersion":"2021-03-01","capabilities":"CrossResourceGroupResourceMove,
+        US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-03-01"],"defaultApiVersion":"2021-03-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"customhostnameSites","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
@@ -933,11 +985,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
         US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
@@ -948,10 +1000,10 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Austria
         East","Belgium Central","Chile Central","Spain Central","Indonesia Central","Israel
         Central","Italy North","Mexico Central","Malaysia West","New Zealand North","Poland
-        Central","France South","South Africa West","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
-        Central 2","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2024-11-01","capabilities":"None"},{"resourceType":"locations/notifyNetworkSecurityPerimeterUpdatesAvailable","locations":["South
+        Central","Denmark East","France South","South Africa West","Norway West","Norway
+        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
+        West","Australia Central 2","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2024-11-01","capabilities":"None"},{"resourceType":"locations/notifyNetworkSecurityPerimeterUpdatesAvailable","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","France South","East
         Asia","Japan East","South Africa West","West US","Australia East","Brazil
@@ -963,20 +1015,21 @@ interactions:
         Central 2","North Central US","UK West","Australia Southeast","Korea South","Canada
         Central","West Europe","South India","West Central US","East Asia (Stage)","North
         Central US (Stage)","West US 3","East US 2 EUAP","Central US EUAP","Jio India
-        West","Jio India Central","Sweden South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-03-01"],"defaultApiVersion":"2022-03-01","capabilities":"None"},{"resourceType":"freeTrialStaticWebApps","locations":["East
-        Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2022-09-01"],"capabilities":"None"},{"resourceType":"recommendations","locations":["France
-        South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"workerApps","locations":["North
-        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2021-02-01","capabilities":"CrossResourceGroupResourceMove,
+        West","Jio India Central","Sweden South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-03-01"],"defaultApiVersion":"2022-03-01","capabilities":"None"},{"resourceType":"freeTrialStaticWebApps","locations":["East
+        Asia (Stage)"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2022-09-01"],"capabilities":"None"},{"resourceType":"aigateways","locations":["Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-03-01-preview"],"apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"workerApps","locations":["North
+        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2021-02-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '114128'
+      - '121399'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 02 Dec 2025 21:06:10 GMT
+      - Wed, 01 Jul 2026 16:48:20 GMT
       expires:
       - '-1'
       pragma:
@@ -990,7 +1043,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: DC1A836F2C1F4759BD2765CC1BF5670B Ref B: SN4AA2022301045 Ref C: 2025-12-02T21:06:10Z'
+      - 'Ref A: BFEB9D9B193E4DB5A8280E51A9CAFA80 Ref B: SN4AA2022304017 Ref C: 2026-07-01T16:48:20Z'
     status:
       code: 200
       message: OK
@@ -1008,35 +1061,39 @@ interactions:
       ParameterSetName:
       - --sku --managed-instance-enabled
       User-Agent:
-      - AZURECLI/2.80.0 (MSI) azsdk-python-core/1.35.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?customModeWorkersEnabled=true&api-version=2025-03-01
   response:
     body:
       string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/North
         Europe","name":"North Europe","type":"Microsoft.Web/geoRegions","properties":{"name":"North
-        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"northeurope-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"northeurope-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
         Asia","name":"East Asia","type":"Microsoft.Web/geoRegions","properties":{"name":"East
-        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSP0V3;LINUXP0V3;WINDOWSMV3;LINUXMV3;FLEXCONSUMPTION;XENONMV3;MANAGEDAPP;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastasia-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSP0V3;LINUXP0V3;WINDOWSMV3;LINUXMV3;FLEXCONSUMPTION;XENONMV3;MANAGEDAPP;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastasia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
         East","name":"Australia East","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
-        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"ZONEREDUNDANCY;FCZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXMV3;LINUXP0V3;WINDOWSMV3;WINDOWSP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"australiaeast-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"ZONEREDUNDANCY;FCZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXMV3;LINUXP0V3;WINDOWSMV3;WINDOWSP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"australiaeast-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
         US","name":"East US","type":"Microsoft.Web/geoRegions","properties":{"name":"East
-        US","description":null,"sortOrder":2147483647,"displayName":"East US","orgDomain":"FCZONEREDUNDANCY;ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastus-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        US","description":null,"sortOrder":2147483647,"displayName":"East US","orgDomain":"FCZONEREDUNDANCY;ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastus-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        India","name":"Central India","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        India","description":null,"sortOrder":2147483647,"displayName":"Central India","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;XENONMV3;FLEXCONSUMPTION;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"centralindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        India","name":"South India","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        India","description":null,"sortOrder":2147483647,"displayName":"South India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSP0V3;WINDOWSMV3;LINUXMV3;LINUXP0V3;FLEXCONSUMPTION;MAVICSERIES","subDomains":"southindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
         Central US","name":"West Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"West
         Central US","description":null,"sortOrder":2147483647,"displayName":"West
-        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"westcentralus-01.azurewebsites.net"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"westcentralus-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
         US 2 EUAP","name":"East US 2 EUAP","type":"Microsoft.Web/geoRegions","properties":{"name":"East
         US 2 EUAP","description":null,"sortOrder":2147483647,"displayName":"East US
-        2 EUAP","orgDomain":"EUAP;XENON;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;LINUXDYNAMIC;DSERIES;ZONEREDUNDANCY;FCZONEREDUNDANCY;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"eastus2euap-01.azurewebsites.net"}}],"nextLink":null,"id":null}'
+        2 EUAP","orgDomain":"EUAP;XENON;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;LINUXDYNAMIC;DSERIES;ZONEREDUNDANCY;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"eastus2euap-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}}],"nextLink":null,"id":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3773'
+      - '5474'
       content-type:
       - application/json
       date:
-      - Tue, 02 Dec 2025 21:06:10 GMT
+      - Wed, 01 Jul 2026 16:48:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1050,11 +1107,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=d1dbc388-1013-482b-b171-79f4269ea689/southcentralus/dec0adb5-066c-4edf-9105-336969234d94
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=d1dbc388-1013-482b-b171-79f4269ea689/southcentralus/e2418909-13b6-45f5-bd25-d2e31f0a99de
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 919652B8647C4682BA469295545EFC2A Ref B: SN4AA2022305023 Ref C: 2025-12-02T21:06:11Z'
+      - 'Ref A: 560197E083EB4498A7D2B504C89FE2E7 Ref B: SN4AA2022302019 Ref C: 2026-07-01T16:48:21Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -1074,12 +1131,12 @@ interactions:
       ParameterSetName:
       - --sku --managed-instance-enabled
       User-Agent:
-      - AZURECLI/2.80.0 (MSI) azsdk-python-core/1.35.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web","namespace":"Microsoft.Web","authorizations":[{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735","managedByRoleDefinitionId":"c29dde9f-14fa-40fb-9fe8-5a07be183f1e"}],"resourceTypes":[{"resourceType":"publishingUsers","locations":["Central
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web","namespace":"Microsoft.Web","authorizations":[{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735","managedByRoleDefinitionId":"c29dde9f-14fa-40fb-9fe8-5a07be183f1e"},{"applicationId":"a7d8f84e-510b-46d6-8f59-77e581db63bc","roleDefinitionId":"213f590f-d0be-4560-836d-7db7e2a32cca"}],"resourceTypes":[{"resourceType":"publishingUsers","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1090,10 +1147,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostnameavailable","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostnameavailable","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1104,10 +1162,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"validate","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"validate","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1118,10 +1177,10 @@ interactions:
         Central","Switzerland North","Germany West Central","UAE North","Jio India
         West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
-        Central","Malaysia West","Austria East","Belgium Central","Taiwan North","Taiwan
-        Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway West","Norway
-        East","UAE Central","Germany North","Australia Central 2","East US 2 EUAP","Central
-        US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"isusernameavailable","locations":["Central
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","East
+        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"isusernameavailable","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1132,10 +1191,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"generateGithubAccessTokenForAppserviceCLI","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"generateGithubAccessTokenForAppserviceCLI","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
         Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
@@ -1145,11 +1205,11 @@ interactions:
         South","Canada Central","West Europe","South India","West Central US","West
         US 3","East Asia","Japan East","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
-        Asia (Stage)","North Central US (Stage)","France South","South Africa West","Taiwan
-        North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sourceControls","locations":["Central
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","France
+        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sourceControls","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1160,10 +1220,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"availableStacks","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"availableStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1174,10 +1235,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"webAppStacks","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"webAppStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1188,10 +1250,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","West US","Australia
         East","Brazil South","Southeast Asia","Japan West","Central India","UK South","Canada
@@ -1201,11 +1264,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","Jio India
         West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
         Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","Central
-        US","West US 2","Norway West","Norway East","UAE Central","Germany North","Brazil
-        Southeast","Sweden South","Switzerland West","Australia Central 2","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
+        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1216,10 +1279,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1229,31 +1293,35 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","West
-        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
-        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"staticSites","locations":["West
-        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2024-04-01","capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"staticSites","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-11-preview","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2024-04-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"locations/previewStaticSiteWorkflowFile","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"locations/staticSitesOperationStatuses","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/linkedBackends","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"locations/staticSitesOperationResults","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/linkedBackends","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/databaseConnections","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/linkedBackends","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/databaseConnections","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/linkedBackends","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/databaseConnections","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/databaseConnections","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP","East Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSiteRegions","locations":["Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSiteRegions","locations":["Central
         US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
         US 2 EUAP","Central US EUAP"],"apiVersions":["2024-04-01"],"capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
@@ -1266,10 +1334,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/getNetworkPolicies","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/getNetworkPolicies","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1277,7 +1346,7 @@ interactions:
         South","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
         Europe","East US 2 (Stage)","Central US (Stage)","France Central","West Central
         US","Jio India West","France South","East Asia (Stage)","North Central US
-        (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operations","locations":["MSFT
+        (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operations","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
         Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
@@ -1287,11 +1356,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","South
         India","West Central US","West US 3","Jio India West","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Malaysia West","Chile Central","Austria East","Belgium Central","East
-        US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
         Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
         South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["MSFT
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
         Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
@@ -1301,11 +1370,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","South
         India","West Central US","West US 3","Jio India West","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Malaysia West","Chile Central","Austria East","Belgium Central","East
-        US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
         Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
         South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["MSFT
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1315,11 +1384,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1329,11 +1398,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1343,11 +1412,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1357,11 +1426,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1372,10 +1441,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1385,11 +1455,12 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","Norway West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
-        South","Switzerland West","North Central US","East Asia (Stage)","North Central
-        US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
         SupportsTags, SupportsLocation"},{"resourceType":"sites/certificates","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
@@ -1400,10 +1471,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
-        West","Austria East","Belgium Central","France South","South Africa West","East
-        US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"sites/slots/certificates","locations":["MSFT
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"sites/slots/certificates","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
         US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
@@ -1413,10 +1485,11 @@ interactions:
         Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
-        West","Austria East","Belgium Central","France South","South Africa West","East
-        US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"serverFarms","locations":["MSFT
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"serverFarms","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1426,11 +1499,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"sites","locations":["MSFT West US","MSFT
         East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
@@ -1442,11 +1515,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"sites/slots","locations":["MSFT West US","MSFT
         East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
@@ -1458,14 +1531,26 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"runtimes","locations":["France South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":["France
-        South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"aseregions","locations":["South
+        SupportsLocation"},{"resourceType":"runtimes","locations":["France South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"recommendations","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"aseregions","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
         East","West US","Australia East","Brazil South","Southeast Asia","Central
@@ -1476,16 +1561,22 @@ interactions:
         Central","West Europe","South India","West Central US","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
         Central","Chile Central","Malaysia West","Austria East","Belgium Central","West
-        US 3","Jio India West","France South","South Africa West","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","Australia Central 2","Taiwan North","Taiwan Northwest","East Asia (Stage)","North
-        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2023-12-01","capabilities":"None"},{"resourceType":"georegions","locations":["West
+        US 3","Jio India West","Denmark East","France South","South Africa West","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","Australia Central 2","Taiwan North","Taiwan Northwest","East
+        Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2023-12-01","capabilities":"None"},{"resourceType":"georegions","locations":["West
         Europe","West US","East US","West India","North Central US","West Central
         US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","East US 2","France Central","Japan East","Korea Central","Korea South","South
         Africa North","South Central US","Southeast Asia","South India","UK South","UK
-        West","West US 3","France South","East US 2 EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["MSFT
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1495,11 +1586,12 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","Norway West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
-        South","Switzerland West","North Central US","East Asia (Stage)","North Central
-        US (Stage)","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East US 2","East US","UK South","Southeast
@@ -1510,29 +1602,29 @@ interactions:
         South","Canada Central","South India","West Central US","West US 3","Jio India
         West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
         Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"Australia
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["1","2","3"]},{"location":"Austria East","zones":[]},{"location":"Belgium
         Central","zones":[]},{"location":"Brazil South","zones":["1","2","3"]},{"location":"Canada
         Central","zones":["1","2","3"]},{"location":"Central India","zones":[]},{"location":"Central
         US","zones":["1","2","3"]},{"location":"Central US EUAP","zones":[]},{"location":"Chile
-        Central","zones":[]},{"location":"East Asia","zones":[]},{"location":"East
-        US","zones":["1","2","3"]},{"location":"East US 2","zones":["1","2","3"]},{"location":"East
-        US 2 EUAP","zones":["1","2","3"]},{"location":"France Central","zones":["1","2","3"]},{"location":"Germany
-        West Central","zones":["1","2","3"]},{"location":"Indonesia Central","zones":[]},{"location":"Israel
-        Central","zones":[]},{"location":"Italy North","zones":[]},{"location":"Japan
-        East","zones":["1","2","3"]},{"location":"Japan West","zones":[]},{"location":"Korea
-        Central","zones":[]},{"location":"Malaysia West","zones":[]},{"location":"Mexico
-        Central","zones":[]},{"location":"New Zealand North","zones":[]},{"location":"North
-        Europe","zones":["1","2","3"]},{"location":"Norway East","zones":[]},{"location":"Poland
-        Central","zones":[]},{"location":"Qatar Central","zones":[]},{"location":"South
-        Africa North","zones":["1","2","3"]},{"location":"South Central US","zones":["1","2","3"]},{"location":"Southeast
-        Asia","zones":["1","2","3"]},{"location":"Spain Central","zones":[]},{"location":"Sweden
-        Central","zones":[]},{"location":"Switzerland North","zones":[]},{"location":"UAE
-        North","zones":[]},{"location":"UK South","zones":["1","2","3"]},{"location":"West
+        Central","zones":[]},{"location":"Denmark East","zones":[]},{"location":"East
+        Asia","zones":[]},{"location":"East US","zones":["1","2","3"]},{"location":"East
+        US 2","zones":["1","2","3"]},{"location":"East US 2 EUAP","zones":["1","2","3"]},{"location":"France
+        Central","zones":["1","2","3"]},{"location":"Germany West Central","zones":["1","2","3"]},{"location":"Indonesia
+        Central","zones":[]},{"location":"Israel Central","zones":[]},{"location":"Italy
+        North","zones":[]},{"location":"Japan East","zones":["1","2","3"]},{"location":"Japan
+        West","zones":[]},{"location":"Korea Central","zones":[]},{"location":"Malaysia
+        West","zones":[]},{"location":"Mexico Central","zones":[]},{"location":"New
+        Zealand North","zones":[]},{"location":"North Europe","zones":["1","2","3"]},{"location":"Norway
+        East","zones":[]},{"location":"Poland Central","zones":[]},{"location":"Qatar
+        Central","zones":[]},{"location":"South Africa North","zones":["1","2","3"]},{"location":"South
+        Central US","zones":["1","2","3"]},{"location":"Southeast Asia","zones":["1","2","3"]},{"location":"Spain
+        Central","zones":[]},{"location":"Sweden Central","zones":[]},{"location":"Switzerland
+        North","zones":[]},{"location":"UAE North","zones":[]},{"location":"UK South","zones":["1","2","3"]},{"location":"West
         Europe","zones":["1","2","3"]},{"location":"West US 2","zones":["1","2","3"]},{"location":"West
         US 3","zones":[]}],"capabilities":"SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["MSFT
@@ -1545,11 +1637,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1559,13 +1651,13 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["West
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["West
         Central US","East US","West Europe","Jio India West","North Europe","Canada
-        Central","East US 2","North Central US (Stage)","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2021-03-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","East US 2","North Central US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2021-03-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"deploymentLocations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
@@ -1577,10 +1669,10 @@ interactions:
         Central","Switzerland North","Germany West Central","UAE North","Jio India
         West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
-        Central","Malaysia West","Austria East","Belgium Central","Taiwan North","Taiwan
-        Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway West","Norway
-        East","UAE Central","Germany North","Australia Central 2","France South","South
-        Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["MSFT
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1590,11 +1682,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","West
-        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
-        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
         South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
@@ -1604,12 +1696,12 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","France South","South Africa West","West
-        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
-        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
-        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
-        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":["France
-        South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1619,11 +1711,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/validateDeleteVirtualNetworkOrSubnets","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/validateDeleteVirtualNetworkOrSubnets","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1633,11 +1725,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/listVirtualNetworkIntegrations","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/listVirtualNetworkIntegrations","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1647,11 +1739,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/purgeUnusedVirtualNetworkIntegration","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/purgeUnusedVirtualNetworkIntegration","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1661,11 +1753,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","East US
-        2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway West","Norway
-        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"connections","locations":["North
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"connections","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -1676,21 +1768,29 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"customApis","locations":["North
-        Central US","Central US","South Central US","North Europe","West Europe","East
-        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
-        India","Central India","West India","West US 2","West US 3","Jio India West","West
-        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
-        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
-        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
-        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
-        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
-        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectorgateways","locations":["West
+        Central US","Central US","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","West US","East US","East US 2","Japan
+        East","Brazil South","Australia East","South India","Central India","West
+        US 2","West US 3","Canada Central","Canada East","UK South","France Central","Korea
+        Central","South Africa North","UAE North","Switzerland North","Norway East","Germany
+        West Central","Italy North","Spain Central","Sweden Central","Poland Central","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-05-01-preview"],"defaultApiVersion":"2026-05-01-preview","apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"customApis","locations":["North Central
+        US","Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","East US 2","Japan West","Japan East","Brazil South","Australia
+        East","Brazil Southeast","Australia Southeast","South India","Central India","West
+        India","West US 2","West US 3","Jio India West","West Central US","Canada
+        Central","Canada East","UK South","UK West","France Central","France South","Korea
+        Central","Korea South","South Africa West","South Africa North","UAE Central","UAE
+        North","Switzerland North","Switzerland West","Norway East","Norway West","Germany
+        North","Germany West Central","Israel Central","Italy North","Mexico Central","Spain
+        Central","Sweden Central","Poland Central","Qatar Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/listWsdlInterfaces","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1702,8 +1802,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
@@ -1714,8 +1814,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/managedApis","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -1726,8 +1826,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/runtimes","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/runtimes","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
@@ -1738,8 +1838,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/apiOperations","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/apiOperations","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -1750,8 +1850,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"connectionGateways","locations":["North
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"connectionGateways","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
@@ -1762,8 +1862,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1775,8 +1875,8 @@ interactions:
         West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
         Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan
-        Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["Central
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1787,10 +1887,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["Central
         US","East Asia","Japan East","West US","Australia East","Brazil South","Japan
         West","Southeast Asia","Central India","UK South","Canada East","Korea Central","France
         Central","North Europe","West US 2","East US","West India","East US 2","Australia
@@ -1800,10 +1901,10 @@ interactions:
         India West","South Africa North","Israel Central","Mexico Central","Poland
         Central","Italy North","New Zealand North","Indonesia Central","Malaysia West","Chile
         Central","Central US (Stage)","Spain Central","Sweden Central","Austria East","Belgium
-        Central","Brazil Southeast","Sweden South","Switzerland West","Norway West","Norway
-        East","UAE Central","Germany North","Australia Central 2","France South","East
-        US 2 EUAP","Central US EUAP","East Asia (Stage)","North Central US (Stage)","South
-        Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"billingMeters","locations":["Central
+        Central","Denmark East","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","East US 2 EUAP","Central US EUAP","East Asia (Stage)","North Central
+        US (Stage)","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"billingMeters","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1814,10 +1915,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"verifyHostingEnvironmentVnet","locations":["Central
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"verifyHostingEnvironmentVnet","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -1828,10 +1930,11 @@ interactions:
         US 3","Australia Central","Switzerland North","Germany West Central","UAE
         North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
         North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
-        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Taiwan
-        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
-        West","Norway East","UAE Central","Germany North","Australia Central 2","East
-        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["MSFT
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1841,11 +1944,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
         East","South Africa West","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["MSFT
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1855,11 +1958,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
         East","South Africa West","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["MSFT
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","Australia East","Brazil South","Southeast
         Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
@@ -1869,11 +1972,11 @@ interactions:
         Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
         East","South Africa West","Jio India West","Poland Central","Italy North","Israel
         Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","West US","Central US","West
-        US 2","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
-        West","North Central US","East Asia (Stage)","North Central US (Stage)","France
-        South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["Brazil
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["Brazil
         South","Canada East","UK West","MSFT West US","MSFT East US","MSFT East Asia","MSFT
         North Europe","East US 2 (Stage)","Central US (Stage)","South Africa North","East
         US 2","East US","UK South","Southeast Asia","North Europe","Japan East","West
@@ -1883,11 +1986,11 @@ interactions:
         South","Canada Central","South India","West Central US","West US 3","Jio India
         West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
         Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
         Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
@@ -1898,10 +2001,11 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","South Africa
         West","Jio India West","Poland Central","Italy North","Israel Central","Spain
         Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","UAE Central","Germany North","Brazil
-        Southeast","Sweden South","Switzerland West","East Asia (Stage)","North Central
-        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps/keyVaultSettings","locations":["MSFT
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps/keyVaultSettings","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
         Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
@@ -1912,12 +2016,13 @@ interactions:
         India","West Central US","West US 3","East Asia","Japan East","South Africa
         West","Jio India West","Poland Central","Italy North","Israel Central","Spain
         Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
-        West","Chile Central","Austria East","Belgium Central","South Central US","Australia
-        Central 2","East US 2 EUAP","Central US EUAP","UAE Central","Germany North","Brazil
-        Southeast","Sweden South","Switzerland West","East Asia (Stage)","North Central
-        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"containerApps","locations":["East
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"containerApps","locations":["East
         US","North Europe","Canada Central","East US 2","West Europe","North Central
-        US (Stage)","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2021-03-01"],"defaultApiVersion":"2021-03-01","capabilities":"CrossResourceGroupResourceMove,
+        US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-03-01"],"defaultApiVersion":"2021-03-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"customhostnameSites","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
@@ -1928,11 +2033,11 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Poland
         Central","Italy North","Israel Central","Spain Central","Mexico Central","New
         Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
-        East","Belgium Central","South Central US","Australia Central 2","France South","South
-        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","North
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["MSFT
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
         US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
@@ -1943,10 +2048,10 @@ interactions:
         Europe","South India","West Central US","West US 3","Jio India West","Austria
         East","Belgium Central","Chile Central","Spain Central","Indonesia Central","Israel
         Central","Italy North","Mexico Central","Malaysia West","New Zealand North","Poland
-        Central","France South","South Africa West","Norway West","Norway East","UAE
-        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
-        Central 2","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2024-11-01","capabilities":"None"},{"resourceType":"locations/notifyNetworkSecurityPerimeterUpdatesAvailable","locations":["South
+        Central","Denmark East","France South","South Africa West","Norway West","Norway
+        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
+        West","Australia Central 2","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2024-11-01","capabilities":"None"},{"resourceType":"locations/notifyNetworkSecurityPerimeterUpdatesAvailable","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","France South","East
         Asia","Japan East","South Africa West","West US","Australia East","Brazil
@@ -1958,20 +2063,21 @@ interactions:
         Central 2","North Central US","UK West","Australia Southeast","Korea South","Canada
         Central","West Europe","South India","West Central US","East Asia (Stage)","North
         Central US (Stage)","West US 3","East US 2 EUAP","Central US EUAP","Jio India
-        West","Jio India Central","Sweden South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-03-01"],"defaultApiVersion":"2022-03-01","capabilities":"None"},{"resourceType":"freeTrialStaticWebApps","locations":["East
-        Asia (Stage)"],"apiVersions":["2025-03-01","2024-11-01","2022-09-01"],"capabilities":"None"},{"resourceType":"recommendations","locations":["France
-        South"],"apiVersions":["2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"workerApps","locations":["North
-        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2025-03-01","2024-11-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2021-02-01","capabilities":"CrossResourceGroupResourceMove,
+        West","Jio India Central","Sweden South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-03-01"],"defaultApiVersion":"2022-03-01","capabilities":"None"},{"resourceType":"freeTrialStaticWebApps","locations":["East
+        Asia (Stage)"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2022-09-01"],"capabilities":"None"},{"resourceType":"aigateways","locations":["Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-03-01-preview"],"apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"workerApps","locations":["North
+        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2021-02-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '114128'
+      - '121399'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 02 Dec 2025 21:06:11 GMT
+      - Wed, 01 Jul 2026 16:48:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1985,7 +2091,3151 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: BE2CC22EAC29421C807C677938597543 Ref B: SN4AA2022305049 Ref C: 2025-12-02T21:06:11Z'
+      - 'Ref A: 2787AF19467446D8919D96B7734FEE4B Ref B: SN4AA2022304045 Ref C: 2026-07-01T16:48:21Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice list-locations
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --sku --managed-instance-enabled
+      User-Agent:
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?customModeWorkersEnabled=true&api-version=2025-03-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/North
+        Europe","name":"North Europe","type":"Microsoft.Web/geoRegions","properties":{"name":"North
+        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"northeurope-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Asia","name":"East Asia","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSP0V3;LINUXP0V3;WINDOWSMV3;LINUXMV3;FLEXCONSUMPTION;XENONMV3;MANAGEDAPP;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastasia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        East","name":"Australia East","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
+        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"ZONEREDUNDANCY;FCZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXMV3;LINUXP0V3;WINDOWSMV3;WINDOWSP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"australiaeast-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US","name":"East US","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US","description":null,"sortOrder":2147483647,"displayName":"East US","orgDomain":"FCZONEREDUNDANCY;ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastus-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        India","name":"Central India","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        India","description":null,"sortOrder":2147483647,"displayName":"Central India","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;XENONMV3;FLEXCONSUMPTION;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"centralindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        India","name":"South India","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        India","description":null,"sortOrder":2147483647,"displayName":"South India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSP0V3;WINDOWSMV3;LINUXMV3;LINUXP0V3;FLEXCONSUMPTION;MAVICSERIES","subDomains":"southindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        Central US","name":"West Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        Central US","description":null,"sortOrder":2147483647,"displayName":"West
+        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"westcentralus-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US 2 EUAP","name":"East US 2 EUAP","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US 2 EUAP","description":null,"sortOrder":2147483647,"displayName":"East US
+        2 EUAP","orgDomain":"EUAP;XENON;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;LINUXDYNAMIC;DSERIES;ZONEREDUNDANCY;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"eastus2euap-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5474'
+      content-type:
+      - application/json
+      date:
+      - Wed, 01 Jul 2026 16:48:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=d1dbc388-1013-482b-b171-79f4269ea689/southcentralus/fc22017e-41ab-4b80-8958-f64b05231953
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: ABF50CF04F914B91B2ABC5CC10CEC875 Ref B: SN4AA2022304029 Ref C: 2026-07-01T16:48:22Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice list-locations
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --sku --managed-instance-enabled
+      User-Agent:
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web","namespace":"Microsoft.Web","authorizations":[{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735","managedByRoleDefinitionId":"c29dde9f-14fa-40fb-9fe8-5a07be183f1e"},{"applicationId":"a7d8f84e-510b-46d6-8f59-77e581db63bc","roleDefinitionId":"213f590f-d0be-4560-836d-7db7e2a32cca"}],"resourceTypes":[{"resourceType":"publishingUsers","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostnameavailable","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"validate","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT
+        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
+        Central US (Stage)","France Central","South Africa North","West US 3","Australia
+        Central","Switzerland North","Germany West Central","UAE North","Jio India
+        West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","East
+        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"isusernameavailable","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"generateGithubAccessTokenForAppserviceCLI","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","North Central US","UK West","Australia Southeast","Korea
+        South","Canada Central","West Europe","South India","West Central US","West
+        US 3","East Asia","Japan East","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","France
+        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sourceControls","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"availableStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"webAppStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","West US","Australia
+        East","Brazil South","Southeast Asia","Japan West","Central India","UK South","Canada
+        East","Korea Central","France Central","North Europe","East US","West India","East
+        US 2","Australia Central","Germany West Central","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
+        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"staticSites","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-11-preview","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2024-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/previewStaticSiteWorkflowFile","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"locations/staticSitesOperationStatuses","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"locations/staticSitesOperationResults","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/linkedBackends","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/linkedBackends","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/databaseConnections","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/databaseConnections","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSiteRegions","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2024-04-01"],"capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/getNetworkPolicies","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","UK West","UK
+        South","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
+        Europe","East US 2 (Stage)","Central US (Stage)","France Central","West Central
+        US","Jio India West","France South","East Asia (Stage)","North Central US
+        (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operations","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
+        East","Brazil South","Central US","Japan West","Central India","Canada East","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","West US 3","Jio India West","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
+        East","Brazil South","Central US","Japan West","Central India","Canada East","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","West US 3","Jio India West","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
+        SupportsTags, SupportsLocation"},{"resourceType":"sites/certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"sites/slots/certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"serverFarms","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sites","locations":["MSFT West US","MSFT
+        East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sites/slots","locations":["MSFT West US","MSFT
+        East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"runtimes","locations":["France South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"recommendations","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"aseregions","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","North Central US","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","West
+        US 3","Jio India West","Denmark East","France South","South Africa West","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","Australia Central 2","Taiwan North","Taiwan Northwest","East
+        Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2023-12-01","capabilities":"None"},{"resourceType":"georegions","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","Australia East","Brazil
+        South","Japan West","Central India","Canada East","Korea Central","France
+        Central","West India","Australia Central","Germany West Central","UAE North","Sweden
+        Central","Qatar Central","Switzerland North","UK West","Australia Southeast","Korea
+        South","Canada Central","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"Australia
+        East","zones":["1","2","3"]},{"location":"Austria East","zones":[]},{"location":"Belgium
+        Central","zones":[]},{"location":"Brazil South","zones":["1","2","3"]},{"location":"Canada
+        Central","zones":["1","2","3"]},{"location":"Central India","zones":[]},{"location":"Central
+        US","zones":["1","2","3"]},{"location":"Central US EUAP","zones":[]},{"location":"Chile
+        Central","zones":[]},{"location":"Denmark East","zones":[]},{"location":"East
+        Asia","zones":[]},{"location":"East US","zones":["1","2","3"]},{"location":"East
+        US 2","zones":["1","2","3"]},{"location":"East US 2 EUAP","zones":["1","2","3"]},{"location":"France
+        Central","zones":["1","2","3"]},{"location":"Germany West Central","zones":["1","2","3"]},{"location":"Indonesia
+        Central","zones":[]},{"location":"Israel Central","zones":[]},{"location":"Italy
+        North","zones":[]},{"location":"Japan East","zones":["1","2","3"]},{"location":"Japan
+        West","zones":[]},{"location":"Korea Central","zones":[]},{"location":"Malaysia
+        West","zones":[]},{"location":"Mexico Central","zones":[]},{"location":"New
+        Zealand North","zones":[]},{"location":"North Europe","zones":["1","2","3"]},{"location":"Norway
+        East","zones":[]},{"location":"Poland Central","zones":[]},{"location":"Qatar
+        Central","zones":[]},{"location":"South Africa North","zones":["1","2","3"]},{"location":"South
+        Central US","zones":["1","2","3"]},{"location":"Southeast Asia","zones":["1","2","3"]},{"location":"Spain
+        Central","zones":[]},{"location":"Sweden Central","zones":[]},{"location":"Switzerland
+        North","zones":[]},{"location":"UAE North","zones":[]},{"location":"UK South","zones":["1","2","3"]},{"location":"West
+        Europe","zones":["1","2","3"]},{"location":"West US 2","zones":["1","2","3"]},{"location":"West
+        US 3","zones":[]}],"capabilities":"SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["West
+        Central US","East US","West Europe","Jio India West","North Europe","Canada
+        Central","East US 2","North Central US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2021-03-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"deploymentLocations","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","Central US (Stage)","North
+        Central US (Stage)","France Central","South Africa North","West US 3","Australia
+        Central","Switzerland North","Germany West Central","UAE North","Jio India
+        West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/validateDeleteVirtualNetworkOrSubnets","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/listVirtualNetworkIntegrations","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/purgeUnusedVirtualNetworkIntegration","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectorgateways","locations":["West
+        Central US","Central US","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","West US","East US","East US 2","Japan
+        East","Brazil South","Australia East","South India","Central India","West
+        US 2","West US 3","Canada Central","Canada East","UK South","France Central","Korea
+        Central","South Africa North","UAE North","Switzerland North","Norway East","Germany
+        West Central","Italy North","Spain Central","Sweden Central","Poland Central","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-05-01-preview"],"defaultApiVersion":"2026-05-01-preview","apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"customApis","locations":["North Central
+        US","Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","East US 2","Japan West","Japan East","Brazil South","Australia
+        East","Brazil Southeast","Australia Southeast","South India","Central India","West
+        India","West US 2","West US 3","Jio India West","West Central US","Canada
+        Central","Canada East","UK South","UK West","France Central","France South","Korea
+        Central","Korea South","South Africa West","South Africa North","UAE Central","UAE
+        North","Switzerland North","Switzerland West","Norway East","Norway West","Germany
+        North","Germany West Central","Israel Central","Italy North","Mexico Central","Spain
+        Central","Sweden Central","Poland Central","Qatar Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/runtimes","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["Central
+        US","East Asia","Japan East","West US","Australia East","Brazil South","Japan
+        West","Southeast Asia","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","South Central US","Jio
+        India West","South Africa North","Israel Central","Mexico Central","Poland
+        Central","Italy North","New Zealand North","Indonesia Central","Malaysia West","Chile
+        Central","Central US (Stage)","Spain Central","Sweden Central","Austria East","Belgium
+        Central","Denmark East","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","East US 2 EUAP","Central US EUAP","East Asia (Stage)","North Central
+        US (Stage)","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"billingMeters","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"verifyHostingEnvironmentVnet","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","Switzerland North","UAE North","Sweden
+        Central","Qatar Central","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["Brazil
+        South","Canada East","UK West","MSFT West US","MSFT East US","MSFT East Asia","MSFT
+        North Europe","East US 2 (Stage)","Central US (Stage)","South Africa North","East
+        US 2","East US","UK South","Southeast Asia","North Europe","Japan East","West
+        Europe","East Asia","Australia East","Japan West","Central India","Korea Central","France
+        Central","West India","Australia Central","Germany West Central","Switzerland
+        North","UAE North","Sweden Central","Qatar Central","Australia Southeast","Korea
+        South","Canada Central","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
+        North","Sweden Central","Qatar Central","Switzerland North","North Central
+        US","UK West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","South Africa
+        West","Jio India West","Poland Central","Italy North","Israel Central","Spain
+        Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps/keyVaultSettings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
+        North","Sweden Central","Qatar Central","Switzerland North","North Central
+        US","UK West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","South Africa
+        West","Jio India West","Poland Central","Italy North","Israel Central","Spain
+        Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"containerApps","locations":["East
+        US","North Europe","Canada Central","East US 2","West Europe","North Central
+        US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-03-01"],"defaultApiVersion":"2021-03-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"customhostnameSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Austria
+        East","Belgium Central","Chile Central","Spain Central","Indonesia Central","Israel
+        Central","Italy North","Mexico Central","Malaysia West","New Zealand North","Poland
+        Central","Denmark East","France South","South Africa West","Norway West","Norway
+        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
+        West","Australia Central 2","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2024-11-01","capabilities":"None"},{"resourceType":"locations/notifyNetworkSecurityPerimeterUpdatesAvailable","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","France South","East
+        Asia","Japan East","South Africa West","West US","Australia East","Brazil
+        South","Southeast Asia","Central US","Japan West","Central India","UK South","Canada
+        East","Korea Central","France Central","North Europe","West US 2","East US","West
+        India","East US 2","Australia Central","Germany West Central","Norway West","Norway
+        East","UAE Central","Germany North","UAE North","Brazil Southeast","Sweden
+        Central","Qatar Central","Switzerland West","Switzerland North","Australia
+        Central 2","North Central US","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","East Asia (Stage)","North
+        Central US (Stage)","West US 3","East US 2 EUAP","Central US EUAP","Jio India
+        West","Jio India Central","Sweden South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-03-01"],"defaultApiVersion":"2022-03-01","capabilities":"None"},{"resourceType":"freeTrialStaticWebApps","locations":["East
+        Asia (Stage)"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2022-09-01"],"capabilities":"None"},{"resourceType":"aigateways","locations":["Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-03-01-preview"],"apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"workerApps","locations":["North
+        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2021-02-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '121399'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 01 Jul 2026 16:48:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 311C1D8032344FD5A11314DB9BE610C8 Ref B: SN4AA2022301017 Ref C: 2026-07-01T16:48:23Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice list-locations
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --sku --managed-instance-enabled
+      User-Agent:
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?customModeWorkersEnabled=true&api-version=2025-03-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/North
+        Europe","name":"North Europe","type":"Microsoft.Web/geoRegions","properties":{"name":"North
+        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"northeurope-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Asia","name":"East Asia","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSP0V3;LINUXP0V3;WINDOWSMV3;LINUXMV3;FLEXCONSUMPTION;XENONMV3;MANAGEDAPP;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastasia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        East","name":"Australia East","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
+        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"ZONEREDUNDANCY;FCZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXMV3;LINUXP0V3;WINDOWSMV3;WINDOWSP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"australiaeast-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US","name":"East US","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US","description":null,"sortOrder":2147483647,"displayName":"East US","orgDomain":"FCZONEREDUNDANCY;ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastus-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        India","name":"Central India","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        India","description":null,"sortOrder":2147483647,"displayName":"Central India","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;XENONMV3;FLEXCONSUMPTION;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"centralindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        India","name":"South India","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        India","description":null,"sortOrder":2147483647,"displayName":"South India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSP0V3;WINDOWSMV3;LINUXMV3;LINUXP0V3;FLEXCONSUMPTION;MAVICSERIES","subDomains":"southindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        Central US","name":"West Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        Central US","description":null,"sortOrder":2147483647,"displayName":"West
+        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"westcentralus-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US 2 EUAP","name":"East US 2 EUAP","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US 2 EUAP","description":null,"sortOrder":2147483647,"displayName":"East US
+        2 EUAP","orgDomain":"EUAP;XENON;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;LINUXDYNAMIC;DSERIES;ZONEREDUNDANCY;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"eastus2euap-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5474'
+      content-type:
+      - application/json
+      date:
+      - Wed, 01 Jul 2026 16:48:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=d1dbc388-1013-482b-b171-79f4269ea689/southcentralus/9b44ee1a-8549-45de-bcc3-cfbf151a6254
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16498'
+      x-msedge-ref:
+      - 'Ref A: B076EC56755648BDB795E6C8A1AA5B61 Ref B: SN4AA2022301035 Ref C: 2026-07-01T16:48:23Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice list-locations
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --sku --managed-instance-enabled
+      User-Agent:
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web","namespace":"Microsoft.Web","authorizations":[{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735","managedByRoleDefinitionId":"c29dde9f-14fa-40fb-9fe8-5a07be183f1e"},{"applicationId":"a7d8f84e-510b-46d6-8f59-77e581db63bc","roleDefinitionId":"213f590f-d0be-4560-836d-7db7e2a32cca"}],"resourceTypes":[{"resourceType":"publishingUsers","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostnameavailable","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"validate","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT
+        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
+        Central US (Stage)","France Central","South Africa North","West US 3","Australia
+        Central","Switzerland North","Germany West Central","UAE North","Jio India
+        West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","East
+        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"isusernameavailable","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"generateGithubAccessTokenForAppserviceCLI","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","North Central US","UK West","Australia Southeast","Korea
+        South","Canada Central","West Europe","South India","West Central US","West
+        US 3","East Asia","Japan East","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","France
+        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sourceControls","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"availableStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"webAppStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","West US","Australia
+        East","Brazil South","Southeast Asia","Japan West","Central India","UK South","Canada
+        East","Korea Central","France Central","North Europe","East US","West India","East
+        US 2","Australia Central","Germany West Central","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
+        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"staticSites","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-11-preview","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2024-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/previewStaticSiteWorkflowFile","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"locations/staticSitesOperationStatuses","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"locations/staticSitesOperationResults","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/linkedBackends","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/linkedBackends","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/databaseConnections","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/databaseConnections","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSiteRegions","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2024-04-01"],"capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/getNetworkPolicies","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","UK West","UK
+        South","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
+        Europe","East US 2 (Stage)","Central US (Stage)","France Central","West Central
+        US","Jio India West","France South","East Asia (Stage)","North Central US
+        (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operations","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
+        East","Brazil South","Central US","Japan West","Central India","Canada East","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","West US 3","Jio India West","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
+        East","Brazil South","Central US","Japan West","Central India","Canada East","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","West US 3","Jio India West","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
+        SupportsTags, SupportsLocation"},{"resourceType":"sites/certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"sites/slots/certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"serverFarms","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sites","locations":["MSFT West US","MSFT
+        East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sites/slots","locations":["MSFT West US","MSFT
+        East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"runtimes","locations":["France South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"recommendations","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"aseregions","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","North Central US","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","West
+        US 3","Jio India West","Denmark East","France South","South Africa West","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","Australia Central 2","Taiwan North","Taiwan Northwest","East
+        Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2023-12-01","capabilities":"None"},{"resourceType":"georegions","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","Australia East","Brazil
+        South","Japan West","Central India","Canada East","Korea Central","France
+        Central","West India","Australia Central","Germany West Central","UAE North","Sweden
+        Central","Qatar Central","Switzerland North","UK West","Australia Southeast","Korea
+        South","Canada Central","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"Australia
+        East","zones":["1","2","3"]},{"location":"Austria East","zones":[]},{"location":"Belgium
+        Central","zones":[]},{"location":"Brazil South","zones":["1","2","3"]},{"location":"Canada
+        Central","zones":["1","2","3"]},{"location":"Central India","zones":[]},{"location":"Central
+        US","zones":["1","2","3"]},{"location":"Central US EUAP","zones":[]},{"location":"Chile
+        Central","zones":[]},{"location":"Denmark East","zones":[]},{"location":"East
+        Asia","zones":[]},{"location":"East US","zones":["1","2","3"]},{"location":"East
+        US 2","zones":["1","2","3"]},{"location":"East US 2 EUAP","zones":["1","2","3"]},{"location":"France
+        Central","zones":["1","2","3"]},{"location":"Germany West Central","zones":["1","2","3"]},{"location":"Indonesia
+        Central","zones":[]},{"location":"Israel Central","zones":[]},{"location":"Italy
+        North","zones":[]},{"location":"Japan East","zones":["1","2","3"]},{"location":"Japan
+        West","zones":[]},{"location":"Korea Central","zones":[]},{"location":"Malaysia
+        West","zones":[]},{"location":"Mexico Central","zones":[]},{"location":"New
+        Zealand North","zones":[]},{"location":"North Europe","zones":["1","2","3"]},{"location":"Norway
+        East","zones":[]},{"location":"Poland Central","zones":[]},{"location":"Qatar
+        Central","zones":[]},{"location":"South Africa North","zones":["1","2","3"]},{"location":"South
+        Central US","zones":["1","2","3"]},{"location":"Southeast Asia","zones":["1","2","3"]},{"location":"Spain
+        Central","zones":[]},{"location":"Sweden Central","zones":[]},{"location":"Switzerland
+        North","zones":[]},{"location":"UAE North","zones":[]},{"location":"UK South","zones":["1","2","3"]},{"location":"West
+        Europe","zones":["1","2","3"]},{"location":"West US 2","zones":["1","2","3"]},{"location":"West
+        US 3","zones":[]}],"capabilities":"SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["West
+        Central US","East US","West Europe","Jio India West","North Europe","Canada
+        Central","East US 2","North Central US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2021-03-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"deploymentLocations","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","Central US (Stage)","North
+        Central US (Stage)","France Central","South Africa North","West US 3","Australia
+        Central","Switzerland North","Germany West Central","UAE North","Jio India
+        West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/validateDeleteVirtualNetworkOrSubnets","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/listVirtualNetworkIntegrations","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/purgeUnusedVirtualNetworkIntegration","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectorgateways","locations":["West
+        Central US","Central US","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","West US","East US","East US 2","Japan
+        East","Brazil South","Australia East","South India","Central India","West
+        US 2","West US 3","Canada Central","Canada East","UK South","France Central","Korea
+        Central","South Africa North","UAE North","Switzerland North","Norway East","Germany
+        West Central","Italy North","Spain Central","Sweden Central","Poland Central","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-05-01-preview"],"defaultApiVersion":"2026-05-01-preview","apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"customApis","locations":["North Central
+        US","Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","East US 2","Japan West","Japan East","Brazil South","Australia
+        East","Brazil Southeast","Australia Southeast","South India","Central India","West
+        India","West US 2","West US 3","Jio India West","West Central US","Canada
+        Central","Canada East","UK South","UK West","France Central","France South","Korea
+        Central","Korea South","South Africa West","South Africa North","UAE Central","UAE
+        North","Switzerland North","Switzerland West","Norway East","Norway West","Germany
+        North","Germany West Central","Israel Central","Italy North","Mexico Central","Spain
+        Central","Sweden Central","Poland Central","Qatar Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/runtimes","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["Central
+        US","East Asia","Japan East","West US","Australia East","Brazil South","Japan
+        West","Southeast Asia","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","South Central US","Jio
+        India West","South Africa North","Israel Central","Mexico Central","Poland
+        Central","Italy North","New Zealand North","Indonesia Central","Malaysia West","Chile
+        Central","Central US (Stage)","Spain Central","Sweden Central","Austria East","Belgium
+        Central","Denmark East","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","East US 2 EUAP","Central US EUAP","East Asia (Stage)","North Central
+        US (Stage)","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"billingMeters","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"verifyHostingEnvironmentVnet","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","Switzerland North","UAE North","Sweden
+        Central","Qatar Central","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["Brazil
+        South","Canada East","UK West","MSFT West US","MSFT East US","MSFT East Asia","MSFT
+        North Europe","East US 2 (Stage)","Central US (Stage)","South Africa North","East
+        US 2","East US","UK South","Southeast Asia","North Europe","Japan East","West
+        Europe","East Asia","Australia East","Japan West","Central India","Korea Central","France
+        Central","West India","Australia Central","Germany West Central","Switzerland
+        North","UAE North","Sweden Central","Qatar Central","Australia Southeast","Korea
+        South","Canada Central","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
+        North","Sweden Central","Qatar Central","Switzerland North","North Central
+        US","UK West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","South Africa
+        West","Jio India West","Poland Central","Italy North","Israel Central","Spain
+        Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps/keyVaultSettings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
+        North","Sweden Central","Qatar Central","Switzerland North","North Central
+        US","UK West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","South Africa
+        West","Jio India West","Poland Central","Italy North","Israel Central","Spain
+        Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"containerApps","locations":["East
+        US","North Europe","Canada Central","East US 2","West Europe","North Central
+        US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-03-01"],"defaultApiVersion":"2021-03-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"customhostnameSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Austria
+        East","Belgium Central","Chile Central","Spain Central","Indonesia Central","Israel
+        Central","Italy North","Mexico Central","Malaysia West","New Zealand North","Poland
+        Central","Denmark East","France South","South Africa West","Norway West","Norway
+        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
+        West","Australia Central 2","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2024-11-01","capabilities":"None"},{"resourceType":"locations/notifyNetworkSecurityPerimeterUpdatesAvailable","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","France South","East
+        Asia","Japan East","South Africa West","West US","Australia East","Brazil
+        South","Southeast Asia","Central US","Japan West","Central India","UK South","Canada
+        East","Korea Central","France Central","North Europe","West US 2","East US","West
+        India","East US 2","Australia Central","Germany West Central","Norway West","Norway
+        East","UAE Central","Germany North","UAE North","Brazil Southeast","Sweden
+        Central","Qatar Central","Switzerland West","Switzerland North","Australia
+        Central 2","North Central US","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","East Asia (Stage)","North
+        Central US (Stage)","West US 3","East US 2 EUAP","Central US EUAP","Jio India
+        West","Jio India Central","Sweden South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-03-01"],"defaultApiVersion":"2022-03-01","capabilities":"None"},{"resourceType":"freeTrialStaticWebApps","locations":["East
+        Asia (Stage)"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2022-09-01"],"capabilities":"None"},{"resourceType":"aigateways","locations":["Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-03-01-preview"],"apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"workerApps","locations":["North
+        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2021-02-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '121399'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 01 Jul 2026 16:48:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 37ABEFD5E02C4FD4A6BC768E55BEF680 Ref B: SN4AA2022301019 Ref C: 2026-07-01T16:48:24Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice list-locations
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --sku --managed-instance-enabled
+      User-Agent:
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?customModeWorkersEnabled=true&api-version=2025-03-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/North
+        Europe","name":"North Europe","type":"Microsoft.Web/geoRegions","properties":{"name":"North
+        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"northeurope-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Asia","name":"East Asia","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSP0V3;LINUXP0V3;WINDOWSMV3;LINUXMV3;FLEXCONSUMPTION;XENONMV3;MANAGEDAPP;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastasia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        East","name":"Australia East","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
+        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"ZONEREDUNDANCY;FCZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXMV3;LINUXP0V3;WINDOWSMV3;WINDOWSP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"australiaeast-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US","name":"East US","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US","description":null,"sortOrder":2147483647,"displayName":"East US","orgDomain":"FCZONEREDUNDANCY;ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;FLEXCONSUMPTION;MANAGEDAPP;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"eastus-01.azurewebsites.net","regionalConstraintLevel":5,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        India","name":"Central India","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        India","description":null,"sortOrder":2147483647,"displayName":"Central India","orgDomain":"ZONEREDUNDANCY;PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;XENONMV3;FLEXCONSUMPTION;FCZONEREDUNDANCY;PV4SERIES;MV4SERIES;MAVICSERIES","subDomains":"centralindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        India","name":"South India","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        India","description":null,"sortOrder":2147483647,"displayName":"South India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSP0V3;WINDOWSMV3;LINUXMV3;LINUXP0V3;FLEXCONSUMPTION;MAVICSERIES","subDomains":"southindia-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        Central US","name":"West Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        Central US","description":null,"sortOrder":2147483647,"displayName":"West
+        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;LINUXFREE;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES","subDomains":"westcentralus-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US 2 EUAP","name":"East US 2 EUAP","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US 2 EUAP","description":null,"sortOrder":2147483647,"displayName":"East US
+        2 EUAP","orgDomain":"EUAP;XENON;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3;XENONMV3;LINUXDYNAMIC;DSERIES;ZONEREDUNDANCY;MANAGEDAPP;PV4SERIES;MV4SERIES;FLEXCONSUMPTION;MAVICSERIES;FCZONEREDUNDANCY","subDomains":"eastus2euap-01.azurewebsites.net","regionalConstraintLevel":0,"zoneRedundantConstraintLevel":5}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5474'
+      content-type:
+      - application/json
+      date:
+      - Wed, 01 Jul 2026 16:48:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=d1dbc388-1013-482b-b171-79f4269ea689/southcentralus/9833d5ba-88df-4bee-89c1-bd1daff62ec9
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 45C1842148494E848D9F5849004B1330 Ref B: SN4AA2022302031 Ref C: 2026-07-01T16:48:24Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice list-locations
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --sku --managed-instance-enabled
+      User-Agent:
+      - AZURECLI/2.88.0 (MSI) azsdk-python-core/1.39.0 Python/3.10.11 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web","namespace":"Microsoft.Web","authorizations":[{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735","managedByRoleDefinitionId":"c29dde9f-14fa-40fb-9fe8-5a07be183f1e"},{"applicationId":"a7d8f84e-510b-46d6-8f59-77e581db63bc","roleDefinitionId":"213f590f-d0be-4560-836d-7db7e2a32cca"}],"resourceTypes":[{"resourceType":"publishingUsers","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostnameavailable","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"validate","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT
+        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
+        Central US (Stage)","France Central","South Africa North","West US 3","Australia
+        Central","Switzerland North","Germany West Central","UAE North","Jio India
+        West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","East
+        US 2 EUAP","Central US EUAP","France South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"isusernameavailable","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"generateGithubAccessTokenForAppserviceCLI","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","North Central US","UK West","Australia Southeast","Korea
+        South","Canada Central","West Europe","South India","West Central US","West
+        US 3","East Asia","Japan East","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","France
+        South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sourceControls","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"availableStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"webAppStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","West US","Australia
+        East","Brazil South","Southeast Asia","Japan West","Central India","UK South","Canada
+        East","Korea Central","France Central","North Europe","East US","West India","East
+        US 2","Australia Central","Germany West Central","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","Australia Central
+        2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"staticSites","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-11-preview","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2024-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/previewStaticSiteWorkflowFile","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"locations/staticSitesOperationStatuses","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"locations/staticSitesOperationResults","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-15"],"defaultApiVersion":"2026-03-15","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/linkedBackends","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/linkedBackends","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/databaseConnections","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/databaseConnections","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP","East Asia (Stage)"],"apiVersions":["2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSiteRegions","locations":["Central
+        US","East US 2","West US 2","West Europe","East Asia","East Asia (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2024-04-01"],"capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/getNetworkPolicies","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","UK West","UK
+        South","West US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
+        Europe","East US 2 (Stage)","Central US (Stage)","France Central","West Central
+        US","Jio India West","France South","East Asia (Stage)","North Central US
+        (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operations","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
+        East","Brazil South","Central US","Japan West","Central India","Canada East","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","West US 3","Jio India West","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US 2","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","West US","Australia
+        East","Brazil South","Central US","Japan West","Central India","Canada East","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","West US 3","Jio India West","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","East US 2 EUAP","South Central US","Australia Central 2","France South","South
+        Africa West","Norway West","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","East Asia (Stage)","North Central US (Stage)","Central
+        US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
+        SupportsTags, SupportsLocation"},{"resourceType":"sites/certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"sites/slots/certificates","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","Malaysia
+        West","Austria East","Belgium Central","Denmark East","France South","South
+        Africa West","East US 2 EUAP","Central US EUAP","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01"],"capabilities":"None"},{"resourceType":"serverFarms","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sites","locations":["MSFT West US","MSFT
+        East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sites/slots","locations":["MSFT West US","MSFT
+        East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"runtimes","locations":["France South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"recommendations","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"aseregions","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","North Central US","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","West
+        US 3","Jio India West","Denmark East","France South","South Africa West","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","Australia Central 2","Taiwan North","Taiwan Northwest","East
+        Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2023-12-01","capabilities":"None"},{"resourceType":"georegions","locations":["West
+        Europe","West US","East US","West India","North Central US","West Central
+        US","North Europe","Central US","East Asia","West US 2","Australia Central","Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","East US 2","France Central","Japan East","Korea Central","Korea South","South
+        Africa North","South Central US","Southeast Asia","South India","UK South","UK
+        West","West US 3","Austria East","Belgium Central","Chile Central","Denmark
+        East","UAE North","Spain Central","Germany West Central","Indonesia Central","Israel
+        Central","Italy North","Jio India West","Mexico Central","Malaysia West","New
+        Zealand North","Japan West","Poland Central","Qatar Central","Sweden Central","Switzerland
+        North","France South","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan
+        Northwest","UAE Central","Germany North","Brazil Southeast","Switzerland West","Sweden
+        South","Norway West","Australia Central 2","South Africa West","Norway East"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","Norway West","Norway East","UAE Central","Germany
+        North","Brazil Southeast","Sweden South","Switzerland West","North Central
+        US","East Asia (Stage)","North Central US (Stage)","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East US 2","East US","UK South","Southeast
+        Asia","North Europe","Japan East","West Europe","East Asia","Australia East","Brazil
+        South","Japan West","Central India","Canada East","Korea Central","France
+        Central","West India","Australia Central","Germany West Central","UAE North","Sweden
+        Central","Qatar Central","Switzerland North","UK West","Australia Southeast","Korea
+        South","Canada Central","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"Australia
+        East","zones":["1","2","3"]},{"location":"Austria East","zones":[]},{"location":"Belgium
+        Central","zones":[]},{"location":"Brazil South","zones":["1","2","3"]},{"location":"Canada
+        Central","zones":["1","2","3"]},{"location":"Central India","zones":[]},{"location":"Central
+        US","zones":["1","2","3"]},{"location":"Central US EUAP","zones":[]},{"location":"Chile
+        Central","zones":[]},{"location":"Denmark East","zones":[]},{"location":"East
+        Asia","zones":[]},{"location":"East US","zones":["1","2","3"]},{"location":"East
+        US 2","zones":["1","2","3"]},{"location":"East US 2 EUAP","zones":["1","2","3"]},{"location":"France
+        Central","zones":["1","2","3"]},{"location":"Germany West Central","zones":["1","2","3"]},{"location":"Indonesia
+        Central","zones":[]},{"location":"Israel Central","zones":[]},{"location":"Italy
+        North","zones":[]},{"location":"Japan East","zones":["1","2","3"]},{"location":"Japan
+        West","zones":[]},{"location":"Korea Central","zones":[]},{"location":"Malaysia
+        West","zones":[]},{"location":"Mexico Central","zones":[]},{"location":"New
+        Zealand North","zones":[]},{"location":"North Europe","zones":["1","2","3"]},{"location":"Norway
+        East","zones":[]},{"location":"Poland Central","zones":[]},{"location":"Qatar
+        Central","zones":[]},{"location":"South Africa North","zones":["1","2","3"]},{"location":"South
+        Central US","zones":["1","2","3"]},{"location":"Southeast Asia","zones":["1","2","3"]},{"location":"Spain
+        Central","zones":[]},{"location":"Sweden Central","zones":[]},{"location":"Switzerland
+        North","zones":[]},{"location":"UAE North","zones":[]},{"location":"UK South","zones":["1","2","3"]},{"location":"West
+        Europe","zones":["1","2","3"]},{"location":"West US 2","zones":["1","2","3"]},{"location":"West
+        US 3","zones":[]}],"capabilities":"SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["West
+        Central US","East US","West Europe","Jio India West","North Europe","Canada
+        Central","East US 2","North Central US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2021-03-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"deploymentLocations","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","Central US (Stage)","North
+        Central US (Stage)","France Central","South Africa North","West US 3","Australia
+        Central","Switzerland North","Germany West Central","UAE North","Jio India
+        West","Sweden Central","Qatar Central","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Chile
+        Central","Malaysia West","Austria East","Belgium Central","Denmark East","Taiwan
+        North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","South Africa West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","France South","South
+        Africa West","West US","Central US","West US 2","Norway West","Norway East","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","Australia
+        Central 2","North Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":["France
+        South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/validateDeleteVirtualNetworkOrSubnets","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/listVirtualNetworkIntegrations","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"locations/purgeUnusedVirtualNetworkIntegration","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","UAE North","Sweden Central","Qatar Central","Switzerland North","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","East US 2 EUAP","Central US EUAP","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectorgateways","locations":["West
+        Central US","Central US","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","West US","East US","East US 2","Japan
+        East","Brazil South","Australia East","South India","Central India","West
+        US 2","West US 3","Canada Central","Canada East","UK South","France Central","Korea
+        Central","South Africa North","UAE North","Switzerland North","Norway East","Germany
+        West Central","Italy North","Spain Central","Sweden Central","Poland Central","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-05-01-preview"],"defaultApiVersion":"2026-05-01-preview","apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"customApis","locations":["North Central
+        US","Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","East US 2","Japan West","Japan East","Brazil South","Australia
+        East","Brazil Southeast","Australia Southeast","South India","Central India","West
+        India","West US 2","West US 3","Jio India West","West Central US","Canada
+        Central","Canada East","UK South","UK West","France Central","France South","Korea
+        Central","Korea South","South Africa West","South Africa North","UAE Central","UAE
+        North","Switzerland North","Switzerland West","Norway East","Norway West","Germany
+        North","Germany West Central","Israel Central","Italy North","Mexico Central","Spain
+        Central","Sweden Central","Poland Central","Qatar Central","New Zealand North","Indonesia
+        Central","Malaysia West","Chile Central","Austria East","Belgium Central","Denmark
+        East","Central US EUAP","East US 2 EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/runtimes","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2022-09-01-preview","2018-07-01-preview","2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","Brazil Southeast","South
+        India","Central India","West India","West US 2","West US 3","Jio India West","West
+        Central US","Canada Central","Canada East","UK South","UK West","France Central","France
+        South","Korea Central","Korea South","South Africa West","South Africa North","UAE
+        Central","UAE North","Switzerland North","Switzerland West","Norway East","Norway
+        West","Germany North","Germany West Central","Israel Central","Italy North","Mexico
+        Central","Spain Central","Sweden Central","Poland Central","Qatar Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","Central US EUAP","East US 2 EUAP","Taiwan
+        North","Taiwan Northwest"],"apiVersions":["2018-03-01-preview","2016-06-01","2015-08-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-06-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-06-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-03-01-preview"}],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["Central
+        US","East Asia","Japan East","West US","Australia East","Brazil South","Japan
+        West","Southeast Asia","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","South Central US","Jio
+        India West","South Africa North","Israel Central","Mexico Central","Poland
+        Central","Italy North","New Zealand North","Indonesia Central","Malaysia West","Chile
+        Central","Central US (Stage)","Spain Central","Sweden Central","Austria East","Belgium
+        Central","Denmark East","Brazil Southeast","Sweden South","Switzerland West","Norway
+        West","Norway East","UAE Central","Germany North","Australia Central 2","France
+        South","East US 2 EUAP","Central US EUAP","East Asia (Stage)","North Central
+        US (Stage)","South Africa West","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"billingMeters","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"verifyHostingEnvironmentVnet","locations":["Central
+        US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
+        US","East US","Japan West","Japan East","East Asia","East US 2","North Central
+        US","South Central US","Brazil South","Australia East","Australia Southeast","West
+        India","Central India","South India","Canada Central","Canada East","West
+        Central US","UK West","UK South","West US 2","MSFT West US","MSFT East US","MSFT
+        East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)","France Central","South Africa North","West
+        US 3","Australia Central","Switzerland North","Germany West Central","UAE
+        North","Jio India West","Sweden Central","Qatar Central","Poland Central","Italy
+        North","Israel Central","Spain Central","Mexico Central","New Zealand North","Indonesia
+        Central","Chile Central","Malaysia West","Austria East","Belgium Central","Denmark
+        East","Taiwan North","Taiwan Northwest","Brazil Southeast","Sweden South","Switzerland
+        West","Norway West","Norway East","UAE Central","Germany North","Australia
+        Central 2","East US 2 EUAP","Central US EUAP","France South","South Africa
+        West"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","UAE North","Sweden Central","Qatar
+        Central","Switzerland North","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","Australia East","Brazil South","Southeast
+        Asia","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","East US","West India","East US 2","Australia Central","Germany
+        West Central","Norway West","Norway East","Switzerland North","UAE North","Sweden
+        Central","Qatar Central","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","West US 3","East Asia","Japan
+        East","South Africa West","Jio India West","Poland Central","Italy North","Israel
+        Central","Spain Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","West
+        US","Central US","West US 2","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","France South","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["Brazil
+        South","Canada East","UK West","MSFT West US","MSFT East US","MSFT East Asia","MSFT
+        North Europe","East US 2 (Stage)","Central US (Stage)","South Africa North","East
+        US 2","East US","UK South","Southeast Asia","North Europe","Japan East","West
+        Europe","East Asia","Australia East","Japan West","Central India","Korea Central","France
+        Central","West India","Australia Central","Germany West Central","Switzerland
+        North","UAE North","Sweden Central","Qatar Central","Australia Southeast","Korea
+        South","Canada Central","South India","West Central US","West US 3","Jio India
+        West","Poland Central","Italy North","Israel Central","Spain Central","Mexico
+        Central","New Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
+        North","Sweden Central","Qatar Central","Switzerland North","North Central
+        US","UK West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","South Africa
+        West","Jio India West","Poland Central","Italy North","Israel Central","Spain
+        Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps/keyVaultSettings","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","West US","Australia East","Brazil South","Southeast
+        Asia","Central US","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","West US 2","East US","West India","East
+        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
+        North","Sweden Central","Qatar Central","Switzerland North","North Central
+        US","UK West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","West US 3","East Asia","Japan East","South Africa
+        West","Jio India West","Poland Central","Italy North","Israel Central","Spain
+        Central","Mexico Central","New Zealand North","Indonesia Central","Malaysia
+        West","Chile Central","Austria East","Belgium Central","Denmark East","South
+        Central US","Australia Central 2","East US 2 EUAP","Central US EUAP","UAE
+        Central","Germany North","Brazil Southeast","Sweden South","Switzerland West","East
+        Asia (Stage)","North Central US (Stage)","France South","Taiwan North","Taiwan
+        Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2024-04-01","capabilities":"None"},{"resourceType":"containerApps","locations":["East
+        US","North Europe","Canada Central","East US 2","West Europe","North Central
+        US (Stage)","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-03-01"],"defaultApiVersion":"2021-03-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"customhostnameSites","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Africa North","East Asia","Japan East","Australia East","Brazil
+        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
+        Central","France Central","North Europe","East US","West India","East US 2","Australia
+        Central","Germany West Central","UAE North","Sweden Central","Qatar Central","Switzerland
+        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Poland
+        Central","Italy North","Israel Central","Spain Central","Mexico Central","New
+        Zealand North","Indonesia Central","Malaysia West","Chile Central","Austria
+        East","Belgium Central","Denmark East","South Central US","Australia Central
+        2","France South","South Africa West","West US","Central US","West US 2","Norway
+        West","Norway East","UAE Central","Germany North","Brazil Southeast","Sweden
+        South","Switzerland West","North Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-09-01","2022-03-01","2021-03-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"defaultApiVersion":"2024-04-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["MSFT
+        West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
+        US (Stage)","South Central US","South Africa North","East Asia","Japan East","West
+        US","Australia East","Brazil South","Southeast Asia","Central US","Japan West","Central
+        India","UK South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","UAE North","Sweden Central","Qatar Central","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","West US 3","Jio India West","Austria
+        East","Belgium Central","Chile Central","Spain Central","Indonesia Central","Israel
+        Central","Italy North","Mexico Central","Malaysia West","New Zealand North","Poland
+        Central","Denmark East","France South","South Africa West","Norway West","Norway
+        East","UAE Central","Germany North","Brazil Southeast","Sweden South","Switzerland
+        West","Australia Central 2","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP","Taiwan North","Taiwan Northwest"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01"],"defaultApiVersion":"2024-11-01","capabilities":"None"},{"resourceType":"locations/notifyNetworkSecurityPerimeterUpdatesAvailable","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","France South","East
+        Asia","Japan East","South Africa West","West US","Australia East","Brazil
+        South","Southeast Asia","Central US","Japan West","Central India","UK South","Canada
+        East","Korea Central","France Central","North Europe","West US 2","East US","West
+        India","East US 2","Australia Central","Germany West Central","Norway West","Norway
+        East","UAE Central","Germany North","UAE North","Brazil Southeast","Sweden
+        Central","Qatar Central","Switzerland West","Switzerland North","Australia
+        Central 2","North Central US","UK West","Australia Southeast","Korea South","Canada
+        Central","West Europe","South India","West Central US","East Asia (Stage)","North
+        Central US (Stage)","West US 3","East US 2 EUAP","Central US EUAP","Jio India
+        West","Jio India Central","Sweden South"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2024-04-01","2023-12-01","2023-01-01","2022-03-01"],"defaultApiVersion":"2022-03-01","capabilities":"None"},{"resourceType":"freeTrialStaticWebApps","locations":["East
+        Asia (Stage)"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2022-09-01"],"capabilities":"None"},{"resourceType":"aigateways","locations":["Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2026-03-01-preview"],"apiProfiles":[],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"workerApps","locations":["North
+        Central US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2026-03-15","2026-03-01-preview","2025-05-01","2025-03-01","2024-11-01","2021-02-01","2021-01-15","2021-01-01","2020-12-01"],"defaultApiVersion":"2021-02-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '121399'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 01 Jul 2026 16:48:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2A9CAC698A924B2CB7B8DB937F44DD69 Ref B: SN4AA2022301011 Ref C: 2026-07-01T16:48:25Z'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2450,6 +2450,15 @@ class WebappListLocationsTest(ScenarioTest):
         self.cmd('appservice list-locations --sku P1MV4 --managed-instance-enabled', checks = [
             JMESPathCheck('length(@) > `0`', True)
         ])
+        self.cmd('appservice list-locations --sku P0V3 --managed-instance-enabled', checks = [
+            JMESPathCheck('length(@) > `0`', True)
+        ])
+        self.cmd('appservice list-locations --sku P1V3 --managed-instance-enabled', checks = [
+            JMESPathCheck('length(@) > `0`', True)
+        ])
+        self.cmd('appservice list-locations --sku P1MV3 --managed-instance-enabled', checks = [
+            JMESPathCheck('length(@) > `0`', True)
+        ])
 
 
 class ContainerWebappE2ETest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -126,7 +126,7 @@ def get_sku_name(tier):
 
 def is_sku_tier_enabled_for_managed_instance(sku_tier):
     sku_tier = sku_tier.upper()
-    enabled_skus = ['PREMIUMV4', 'PREMIUMMV4']
+    enabled_skus = ['PREMIUM0V3', 'PREMIUMV3', 'PREMIUMMV3', 'PREMIUMV4', 'PREMIUMMV4']
     return sku_tier in enabled_skus
 
 


### PR DESCRIPTION
**Related command**
`az appservice plan create`, `az appservice plan update`, `az appservice plan managed-instance`, `az appservice plan identity`, `az appservice list-locations`

**Description**

This PR does two things for managed instance App Service plans:

1. **Graduates the managed instance commands out of preview** (removes the preview flag) in preparation for GA:
   - Command groups: `az appservice plan managed-instance instance`, `az appservice plan identity`
   - Arguments on `az appservice plan create` / `az appservice plan update`: `--is-managed-instance`, `--mi-system-assigned`, `--mi-user-assigned`, `--default-identity`, `--rdp-enabled`, `--vnet`, `--subnet`, `--registry-adapter`, `--install-script`, `--storage-mount`
   - Argument on `az appservice list-locations`: `--managed-instance-enabled`
   - The aaz command stubs for the `managed-instance` command group and the `managed-instance instance list` command

2. **Adds Premium V3 SKU support** for managed instances. Previously only `PremiumV4` / `PremiumMV4` were allowed for `az appservice list-locations --managed-instance-enabled`. This adds `Premium0V3`, `PremiumV3`, and `PremiumMV3` to the allowed SKUs for managed instance.

**Testing Guide**

Validated locally against a source build and compared with the officially installed CLI (2.87.0).

Preview flag removed (help no longer shows `[Preview]` / "in preview" warnings):

```
az appservice plan create -h
az appservice plan update -h
az appservice plan managed-instance -h
az appservice plan managed-instance instance list -h
az appservice plan identity -h
az appservice list-locations -h
```

Premium V3 SKUs are now listed for managed instance (read-only `list-locations`):

```
az appservice list-locations --sku P1V4 --managed-instance-enabled     # returns regions (unchanged)
az appservice list-locations --sku P0V3 --managed-instance-enabled     # previously empty, now returns regions
az appservice list-locations --sku P1V3 --managed-instance-enabled     # previously empty, now returns regions
az appservice list-locations --sku P1MV3 --managed-instance-enabled    # previously empty, now returns regions
```

Result counts observed (same subscription): the old CLI returned 0 regions for the V3 SKUs and 8 for P1V4; the source build returns 8 regions for all of P1V4 / P0V3 / P1V3 / P1MV3.

**History Notes**

[App Service] `az appservice plan`: Remove preview flag for managed instance app service plans
[App Service] `az appservice plan`: Add Premium V3 SKU support (`P0V3`, `P1-3V3`, `P1-5MV3`) for managed instances

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
