### PR TITLE
[ACR] Surface x-ms-warning header on PE connection delete

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/private_endpoint_connection.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/private_endpoint_connection.py
@@ -62,7 +62,7 @@ def delete(cmd, client, registry_name, private_endpoint_connection_name, resourc
                                  private_endpoint_connection_name=private_endpoint_connection_name)
 
     # Surface server-side warning (e.g. PE connection not found, returned 204)
-    initial_response = poller.polling_method()._initial_response
+    initial_response = poller.polling_method()._initial_response  # pylint: disable=protected-access
     warning = initial_response.http_response.headers.get("x-ms-warning")
     if warning:
         logger.warning(warning)

--- a/src/azure-cli/azure/cli/command_modules/acr/private_endpoint_connection.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/private_endpoint_connection.py
@@ -3,7 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from knack.log import get_logger
+
 from ._utils import get_resource_group_name_by_registry_name
+
+logger = get_logger(__name__)
 
 
 def _update_private_endpoint_connection_status(cmd, client, resource_group_name, registry_name,
@@ -54,8 +58,16 @@ def delete(cmd, client, registry_name, private_endpoint_connection_name, resourc
 
     resource_group_name = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
-    return client.begin_delete(resource_group_name=resource_group_name, registry_name=registry_name,
-                               private_endpoint_connection_name=private_endpoint_connection_name)
+    poller = client.begin_delete(resource_group_name=resource_group_name, registry_name=registry_name,
+                                 private_endpoint_connection_name=private_endpoint_connection_name)
+
+    # Surface server-side warning (e.g. PE connection not found, returned 204)
+    initial_response = poller.polling_method()._initial_response
+    warning = initial_response.http_response.headers.get("x-ms-warning")
+    if warning:
+        logger.warning(warning)
+
+    return poller
 
 
 # cannot redefine list as it is a builtin function


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

When a private endpoint connection delete returns 204 (resource not found), the ACR server now sends an `x-ms-warning` response header. This change reads that header from the initial LRO response and displays it to the user via `logger.warning()`.

## Changes

- `src/azure-cli/azure/cli/command_modules/acr/private_endpoint_connection.py`: Read `x-ms-warning` header from the delete LRO initial response and display it to the CLI user.

## Testing

Tested with `az acr private-endpoint-connection delete -r myRegistry -n nonExistentPE` — warning message from server is displayed when PE does not exist (204 response).