### PR TITLE
{Packaging} harden launcher against cwd module loading

### DIFF
--- a/src/azure-cli/az
+++ b/src/azure-cli/az
@@ -4,20 +4,22 @@ import runpy
 import sys
 import os
 
-dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'src')
+launcher_dir = os.path.dirname(os.path.realpath(__file__))
+launcher_src_dir = os.path.join(launcher_dir, 'src')
+module_search_path = launcher_src_dir if os.path.isdir(launcher_src_dir) else launcher_dir
 
 if os.environ.get('PYTHONPATH') is None:
-    os.environ['PYTHONPATH'] = dir
+    os.environ['PYTHONPATH'] = module_search_path
 else:
     os.environ['PYTHONPATH'] = os.pathsep.join([
-        dir,
+        module_search_path,
         os.environ.get('PYTHONPATH'),
     ])
 
 if os.environ.get('AZ_INSTALLER') is None:
     os.environ['AZ_INSTALLER'] = 'PIP'
 
-if dir not in sys.path:
-    sys.path.insert(0, dir)
+if module_search_path not in sys.path:
+    sys.path.insert(0, module_search_path)
 
-runpy.run_module('azure.cli', run_name='__main__', alter_sys=True)
+runpy.run_module('azure.cli.__main__', run_name='__main__', alter_sys=True)

--- a/src/azure-cli/az
+++ b/src/azure-cli/az
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import runpy
 import sys
 import os
 
@@ -16,4 +17,7 @@ else:
 if os.environ.get('AZ_INSTALLER') is None:
     os.environ['AZ_INSTALLER'] = 'PIP'
 
-os.execl(sys.executable, sys.executable, '-m', 'azure.cli', *sys.argv[1:])
+if dir not in sys.path:
+    sys.path.insert(0, dir)
+
+runpy.run_module('azure.cli', run_name='__main__', alter_sys=True)


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ❌ 2 | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Failed" summary="2" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>❌AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>❌acs</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |aks create|cmd `aks create` removed parameter `enable_upstream_kubescheduler_user_configuration`|please add back parameter `enable_upstream_kubescheduler_user_configuration` for cmd `aks create`|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |aks update|cmd `aks update` removed parameter `disable_upstream_kubescheduler_user_configuration`|please add back parameter `disable_upstream_kubescheduler_user_configuration` for cmd `aks update`|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |aks update|cmd `aks update` removed parameter `enable_upstream_kubescheduler_user_configuration`|please add back parameter `enable_upstream_kubescheduler_user_configuration` for cmd `aks update`|
>
></details>
><details>
> <summary>❌vm</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |capacity reservation group create|cmd `capacity reservation group create` removed parameter `reservation_type`|please add back parameter `reservation_type` for cmd `capacity reservation group create`|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |capacity reservation group update|cmd `capacity reservation group update` removed parameter `reservation_type`|please add back parameter `reservation_type` for cmd `capacity reservation group update`|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |vm create|cmd `vm create` removed parameter `disable_capacity_reservation_assignment`|please add back parameter `disable_capacity_reservation_assignment` for cmd `vm create`|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |vm update|cmd `vm update` removed parameter `disable_capacity_reservation_assignment`|please add back parameter `disable_capacity_reservation_assignment` for cmd `vm update`|
>
></details>
</details>


**Please submit your Breaking Change Pre-announcement ASAP** if you haven't already. Please note:

- Breaking changes can **only** be merged during the designated breaking change window
- A pre-announcement **must** be released at least one month in advance

> For more details on how to introduce breaking changes, refer to the documentation: [azure-cli/doc/how_to_introduce_breaking_changes.md](https://github.com/Azure/azure-cli/blob/dev/doc/how_to_introduce_breaking_changes.md)
<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

`python -m` adds the current working directory to the start of `sys.path`, so running `az` from an untrusted directory can load a local `azure.py` before the real package.

This change hardens the launcher in `src/azure-cli/az` to avoid that cwd import path.

## Changes

- Replaced `os.execl(sys.executable, sys.executable, '-m', 'azure.cli', *sys.argv[1:])` with `runpy.run_module(...)`.
- Explicitly prepended the launcher `src` directory to `sys.path` before module execution to preserve local launcher import behavior.
- Used `run_name='__main__'` and `alter_sys=True` for closer `-m` semantics while avoiding `-m` cwd import behavior.

## Security context

This addresses the cwd import vector described in Debian bug #1005251 while keeping launcher behavior stable.

## Related

- Original PR: https://github.com/Azure/azure-cli/pull/21261