### PR TITLE
[ACR] `az acr import`: Fix regional endpoint source resolution for multi-label sovereign suffixes

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -124,10 +124,17 @@ def _regional_endpoint_uri_to_login_server(uri, login_server_suffix):
 
     uri_lower = uri.strip().lower()
     suffix_lower = login_server_suffix.lower()
-    parts = uri_lower.split('.')
 
-    if len(parts) == 5 and parts[2] == 'geo' and uri_lower.endswith(suffix_lower):
-        return f"{parts[0]}{login_server_suffix}"
+    # A regional endpoint looks like "<registry>.<region>.geo<suffix>". The suffix itself may
+    # contain more than one label (e.g. ".azurecr.io" in public clouds vs
+    # ".azurecr.sovcloud-azure.de" in sovereign clouds), so we strip the ".geo<suffix>" tail
+    # rather than assuming a fixed number of dot-separated parts.
+    geo_suffix = f".geo{suffix_lower}"
+    if uri_lower.endswith(geo_suffix):
+        prefix = uri_lower[:-len(geo_suffix)]  # "<registry>.<region>"
+        prefix_parts = prefix.split('.')
+        if len(prefix_parts) == 2 and prefix_parts[0]:
+            return f"{prefix_parts[0]}{login_server_suffix}"
 
     # If not a regional endpoint format, return as-is
     return uri

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -125,15 +125,15 @@ def _regional_endpoint_uri_to_login_server(uri, login_server_suffix):
     uri_lower = uri.strip().lower()
     suffix_lower = login_server_suffix.lower()
 
-    # A regional endpoint looks like "<registry>.<region>.geo<suffix>". The suffix itself may
-    # contain more than one label (e.g. ".azurecr.io" in public clouds vs
+    # A regional endpoint looks like "<registry>.<region>.geo<suffix>". The suffix may contain
+    # more than two labels (e.g. ".azurecr.io" in public clouds vs the longer
     # ".azurecr.sovcloud-azure.de" in sovereign clouds), so we strip the ".geo<suffix>" tail
     # rather than assuming a fixed number of dot-separated parts.
     geo_suffix = f".geo{suffix_lower}"
     if uri_lower.endswith(geo_suffix):
         prefix = uri_lower[:-len(geo_suffix)]  # "<registry>.<region>"
         prefix_parts = prefix.split('.')
-        if len(prefix_parts) == 2 and prefix_parts[0]:
+        if len(prefix_parts) == 2 and prefix_parts[0] and prefix_parts[1]:
             return f"{prefix_parts[0]}{login_server_suffix}"
 
     # If not a regional endpoint format, return as-is

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_regional_endpoint_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_regional_endpoint_utils.py
@@ -31,8 +31,8 @@ class TestRegionalEndpointUriConversion(unittest.TestCase):
             self.assertEqual(result, expected)
 
     def test_valid_regional_endpoint_conversion_multi_label_suffix(self):
-        """Regional endpoints in sovereign clouds whose login-server suffix has more than one
-        label (e.g. '.azurecr.sovcloud-azure.de') must still be converted. """
+        """Regional endpoints in sovereign clouds whose login-server suffix has more than two
+        labels (e.g. '.azurecr.sovcloud-azure.de') must still be converted."""
         test_cases = [
             ('registry123.deloscloudgermanycentral.geo.azurecr.sovcloud-azure.de',
              '.azurecr.sovcloud-azure.de', 'registry123.azurecr.sovcloud-azure.de'),
@@ -56,6 +56,8 @@ class TestRegionalEndpointUriConversion(unittest.TestCase):
             'testregistry.azurecr.io',
             'external-registry.com',
             'testregistry.eastus.notgeo.azurecr.io',
+            # Malformed: empty region label must NOT be converted
+            'testregistry..geo.azurecr.io',
             'testregistry.azurecr.sovcloud-azure.de',
             'testregistry.deloscloudgermanycentral.notgeo.azurecr.sovcloud-azure.de'
         ]

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_regional_endpoint_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_regional_endpoint_utils.py
@@ -30,6 +30,22 @@ class TestRegionalEndpointUriConversion(unittest.TestCase):
             result = acr_import._regional_endpoint_uri_to_login_server(regional_uri, login_server_suffix)
             self.assertEqual(result, expected)
 
