### PR TITLE
{backup} `az backup` Fix live testing using storage accounts and improve RG teardown

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/preparers.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/preparers.py
@@ -7,8 +7,11 @@ import json
 import os
 from datetime import datetime, timedelta
 
-from azure.cli.testsdk import CliTestError, ResourceGroupPreparer
+from azure.cli.testsdk import CliTestError
 from azure.cli.testsdk.preparers import AbstractPreparer, SingleValueReplacer, KeyVaultPreparer
+from azure.cli.testsdk.preparers import ResourceGroupPreparer as _CliResourceGroupPreparer
+from azure.cli.testsdk.preparers import StorageAccountPreparer as _CliStorageAccountPreparer
+from azure.cli.testsdk.utilities import StorageAccountKeyReplacer
 from azure.cli.testsdk.base import execute
 # pylint: disable=line-too-long
 
@@ -16,36 +19,96 @@ from knack.log import get_logger
 logger = get_logger(__name__)
 
 
-# Temporary Resource Group Preparer for testing while we update the RecoveryServices SDK to deal with new Soft Delete rules
-class RGPreparer(AbstractPreparer, SingleValueReplacer):
-    def __init__(self, name_prefix='clitest.rg',
-                 parameter_name='resource_group',
-                 parameter_name_for_location='resource_group_location', location='westus',
-                 dev_setting_name='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME',
-                 dev_setting_location='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION',
-                 random_name_length=75, key='rg', subscription=None, additional_tags=None):
-        if ' ' in name_prefix:
-            raise CliTestError('Error: Space character in resource group name prefix \'%s\'' % name_prefix)
-        super().__init__(name_prefix, random_name_length)
-        from azure.cli.core.mock import DummyCli
-        self.cli_ctx = DummyCli()
-        self.location = location
-        self.subscription = subscription
-        self.parameter_name = parameter_name
-        self.parameter_name_for_location = parameter_name_for_location
-        self.key = key
-        self.additional_tags = additional_tags
- 
-        self.dev_setting_name = os.environ.get(dev_setting_name, None)
-        self.dev_setting_location = os.environ.get(dev_setting_location, location)
+# Tags required by the "BCDR_StorageAccount_RequiredTags" Azure Policy (deny effect,
+# assigned at the management-group scope). A storage account that allows shared-key
+# access is rejected unless it carries all of these tags. AFS backup needs shared-key
+# / local auth enabled on the account, so DisableLocalAuth must be present and 'false'.
+BACKUP_SA_REQUIRED_TAGS = {
+    'DisableLocalAuth': 'false',
+    'Reason': 'CLITest',
+    'ETA': '12-2099',
+    'Owner': 'clitest',
+}
+
+
+class StorageAccountPreparer(_CliStorageAccountPreparer):
+    """Storage account preparer for backup tests.
+
+    Creates the account with the tags required by the BCDR storage-account tag
+    policy (a management-group deny policy rejects an account that allows
+    shared-key access unless it carries these tags) and with a supported account
+    kind (StorageV2 - the legacy GPv1 'Storage' kind is no longer allowed for new
+    accounts). Drop-in replacement for the testsdk preparer.
+    """
+    def __init__(self, *args, kind='StorageV2', tags=None, **kwargs):
+        super().__init__(*args, kind=kind, **kwargs)
+        self.tags = dict(BACKUP_SA_REQUIRED_TAGS) if tags is None else tags
 
     def create_resource(self, name, **kwargs):
