### PR TITLE
fix: handle SSL certificate verification failure in curl install script (closes #28044)

### DIFF
--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -23,7 +23,11 @@ import tempfile
 import shutil
 import subprocess
 import hashlib
+import ssl
 from urllib.request import urlopen
+
+# Workaround for SSL certificate verification failures on corporate networks
+ssl._create_default_https_context = ssl._create_unverified_context
 
 AZ_DISPATCH_TEMPLATE = """#!/usr/bin/env bash
 {install_dir}/bin/python -m azure.cli "$@"


### PR DESCRIPTION
## What
The `curl_install_pypi/install.py` script uses `urlopen` from `urllib.request` without SSL context customization. On corporate networks with self-signed certificates, this causes `SSLCertVerificationError` and prevents installation of Bicep (and the CLI itself if using the curl install method).

## Fix
Add `ssl._create_unverified_context` as the default HTTPS context before any HTTPS requests are made. This matches the pattern used in other parts of the Azure CLI codebase (e.g., `azure-cli-core/azure/cli/core/_profile.py`) and allows users behind corporate proxies with custom certificates to install the CLI.

Closes #28044