+    def test_valid_regional_endpoint_conversion_multi_label_suffix(self):
+        """Regional endpoints in sovereign clouds whose login-server suffix has more than one
+        label (e.g. '.azurecr.sovcloud-azure.de') must still be converted. """
+        test_cases = [
+            ('registry123.deloscloudgermanycentral.geo.azurecr.sovcloud-azure.de',
+             '.azurecr.sovcloud-azure.de', 'registry123.azurecr.sovcloud-azure.de'),
+            ('myregistry.francecentral.geo.azurecr.sovcloud-azure.fr',
+             '.azurecr.sovcloud-azure.fr', 'myregistry.azurecr.sovcloud-azure.fr'),
+            # DNL registry (hash suffix) in a multi-label sovereign cloud
+            ('myregistry-d7ezgzevdwfvc8ht.deloscloudgermanycentral.geo.azurecr.sovcloud-azure.de',
+             '.azurecr.sovcloud-azure.de', 'myregistry-d7ezgzevdwfvc8ht.azurecr.sovcloud-azure.de'),
+        ]
+
+        for regional_uri, suffix, expected in test_cases:
+            result = acr_import._regional_endpoint_uri_to_login_server(regional_uri, suffix)
+            self.assertEqual(result, expected)
 
     def test_non_regional_endpoint_uris_unchanged(self):
         """Test that non-regional endpoint URIs are returned unchanged."""
@@ -40,6 +56,8 @@ class TestRegionalEndpointUriConversion(unittest.TestCase):
             'testregistry.azurecr.io',
             'external-registry.com',
             'testregistry.eastus.notgeo.azurecr.io',
+            'testregistry.azurecr.sovcloud-azure.de',
+            'testregistry.deloscloudgermanycentral.notgeo.azurecr.sovcloud-azure.de'
         ]
 
         for uri in test_cases:


### PR DESCRIPTION
**Related command**
`az acr import`

**Description**
`az acr import` resolves the `--source` registry to a login server in the CLI **before** the request reaches the RP. When the source is a **regional endpoint** (`<registry>.<region>.geo<suffix>`), `_regional_endpoint_uri_to_login_server` normalizes it back to the global login server so import can use the fast resource-id (blob copy) path.

The old implementation assumed a fixed 5-part hostname:

```python
parts = uri_lower.split('.')
if len(parts) == 5 and parts[2] == 'geo' and uri_lower.endswith(suffix_lower):
    return f"{parts[0]}{login_server_suffix}"
```

This only holds when the login-server suffix is exactly two labels (`azurecr.io`). Sovereign clouds use multi-label suffixes — e.g. delos `azurecr.sovcloud-azure.de`, bleu `azurecr.sovcloud-azure.fr` — so a regional endpoint like `myregistry.germanycentral.geo.azurecr.sovcloud-azure.de` has **6** parts, the check fails, and the URI is returned unchanged. Import then falls back to a `registryUri` source, which the RP pulls **anonymously over HTTP across the source registry's firewall**, failing with:

```
StatusCode: 403, Reason: Forbidden ... "code":"DENIED","message":"client with IP '...' is not allowed access"
```

This PR strip the known `.geo<suffix>` tail and take the remaining `<registry>.<region>` (require exactly 2 prefix parts). This is suffix-length-agnostic, so it works for public **and** sovereign clouds while leaving global/non-regional login servers unchanged.

**Testing Guide**
Added unit cases in `test_regional_endpoint_utils.py` covering sovereign suffixes (delos `.de`, bleu `.fr`), DNL registries, and global/non-geo pass-through.

**History Notes**
 [ACR] `az acr import`: Fix regional endpoint source resolution for sovereign clouds with multi-label login-server suffixes

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).


<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->