### PR TITLE
fix: catch all requests exceptions in get_index to prevent unhandled NameResolutionError (closes #33691)

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/_index.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_index.py
@@ -49,7 +49,7 @@ def get_index(index_url=None, cli_ctx=None):
                 return response.json()
             msg = ERR_TMPL_NON_200.format(response.status_code, index_url)
             raise CLIError(msg)
-        except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError, ValueError) as err:
+        except (requests.exceptions.RequestException, ValueError) as err:
             if try_number == TRIES - 1:
                 # ValueError indicates that shortlink url is not redirecting properly to intended index url
                 msg = ERR_TMPL_BAD_JSON.format(str(err)) if isinstance(err, ValueError) else \


### PR DESCRIPTION
## What
The `az find` command crashes with an unhandled `NameResolutionError` when DNS resolution fails for the extension index endpoint (e.g., `app.aladdin.microsoft.com` returns NXDOMAIN). The exception is not caught by the existing except clause, causing a Python traceback instead of a user-friendly error.

## Fix
Replace `(requests.exceptions.ConnectionError, requests.exceptions.HTTPError, ValueError)` with `(requests.exceptions.RequestException, ValueError)` in the `get_index()` function. `RequestException` is the base class for all exceptions raised by the `requests` library, including DNS resolution failures, connection errors, timeouts, and HTTP errors. This ensures any network-related error is caught and converted to a `CLIError` with a clear message.

Closes #33691