### PR TITLE
{CodeOwner} Remove dead CODEOWNERS rule for non-existent natgateway module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,6 @@
 /src/azure-cli/azure/cli/command_modules/keyvault/ @Azure/act-identity-squad
 /src/azure-cli/azure/cli/command_modules/monitor/ @Azure/act-observability-squad
 /src/azure-cli/azure/cli/command_modules/mysql/ @Azure/act-codegen-extensibility-squad
-/src/azure-cli/azure/cli/command_modules/natgateway/ @Azure/act-quality-productivity-squad
 /src/azure-cli/azure/cli/command_modules/network/ @Azure/act-quality-productivity-squad
 /src/azure-cli/azure/cli/command_modules/policyinsights/ @Azure/act-identity-squad
 /src/azure-cli/azure/cli/command_modules/postgresql/ @Azure/act-codegen-extensibility-squad


### PR DESCRIPTION
Hi, and thank you for azure-cli.

Tiny repo-hygiene cleanup: `.github/CODEOWNERS` line 59 assigns

```
/src/azure-cli/azure/cli/command_modules/natgateway/ @Azure/act-quality-productivity-squad
```

but that directory no longer exists at HEAD (`gh api repos/Azure/azure-cli/contents/src/azure-cli/azure/cli/command_modules/natgateway?ref=8d2615f9…` → 404; the module listing contains only `network`, where nat-gateway commands now live). The rule matches nothing, so it silently assigns no reviewers.

This PR removes the one dead line. No coverage is lost — the very next line already routes `command_modules/network/` to the same team.

For transparency: I used AI assistance to spot and draft this; I verified the 404 and the surviving `network/` rule myself.