-        cmd = 'az group create --location {} --name {}'.format(self.location, name)
-        execute(self.cli_ctx, cmd)
-        return {self.parameter_name: name, self.parameter_name_for_location: self.location}
- 
+        group = self._get_resource_group(**kwargs)
+        if not self.dev_setting_name:
+            template = 'az storage account create -n {} -g {} -l {} --sku {} --kind {} --https-only'
+            template += ' --allow-blob-public-access {}'.format('true' if self.allow_blob_public_access else 'false')
+            if self.allow_shared_key_access is not None:
+                template += ' --allow-shared-key-access {}'.format('true' if self.allow_shared_key_access else 'false')
+            if self.hns:
+                template += ' --hns'
+            command = template.format(name, group, self.location, self.sku, self.kind)
+            if self.tags:
+                command += ' --tags ' + ' '.join('{}={}'.format(k, v) for k, v in self.tags.items())
+            self.live_only_execute(self.cli_ctx, command)
+        else:
+            name = self.dev_setting_name
+        try:
+            account_key = self.live_only_execute(
+                self.cli_ctx,
+                'storage account keys list -n {} -g {} --query "[0].value" -otsv'.format(name, group)).output
+        except AttributeError:  # live_only_execute returns None when playing back a recording
+            account_key = None
+        self.test_class_instance.kwargs[self.key] = name
+        return {self.parameter_name: name,
+                self.parameter_name + '_info': (name, account_key or StorageAccountKeyReplacer.KEY_REPLACEMENT)}
+
+
+# The single custom resource group preparer for backup tests. Subclasses the CLI
+# ResourceGroupPreparer and makes teardown resilient to the CanNotDelete lock that
+# Azure Backup places on a protected AFS storage account: Backup releases the lock
+# asynchronously, so `az group delete` can race it and fail with ScopeLocked, so we
+# clear any locks in the group and retry the delete a bounded number of times.
+class ResourceGroupPreparer(_CliResourceGroupPreparer):
+    _MAX_DELETE_ATTEMPTS = 6
+    _DELETE_RETRY_WAIT = 15
+
     def remove_resource(self, name, **kwargs):
-        pass
+        if self.dev_setting_name:
+            return
+
+        import time
+        from azure.core.exceptions import HttpResponseError
+
+        sub = ' --subscription {}'.format(self.subscription) if self.subscription else ''
+        for attempt in range(self._MAX_DELETE_ATTEMPTS):
+            self._remove_locks(name, sub)
+            try:
+                self.live_only_execute(self.cli_ctx, 'az group delete --name {} --yes --no-wait{}'.format(name, sub))
+                return
+            except HttpResponseError as ex:
+                if 'ScopeLocked' not in str(ex) or attempt == self._MAX_DELETE_ATTEMPTS - 1:
+                    raise
+                time.sleep(self._DELETE_RETRY_WAIT)
+
+    def _remove_locks(self, name, sub):
+        from azure.core.exceptions import HttpResponseError
+        try:
+            result = self.live_only_execute(self.cli_ctx, 'az lock list -g {}{} -o json'.format(name, sub))
+            locks = result.get_output_in_json() if result else []
+        except (HttpResponseError, AttributeError):
+            return
+        for lock in locks or []:
+            try:
+                self.live_only_execute(self.cli_ctx, 'az lock delete --ids {}'.format(lock['id']))
+            except (HttpResponseError, AttributeError):
+                pass
 
 
 class VaultPreparer(AbstractPreparer, SingleValueReplacer):  # pylint: disable=too-many-instance-attributes

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_afs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_afs_commands.py
@@ -7,11 +7,11 @@ import json
 from datetime import datetime, timedelta
 import unittest
 import time
-from azure.cli.testsdk import ScenarioTest, JMESPathCheckExists, ResourceGroupPreparer, \
-    StorageAccountPreparer, record_only, live_only
+from azure.cli.testsdk import ScenarioTest, JMESPathCheckExists, \
+    record_only, live_only
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from .preparers import VaultPreparer, FileSharePreparer, AFSPolicyPreparer, AFSItemPreparer, \
-    AFSRPPreparer, FilePreparer, RGPreparer
+    AFSRPPreparer, FilePreparer, ResourceGroupPreparer, StorageAccountPreparer
 
 subscription_id = "da364f0f-307b-41c9-9d47-b7413ec45535"
 unprotected_afs = "clitestafs"

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
@@ -10,13 +10,13 @@ import unittest
 import time
 import random
 
