### PR TITLE
{CI} Change azdev pin to azdev==0.2.12

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -15,17 +15,8 @@ steps:
       python -m venv env
       chmod +x env/bin/activate
       . env/bin/activate
-      # Cap setuptools<81 to match the CLI build (81 drops setup.py --dry-run,
-      # 82 removes pkg_resources) so `azdev setup` builds under a supported
-      # setuptools regardless of what the agent image ships.
+
       python -m pip install -U pip "setuptools<81"
-      # Pin azdev to azure-cli-dev-tools commit 644d296 (0.2.12). This bundles:
-      # decouple extension metadata from wheel==0.30.0 (#549), quote paths in
-      # editable installs (#551), and --no-build-isolation for editable installs
-      # (#552) so extensions whose setup.py imports azure (e.g. confcom) build
-      # against the environment instead of an isolated PEP 517 env under
-      # setuptools>=79. It is not on PyPI yet; switch this to
-      # `pip install --upgrade "azdev==0.2.12"` once published to PyPI.
       pip install --upgrade "azdev==0.2.12"
       azdev --version
 

--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -26,7 +26,7 @@ steps:
       # against the environment instead of an isolated PEP 517 env under
       # setuptools>=79. It is not on PyPI yet; switch this to
       # `pip install --upgrade "azdev==0.2.12"` once published to PyPI.
-      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@644d296d9ca9b322b438d5ca21141b247258d0e5#egg=azdev"
+      pip install --upgrade "azdev==0.2.12"
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then


### PR DESCRIPTION
azdev 0.2.12 is now on PyPI, so switch the pin from the git commit (644d296) to the published `azdev==0.2.12`. Functionally identical, 0.2.12 adds `--no-build-isolation` to editable installs, which already fixed the Codegen Coverage failure when 644d296 was pinned.

Verified locally with azdev 0.2.12 from PyPI: `azdev setup -c azure-cli -r azure-cli-extensions` and `azdev extension add confcom` both pass on setuptools 79.x.