### PR TITLE
ARO fixed default vm size for master nodes if not provided 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_params.py
@@ -94,7 +94,7 @@ def load_arguments(self, _):
                    options_list=['--master-encryption-at-host', '--master-enc-host'],
                    help='Encryption at host flag for master VMs. [Default: false]')
         c.argument('master_vm_size',
-                   help='Size of master VMs. [Default: Standard_D8s_v5]')
+                   help='Size of master VMs.')
 
         c.argument('worker_encryption_at_host', arg_type=get_three_state_flag(),
                    options_list=['--worker-encryption-at-host', '--worker-enc-host'],

--- a/src/azure-cli/azure/cli/command_modules/aro/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/custom.py
@@ -77,7 +77,7 @@ def aro_create(*,  # pylint: disable=too-many-locals
                outbound_type=None,
                disk_encryption_set=None,
                master_encryption_at_host=False,
-               master_vm_size=None,
+               master_vm_size="Standard_D8s_v5",
                worker_encryption_at_host=False,
                worker_vm_size="Standard_D4s_v5",
                worker_vm_disk_size_gb=None,
@@ -169,7 +169,7 @@ def aro_create(*,  # pylint: disable=too-many-locals
             preconfigured_nsg='Enabled' if enable_preconfigured_nsg else 'Disabled',
         ),
         master_profile=openshiftcluster.MasterProfile(
-            vm_size=master_vm_size or 'Standard_D8s_v5',
+            vm_size=master_vm_size,
             subnet_id=master_subnet,
             encryption_at_host='Enabled' if master_encryption_at_host else 'Disabled',
             disk_encryption_set_id=disk_encryption_set,


### PR DESCRIPTION
Relates to previous change at https://github.com/Azure/azure-cli/pull/33508 

Command:

`az aro create -n -g --vnet --master-subnet --master-subnet
`
**Description**

If `--master-vm-size` is not provided to `az aro create`, a default value of `Standard_D8s_v5` should be set on the parameter itself (rather than relying on a runtime `or` fallback). This mirrors the fix applied to `--worker-vm-size` in PR #33508 and ensures the CLI help text correctly auto-displays the default value.

**Testing Guide**

Create an ARO cluster without passing the `--master-vm-size` flag. It should create the cluster using `Standard_D8s_v5` for master VMs without returning an error. Running `az aro create --help` should display the default value for `--master-vm-size`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in Submitting Pull Requests.
- [x] I adhere to the Command Guidelines.
- [x] I adhere to the Error Handling Guidelines.