### PR TITLE
[Compute] `az vmss application set`: Fix command silently failing to set gallery applications

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -6508,7 +6508,6 @@ def set_vmss_applications(cmd, vmss_name, resource_group_name, application_versi
 
             # Resolve flatten conflict
             # When the type field conflicts, the type in inner layer is ignored and the outer layer is applied
-            print(self.ctx.vars.instance.properties.virtual_machine_profile.extension_profile.extensions)
             if has_value(self.ctx.vars.instance.properties.virtual_machine_profile.extension_profile.extensions):
                 for extension in self.ctx.vars.instance.properties.virtual_machine_profile.extension_profile.extensions:
                     if has_value(extension.type):

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -6474,11 +6474,11 @@ def set_vmss_applications(cmd, vmss_name, resource_group_name, application_versi
             args.no_wait = no_wait
 
         def pre_instance_update(self, instance):
-            instance.properties.virtualMachineProfile.application_profile.gallery_applications = [{"package_reference_id": avid} for avid in application_version_ids]
+            instance.properties.virtual_machine_profile.application_profile.gallery_applications = [{"package_reference_id": avid} for avid in application_version_ids]
 
             if order_applications:
                 index = 1
-                for app in instance.properties.virtualMachineProfile.application_profile.gallery_applications:
+                for app in instance.properties.virtual_machine_profile.application_profile.gallery_applications:
                     app["order"] = index
                     index += 1
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az vmss application set`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
- Remove leftover debug print
- Fix property naming error, it is being set to CamelCase property, which is incorrect.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] `az vmss application set`: Fix command silently failing to set gallery applications and remove leftover debug output

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
