### PR TITLE
{KeyVault} Upgrade azure-keyvault-administration to 4.8.0b2

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -12,7 +12,7 @@ azure-core==1.39.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
-azure-keyvault-administration==4.8.0b1
+azure-keyvault-administration==4.8.0b2
 azure-keyvault-certificates==4.7.0
 azure-keyvault-keys==4.12.0b2
 azure-keyvault-secrets==4.7.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -12,7 +12,7 @@ azure-core==1.39.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
-azure-keyvault-administration==4.8.0b1
+azure-keyvault-administration==4.8.0b2
 azure-keyvault-certificates==4.7.0
 azure-keyvault-keys==4.12.0b2
 azure-keyvault-secrets==4.7.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -12,7 +12,7 @@ azure-core==1.39.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
-azure-keyvault-administration==4.8.0b1
+azure-keyvault-administration==4.8.0b2
 azure-keyvault-certificates==4.7.0
 azure-keyvault-keys==4.12.0b2
 azure-keyvault-secrets==4.7.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -59,7 +59,7 @@ DEPENDENCIES = [
     'azure-cosmos~=3.0,>=3.0.2',
     'azure-data-tables==12.4.0',
     'azure-datalake-store~=1.0.1',
-    'azure-keyvault-administration==4.8.0b1',
+    'azure-keyvault-administration==4.8.0b2',
     'azure-keyvault-certificates==4.7.0',
     'azure-keyvault-keys==4.12.0b2',
     'azure-keyvault-secrets==4.7.0',


### PR DESCRIPTION
*Related command**
`az keyvault backup start`, `az keyvault backup restore` (Azure Managed HSM)

**Description**
Fixes [ICM 757505017]
`az keyvault backup start --use-managed-identity true` against Azure Managed HSM fails
with `409 Conflict: Another backup operation is in progress`, even though the backup
was accepted by the service.

Root cause is a client-side replay bug in `azure-keyvault-administration`'s
`ChallengeAuthPolicy`

The SDK fix ([Azure/azure-sdk-for-python#47742](https://github.com/Azure/azure-sdk-for-python/pull/47742))
moves the request copy to per-request pipeline context so it can't leak into subsequent
requests on the same client. It shipped in `azure-keyvault-administration 4.8.0b2` on
2026-07-08. This PR picks up that fix.

Affected CLI versions: 2.77.0 – 2.88.0 (2.77–2.87 pinned `4.4.0`, 2.88 pinned `4.8.0b1`;
both contain the bug).

**Testing Guide**
Manual verification against Managed HSM with managed identity:

```bash
# Prereqs: an MHSM, a storage account, a user-assigned managed identity with
# 'Managed HSM Crypto Officer' role on the MHSM and 'Storage Blob Data Contributor'
# on the storage account.

az keyvault backup start \
  --hsm-name <mhsm-name> \
  --blob-container-name <container> \
  --storage-account-name <storage-account> \
  --use-managed-identity true