### PR TITLE
{AKS} Fix missing wait on LRO pollers in azuremonitormetrics helpers

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/addonput.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/addonput.py
@@ -22,6 +22,7 @@ def addon_put(cmd, cluster_subscription, cluster_resource_group_name, cluster_na
             if getattr(mc.azure_monitor_profile.metrics, "enabled", None) is False:
                 mc.azure_monitor_profile.metrics.enabled = True
     try:
-        client.begin_create_or_update(cluster_resource_group_name, cluster_name, mc)
+        poller = client.begin_create_or_update(cluster_resource_group_name, cluster_name, mc)
+        poller.result()
     except Exception as e:
         raise UnknownError(e)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amg/link.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amg/link.py
@@ -69,11 +69,12 @@ def link_grafana_instance(cmd, raw_parameters, azure_monitor_workspace_resource_
             }
         }
         try:
-            resources.begin_create_or_update_by_id(
+            poller = resources.begin_create_or_update_by_id(
                 roleAssignmentResourceId,
                 GRAFANA_ROLE_ASSIGNMENT_API,
                 association_body
             )
+            poller.result()
         except HttpResponseError as e:
             # If already exists (RoleAssignmentExists), warn and continue, else print error
             if e.error and e.error.code == "RoleAssignmentExists":
@@ -109,11 +110,12 @@ def link_grafana_instance(cmd, raw_parameters, azure_monitor_workspace_resource_
         targetGrafanaArmPayload["properties"]["grafanaIntegrations"]["azureMonitorWorkspaceIntegrations"].append({
             "azureMonitorWorkspaceResourceId": azure_monitor_workspace_resource_id
         })
-        resources.begin_create_or_update_by_id(
+        poller = resources.begin_create_or_update_by_id(
             grafana_resource_id,
             GRAFANA_API,
             targetGrafanaArmPayload
         )
+        poller.result()
     except CLIError as e:
         raise CLIError(e)
     return GrafanaLink.SUCCESS

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/create.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/create.py
@@ -34,7 +34,7 @@ def create_default_mac(cmd, cluster_subscription, cluster_region):
     else:
         resource_groups.create_or_update(default_resource_group_name, {"location": default_mac_region})
     try:
-        resources.begin_create_or_update_by_id(
+        poller = resources.begin_create_or_update_by_id(
             azure_monitor_workspace_resource_id,
             MAC_API,
             {
@@ -42,6 +42,7 @@ def create_default_mac(cmd, cluster_subscription, cluster_region):
                 "properties": {}
             }
         )
+        poller.result()
         return azure_monitor_workspace_resource_id, default_mac_region
     except Exception as e:
         raise CLIError(e)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/dce_api.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/dce_api.py
@@ -20,7 +20,7 @@ def create_dce(cmd, cluster_subscription, cluster_resource_group_name, cluster_n
     from azure.cli.command_modules.acs._client_factory import get_resources_client
     resources = get_resources_client(cmd.cli_ctx, cluster_subscription)
     try:
-        resources.begin_create_or_update_by_id(
+        poller = resources.begin_create_or_update_by_id(
             dce_resource_id,
             DC_API,
             {
@@ -30,6 +30,7 @@ def create_dce(cmd, cluster_subscription, cluster_resource_group_name, cluster_n
                 "properties": {}
             }
         )
+        poller.result()
         return dce_resource_id
     except Exception as error:
         raise CLIError(error)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/dcr_api.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/dcr_api.py
@@ -33,11 +33,12 @@ def create_dcr(cmd, mac_region, azure_monitor_workspace_resource_id, cluster_sub
         }
     }
     try:
-        resources.begin_create_or_update_by_id(
+        poller = resources.begin_create_or_update_by_id(
             dcr_resource_id,
             DC_API,
             dcr_creation_body
         )
+        poller.result()
         return dcr_resource_id
     except Exception as error:
         raise CLIError(error)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/dcra_api.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/dcra_api.py
@@ -31,11 +31,12 @@ def create_dcra(cmd, cluster_region, cluster_subscription, cluster_resource_grou
     from azure.cli.command_modules.acs._client_factory import get_resources_client
     resources = get_resources_client(cmd.cli_ctx, cluster_subscription)
     try:
-        resources.begin_create_or_update_by_id(
+        poller = resources.begin_create_or_update_by_id(
             f"{cluster_resource_id}/providers/Microsoft.Insights/dataCollectionRuleAssociations/{dcra_name}",
             DC_API,
             association_body
         )
+        poller.result()
         return dcra_resource_id
     except Exception as error:
         raise CLIError(error)


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
`az aks create --sku automatic`, `az aks addon`/Azure Monitor metrics enablement commands (any command path that calls `ensure_azure_monitor_profile_prerequisites`, e.g. `create_dce`/`create_dcr`/`create_dcra`/`addon_put`/`create_default_mac`/`link_grafana_instance`).

**Description**
`create_dce`, `create_dcr`, `create_dcra`, `addon_put`, `create_default_mac`, and `link_grafana_instance` (in `azure.cli.command_modules.acs.azuremonitormetrics`) all call `begin_create_or_update`/`begin_create_or_update_by_id` but never call `.result()`/`.wait()` on the returned poller before returning.

Because the generic `ResourceManagementClient` used here polls via a background thread, the code proceeds as soon as the initial PUT is accepted instead of waiting for the resource to actually finish provisioning.

This is invisible in VCR-recorded tests (responses replay instantly, so the background poller thread finishes almost immediately), but is exposed in live tests: `azure-cli-testsdk`'s `tearDown()` asserts that no thread named `"LROPoller"` is still alive (`scenario_tests/base.py`). A live `az aks create --sku automatic` run (which always provisions DCE/DCR/DCRA/Grafana-link resources for Azure Monitor metrics) can leave one of these pollers still polling in the background after the command returns, failing that assertion, and more generally means the CLI can return control to the caller before these dependent resources are actually ready.

Fix: capture the poller returned by each `begin_create_or_update`/`begin_create_or_update_by_id` call and call `.result()` on it before returning, so callers only get control back once the resource has actually finished provisioning. No public interface/behavior changes other than the command now waiting for these ARM operations to complete.

**Testing Guide**
```
az aks create -g <rg> -n <name> --sku automatic --enable-hosted-system \
  --workspace-resource-id <log-analytics-workspace-id>
```
Before the fix, a live test run of any `@live_only()` scenario that creates a `--sku automatic` cluster (which always enables Azure Monitor metrics and calls the affected helpers) could fail in `tearDown()` with:
```
AssertionError: You need to call 'result' or 'wait' on all LROPoller you have created
```
After the fix, this teardown assertion should no longer trigger from these code paths, since each `begin_create_or_update[_by_id]` call is now fully awaited via `.result()`.

**History Notes**
[AKS] Fix missing wait on LRO pollers when provisioning Azure Monitor metrics artifacts (DCE/DCR/DCRA/Grafana link) for `az aks create --sku automatic`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