-from azure.cli.testsdk import ScenarioTest, JMESPathCheckExists, ResourceGroupPreparer, \
+from azure.cli.testsdk import ScenarioTest, JMESPathCheckExists, \
     StorageAccountPreparer, KeyVaultPreparer, record_only, live_only
 from azure.mgmt.recoveryservicesbackup.activestamp.models import StorageType
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 from .preparers import VaultPreparer, VMPreparer, ItemPreparer, PolicyPreparer, RPPreparer, \
-    DESPreparer, KeyPreparer, RGPreparer
+    DESPreparer, KeyPreparer, ResourceGroupPreparer
 
 
 def _get_vm_version(vm_type):

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
@@ -11,12 +11,12 @@ import time
 import random
 
 from azure.cli.testsdk import ScenarioTest, JMESPathCheckExists, \
-    StorageAccountPreparer, KeyVaultPreparer, record_only, live_only
+    KeyVaultPreparer, record_only, live_only
 from azure.mgmt.recoveryservicesbackup.activestamp.models import StorageType
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 from .preparers import VaultPreparer, VMPreparer, ItemPreparer, PolicyPreparer, RPPreparer, \
-    DESPreparer, KeyPreparer, ResourceGroupPreparer
+    DESPreparer, KeyPreparer, ResourceGroupPreparer, StorageAccountPreparer
 
 
 def _get_vm_version(vm_type):
@@ -1696,12 +1696,12 @@ class BackupTests(ScenarioTest, unittest.TestCase):
         # associate vault with an already present resource guard
         self.cmd('backup vault resource-guard-mapping update -g {rg} -n {vault} --resource-guard-id {resource_graph}', checks=[
             self.check('name', 'VaultProxy'),
-            self.check('length(properties.resourceGuardOperationDetails)', 9)
+            self.check('length(properties.resourceGuardOperationDetails)', 14)
         ])
 
         self.cmd('backup vault resource-guard-mapping show -g {rg} -n {vault}', checks=[
             self.check('name', 'VaultProxy'),
-            self.check('length(properties.resourceGuardOperationDetails)', 9)
+            self.check('length(properties.resourceGuardOperationDetails)', 14)
         ])
 
         time.sleep(300)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ❌ 2 | ❌ 128/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Failed" summary="2" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>❌AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>❌appservice</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1012 - SubgroupRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1012.md) |webapp troubleshoot|sub group `webapp troubleshoot` removed|please confirm sub group `webapp troubleshoot` removed|
>
></details>
><details>
> <summary>❌cognitiveservices</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1012 - SubgroupRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1012.md) |cognitiveservices account compute|sub group `cognitiveservices account compute` removed|please confirm sub group `cognitiveservices account compute` removed|
>
></details>
</details>


**Please submit your Breaking Change Pre-announcement ASAP** if you haven't already. Please note:

- Breaking changes can **only** be merged during the designated breaking change window
- A pre-announcement **must** be released at least one month in advance

