### PR TITLE
{Service Connector} `az containerapp connection create`: Block command as Service Connector (preview) on Azure Container Apps has been retired

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -105,6 +105,10 @@ Release History
 
 * `az role deny-assignment create/delete`: Add new commands (#33109)
 
+**Service Connector**
+
+* `az containerapp connection create`: Block the command as Service Connector (preview) on Azure Container Apps has been retired (#38660284)
+
 **SSH**
 
 * `az ssh`: Restore explicit failure for unsupported managed identity and Cloud Shell SSH cert flows (#33534)

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
@@ -78,6 +78,18 @@ def get_target_resource_name(cmd):
     return target
 
 
+def block_retired_containerapp_connection_create(cmd):
+    '''Block creating new Service Connector connections on Azure Container Apps.
+    Service Connector (preview) on Azure Container Apps has been retired.
+    See https://github.com/microsoft/azure-container-apps/issues/1566
+    '''
+    if 'create' in cmd.name and get_source_resource_name(cmd) == RESOURCE.ContainerApp:
+        raise ValidationError(
+            "Service Connector (preview) on Azure Container Apps has been retired. "
+            "'az containerapp connection create' is no longer supported. "
+            "For more information, see https://github.com/microsoft/azure-container-apps/issues/1566.")
+
+
 def get_resource_type_by_id(resource_id):
     '''Get source or target resource type by resource id
     '''
@@ -930,6 +942,8 @@ def validate_local_params(cmd, namespace):
 def validate_params(cmd, namespace):
     '''Validate command parameters
     '''
+    block_retired_containerapp_connection_create(cmd)
+
     def _validate_and_apply(validate, apply):
         missing_args = validate(cmd, namespace)
         if missing_args:
@@ -961,6 +975,8 @@ def validate_params(cmd, namespace):
 
 
 def validate_kafka_params(cmd, namespace):
+    block_retired_containerapp_connection_create(cmd)
+
     def _validate_and_apply(validate, apply):
         missing_args = validate(cmd, namespace)
         if missing_args:


### PR DESCRIPTION
### Related command
`az containerapp connection create`

### Description
Service Connector (preview) on Azure Container Apps has been retired (see https://github.com/microsoft/azure-container-apps/issues/1566). This change blocks creating **new** connections for the `containerapp` source while keeping existing connections fully manageable.

- Added `block_retired_containerapp_connection_create` in `serviceconnector/_validators.py`, invoked at the top of `validate_params` and `validate_kafka_params`. It raises a `ValidationError` for the ContainerApp source **before** any argument prompting, so the command fails fast with a clear retirement message instead of prompting for parameters.
- `az containerapp connection create <target>` (all targets, including `confluent-cloud`) now exits non-zero with:
  > Service Connector (preview) on Azure Container Apps has been retired. 'az containerapp connection create' is no longer supported. For more information, see https://github.com/microsoft/azure-container-apps/issues/1566.
- `list`, `show`, `validate`, `delete`, and `update` remain functional so users can still manage existing connections.
- Other source resources (webapp, functionapp, spring-cloud, aks, etc.) are unaffected.

### Testing Guide
Built the CLI from source with `azdev` and verified:
- `az containerapp connection create postgres` and `az containerapp connection create confluent-cloud ...` → retirement error, exit code 1, no prompting.
- `az containerapp connection update/list/show/delete/validate` → work as before.
- `az webapp connection create postgres` → unaffected (other sources still allow create).

Work item: 38660284 (Remove Service Connector on ACA)