> For more details on how to introduce breaking changes, refer to the documentation: [azure-cli/doc/how_to_introduce_breaking_changes.md](https://github.com/Azure/azure-cli/blob/dev/doc/how_to_introduce_breaking_changes.md)
<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Failed" summary="128/130" -->
<details>
<summary>❌AzureCLI-FullTest</summary>

><details>
> <summary>️✔️acr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️acs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️advisor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️ams</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️apim</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appconfig</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️aro</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>❌backup</summary>
>
>><details>
>> <summary>❌latest</summary>
>>
>>><details>
>>> <summary>❌3.12</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_backup_rg_mapping|self&nbsp;=&nbsp;<azure.cli.command_modules.backup.tests.latest.test_backup_commands.BackupTests&nbsp;testMethod=test_backup_rg_mapping><br>resource_group&nbsp;=&nbsp;'AzureBackupRG_clitest_000001'<br>vault_name&nbsp;=&nbsp;'clitest-vault000002',&nbsp;vm1&nbsp;=&nbsp;'clitest-vm000003'<br>policy1&nbsp;=&nbsp;'clitest-item000005',&nbsp;policy2&nbsp;=&nbsp;'clitest-item000006'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(name_prefix="AzureBackupRG_clitest_",&nbsp;location="centraluseuap")<br>&nbsp;&nbsp;&nbsp;&nbsp;@VaultPreparer()<br>&nbsp;&nbsp;&nbsp;&nbsp;@VMPreparer(parameter_name='vm1')<br>&nbsp;&nbsp;&nbsp;&nbsp;@ItemPreparer(vm_parameter_name='vm1')<br>&nbsp;&nbsp;&nbsp;&nbsp;@PolicyPreparer(parameter_name='policy1',&nbsp;instant_rp_days='4')<br>&nbsp;&nbsp;&nbsp;&nbsp;@PolicyPreparer(parameter_name='policy2',&nbsp;instant_rp_days='2')<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_backup_rg_mapping(self,&nbsp;resource_group,&nbsp;vault_name,&nbsp;vm1,&nbsp;policy1,&nbsp;policy2):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'rg':&nbsp;resource_group,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'vault':&nbsp;vault_name,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'vm1':&nbsp;vm1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'policy1':&nbsp;policy1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'policy2':&nbsp;policy2,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'default':&nbsp;'DefaultPolicy',<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'resource_graph':&nbsp;'/subscriptions/38304e13-357e-405e-9e9a-220351dcce8c/resourceGroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;associate&nbsp;vault&nbsp;with&nbsp;an&nbsp;already&nbsp;present&nbsp;resource&nbsp;guard<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd('backup&nbsp;vault&nbsp;resource-guard-mapping&nbsp;update&nbsp;-g&nbsp;{rg}&nbsp;-n&nbsp;{vault}&nbsp;--resource-guard-id&nbsp;{resource_graph}',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.check('name',&nbsp;'VaultProxy'),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.check('length(properties.resourceGuardOperationDetails)',&nbsp;14)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br><br>src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py:1697:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:278:&nbsp;in&nbsp;assert_with_checks<br>&nbsp;&nbsp;&nbsp;&nbsp;c(self)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.checkers.JMESPathCheck&nbsp;object&nbsp;at&nbsp;0x7f322f9bed20><br>execution_result&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f322f9bf230><br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;__call__(self,&nbsp;execution_result):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;json_value&nbsp;=&nbsp;execution_result.get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;actual_result&nbsp;=&nbsp;None<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;actual_result&nbsp;=&nbsp;jmespath.search(self._query,&nbsp;json_value,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jmespath.Options(collections.OrderedDict))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;jmespath.exceptions.JMESPathTypeError:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;JMESPathCheckAssertionError(self._query,&nbsp;self._expected_result,&nbsp;actual_result,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;execution_result.output)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self._case_sensitive:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;equals&nbsp;=&nbsp;actual_result&nbsp;==&nbsp;self._expected_result&nbsp;or&nbsp;str(actual_result)&nbsp;==&nbsp;str(self._expected_result)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;equals&nbsp;=&nbsp;actual_result&nbsp;==&nbsp;self._expected_result&nbsp;\<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;or&nbsp;str(actual_result).lower()&nbsp;==&nbsp;str(self._expected_result).lower()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;not&nbsp;equals:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;actual_result:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;JMESPathCheckAssertionError(self._query,&nbsp;self._expected_result,&nbsp;actual_result,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;execution_result.output)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;azure.cli.testsdk.exceptions.JMESPathCheckAssertionError:&nbsp;Query&nbsp;'length(properties.resourceGuardOperationDetails)'&nbsp;doesn't&nbsp;yield&nbsp;expected&nbsp;value&nbsp;'14',&nbsp;instead&nbsp;the&nbsp;actual&nbsp;value&nbsp;is&nbsp;'9'.&nbsp;Data:&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"eTag":&nbsp;null,<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"id":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzureBackupRG_clitest_000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies/VaultProxy",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"location":&nbsp;null,<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"VaultProxy",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"properties":&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"description":&nbsp;"resource&nbsp;guard&nbsp;for&nbsp;CLI&nbsp;automated&nbsp;test",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"lastUpdatedTime":&nbsp;"2025-10-27T12:43:09.7627603Z",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"resourceGuardOperationDetails":&nbsp;[<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/deleteProtectedItemRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/delete"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/updateProtectedItemRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/write"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/updateProtectionPolicyRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupPolicies/write"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/deleteResourceGuardProxyRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/getBackupSecurityPINRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupSecurityPIN/action"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/disableSoftDeleteRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupconfig/write"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/stopProtectionWithRetainDataRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/write#stopProtectionWithRetainData"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/reduceImmutabilityStateRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/write#reduceImmutabilityState"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/deleteMABIdentityRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/registeredIdentities/delete"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"resourceGuardResourceId":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"resourceGroup":&nbsp;"AzureBackupRG_clitest_000001",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"tags":&nbsp;null,<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type":&nbsp;"Microsoft.RecoveryServices/vaults/backupResourceGuardProxies"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br><br>src/azure-cli-testsdk/azure/cli/testsdk/checkers.py:34:&nbsp;JMESPathCheckAssertionError|azure/cli/command_modules/backup/tests/latest/test_backup_commands.py:1679|
>>>
>>></details>
>>><details>
>>> <summary>❌3.14</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_backup_rg_mapping|self&nbsp;=&nbsp;<azure.cli.command_modules.backup.tests.latest.test_backup_commands.BackupTests&nbsp;testMethod=test_backup_rg_mapping><br>resource_group&nbsp;=&nbsp;'AzureBackupRG_clitest_000001'<br>vault_name&nbsp;=&nbsp;'clitest-vault000002',&nbsp;vm1&nbsp;=&nbsp;'clitest-vm000003'<br>policy1&nbsp;=&nbsp;'clitest-item000005',&nbsp;policy2&nbsp;=&nbsp;'clitest-item000006'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(name_prefix="AzureBackupRG_clitest_",&nbsp;location="centraluseuap")<br>&nbsp;&nbsp;&nbsp;&nbsp;@VaultPreparer()<br>&nbsp;&nbsp;&nbsp;&nbsp;@VMPreparer(parameter_name='vm1')<br>&nbsp;&nbsp;&nbsp;&nbsp;@ItemPreparer(vm_parameter_name='vm1')<br>&nbsp;&nbsp;&nbsp;&nbsp;@PolicyPreparer(parameter_name='policy1',&nbsp;instant_rp_days='4')<br>&nbsp;&nbsp;&nbsp;&nbsp;@PolicyPreparer(parameter_name='policy2',&nbsp;instant_rp_days='2')<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_backup_rg_mapping(self,&nbsp;resource_group,&nbsp;vault_name,&nbsp;vm1,&nbsp;policy1,&nbsp;policy2):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'rg':&nbsp;resource_group,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'vault':&nbsp;vault_name,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'vm1':&nbsp;vm1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'policy1':&nbsp;policy1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'policy2':&nbsp;policy2,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'default':&nbsp;'DefaultPolicy',<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'resource_graph':&nbsp;'/subscriptions/38304e13-357e-405e-9e9a-220351dcce8c/resourceGroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;associate&nbsp;vault&nbsp;with&nbsp;an&nbsp;already&nbsp;present&nbsp;resource&nbsp;guard<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd('backup&nbsp;vault&nbsp;resource-guard-mapping&nbsp;update&nbsp;-g&nbsp;{rg}&nbsp;-n&nbsp;{vault}&nbsp;--resource-guard-id&nbsp;{resource_graph}',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.check('name',&nbsp;'VaultProxy'),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.check('length(properties.resourceGuardOperationDetails)',&nbsp;14)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br><br>src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py:1697:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:278:&nbsp;in&nbsp;assert_with_checks<br>&nbsp;&nbsp;&nbsp;&nbsp;c(self)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.checkers.JMESPathCheck&nbsp;object&nbsp;at&nbsp;0x7f952ab82490><br>execution_result&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f952abc79b0><br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;__call__(self,&nbsp;execution_result):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;json_value&nbsp;=&nbsp;execution_result.get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;actual_result&nbsp;=&nbsp;None<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;actual_result&nbsp;=&nbsp;jmespath.search(self._query,&nbsp;json_value,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jmespath.Options(collections.OrderedDict))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;jmespath.exceptions.JMESPathTypeError:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;JMESPathCheckAssertionError(self._query,&nbsp;self._expected_result,&nbsp;actual_result,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;execution_result.output)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self._case_sensitive:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;equals&nbsp;=&nbsp;actual_result&nbsp;==&nbsp;self._expected_result&nbsp;or&nbsp;str(actual_result)&nbsp;==&nbsp;str(self._expected_result)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;equals&nbsp;=&nbsp;actual_result&nbsp;==&nbsp;self._expected_result&nbsp;\<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;or&nbsp;str(actual_result).lower()&nbsp;==&nbsp;str(self._expected_result).lower()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;not&nbsp;equals:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;actual_result:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;JMESPathCheckAssertionError(self._query,&nbsp;self._expected_result,&nbsp;actual_result,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;execution_result.output)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;azure.cli.testsdk.exceptions.JMESPathCheckAssertionError:&nbsp;Query&nbsp;'length(properties.resourceGuardOperationDetails)'&nbsp;doesn't&nbsp;yield&nbsp;expected&nbsp;value&nbsp;'14',&nbsp;instead&nbsp;the&nbsp;actual&nbsp;value&nbsp;is&nbsp;'9'.&nbsp;Data:&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"eTag":&nbsp;null,<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"id":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzureBackupRG_clitest_000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies/VaultProxy",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"location":&nbsp;null,<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"VaultProxy",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"properties":&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"description":&nbsp;"resource&nbsp;guard&nbsp;for&nbsp;CLI&nbsp;automated&nbsp;test",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"lastUpdatedTime":&nbsp;"2025-10-27T12:43:09.7627603Z",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"resourceGuardOperationDetails":&nbsp;[<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/deleteProtectedItemRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/delete"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/updateProtectedItemRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/write"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/updateProtectionPolicyRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupPolicies/write"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/deleteResourceGuardProxyRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/getBackupSecurityPINRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupSecurityPIN/action"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/disableSoftDeleteRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupconfig/write"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/stopProtectionWithRetainDataRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/write#stopProtectionWithRetainData"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/reduceImmutabilityStateRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/write#reduceImmutabilityState"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"defaultResourceRequest":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard/deleteMABIdentityRequests/default",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"vaultCriticalOperation":&nbsp;"Microsoft.RecoveryServices/vaults/registeredIdentities/delete"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"resourceGuardResourceId":&nbsp;"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-rg/providers/Microsoft.DataProtection/resourceGuards/clitest-resource-guard"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"resourceGroup":&nbsp;"AzureBackupRG_clitest_000001",<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"tags":&nbsp;null,<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type":&nbsp;"Microsoft.RecoveryServices/vaults/backupResourceGuardProxies"<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br><br>src/azure-cli-testsdk/azure/cli/testsdk/checkers.py:34:&nbsp;JMESPathCheckAssertionError|azure/cli/command_modules/backup/tests/latest/test_backup_commands.py:1679|
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batch</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batchai</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️billing</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️botservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cloud</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cognitiveservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️compute_recommender</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️computefleet</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️config</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️configure</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️consumption</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️container</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️containerapp</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️core</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cosmosdb</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️databoxedge</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dls</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventgrid</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventhubs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️feedback</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️find</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️hdinsight</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️identity</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️iot</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️keyvault</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️lab</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️managedservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️maps</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️marketplaceordering</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️monitor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️mysql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️netappfiles</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️network</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️policyinsights</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️postgresql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️privatedns</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️profile</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️rdbms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️redis</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️relay</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️resource</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️role</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️search</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️security</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicebus</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️serviceconnector</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicefabric</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️signalr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sqlvm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️storage</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️synapse</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️telemetry</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️util</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️vm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->