### PR TITLE
[AKS] `az aks nodepool update`, `az aks nodepool auto-scale`, `--enable-cluster-autoscaler`: Add CAS support for VMS agent pools

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -2422,7 +2422,7 @@ examples:
 
 helps["aks nodepool manual-scale"] = """
     type: group
-    short-summary: Commands to manage nodepool virtualMachineProfile.scale.manual.
+    short-summary: Commands to manage nodepool virtualMachinesProfile.scale.manual.
 """
 
 helps["aks nodepool manual-scale add"] = """
@@ -2463,7 +2463,7 @@ helps["aks nodepool manual-scale delete"] = """
 
 helps["aks nodepool auto-scale"] = """
     type: group
-    short-summary: Commands to manage nodepool virtualMachineProfile.scale.autoscale.
+    short-summary: Commands to manage nodepool virtualMachinesProfile.scale.autoscale.
 """
 
 helps["aks nodepool auto-scale add"] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -775,13 +775,13 @@ short-summary: Update a managed Kubernetes cluster. When called with no optional
 parameters:
   - name: --enable-cluster-autoscaler -e
     type: bool
-    short-summary: Enable cluster autoscaler.
+    short-summary: Enable cluster autoscaler. For VirtualMachines pools, converts all manual scale profiles to autoscale profiles using the same min/max counts.
   - name: --disable-cluster-autoscaler -d
     type: bool
-    short-summary: Disable cluster autoscaler.
+    short-summary: Disable cluster autoscaler. For VirtualMachines pools, converts all autoscale profiles back to manual scale profiles.
   - name: --update-cluster-autoscaler -u
     type: bool
-    short-summary: Update min-count or max-count for cluster autoscaler.
+    short-summary: Update min-count or max-count for cluster autoscaler. Not supported for VirtualMachines pools; use 'az aks nodepool auto-scale update' instead.
   - name: --min-count
     type: int
     short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [1, 1000]
@@ -2182,13 +2182,13 @@ long-summary: Update a node pool to enable/disable cluster-autoscaler or change 
 parameters:
   - name: --enable-cluster-autoscaler -e
     type: bool
-    short-summary: Enable cluster autoscaler.
+    short-summary: Enable cluster autoscaler. For VirtualMachines pools, converts all manual scale profiles to autoscale profiles using the same min/max counts.
   - name: --disable-cluster-autoscaler -d
     type: bool
-    short-summary: Disable cluster autoscaler.
+    short-summary: Disable cluster autoscaler. For VirtualMachines pools, converts all autoscale profiles back to manual scale profiles.
   - name: --update-cluster-autoscaler -u
     type: bool
-    short-summary: Update min-count or max-count for cluster autoscaler.
+    short-summary: Update min-count or max-count for cluster autoscaler. Not supported for VirtualMachines pools; use 'az aks nodepool auto-scale update' instead.
   - name: --min-count
     type: int
     short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000] for user nodepool, and [1,1000] for system nodepool.
@@ -2459,6 +2459,62 @@ helps["aks nodepool manual-scale delete"] = """
         - name: --current-vm-sizes
           type: string
           short-summary: Comma-separated list of sizes in the manual to be deleted.
+"""
+
+helps["aks nodepool auto-scale"] = """
+    type: group
+    short-summary: Commands to manage nodepool virtualMachineProfile.scale.autoscale.
+"""
+
+helps["aks nodepool auto-scale add"] = """
+    type: command
+    short-summary: Add a new autoscale profile to a VirtualMachines agentpool in the managed Kubernetes cluster.
+    parameters:
+        - name: --node-vm-size
+          type: string
+          short-summary: VM size for the autoscale profile.
+        - name: --min-count
+          type: int
+          short-summary: Minimum number of nodes for autoscaling.
+        - name: --max-count
+          type: int
+          short-summary: Maximum number of nodes for autoscaling.
+    examples:
+        - name: Add an autoscale profile to a VirtualMachines agentpool
+          text: az aks nodepool auto-scale add -g MyResourceGroup --cluster-name MyMC --name MyNodePool --node-vm-size Standard_D2s_v3 --min-count 3 --max-count 5
+"""
+
+helps["aks nodepool auto-scale update"] = """
+    type: command
+    short-summary: Update an existing autoscale profile of a VirtualMachines agentpool in the managed Kubernetes cluster.
+    parameters:
+        - name: --current-node-vm-size
+          type: string
+          short-summary: The current VM size of the autoscale profile to be updated.
+        - name: --node-vm-size
+          type: string
+          short-summary: The new VM size for the autoscale profile.
+        - name: --min-count
+          type: int
+          short-summary: Minimum number of nodes for autoscaling.
+        - name: --max-count
+          type: int
+          short-summary: Maximum number of nodes for autoscaling.
+    examples:
+        - name: Update an existing autoscale profile in a VirtualMachines agentpool
+          text: az aks nodepool auto-scale update -g MyResourceGroup --cluster-name MyMC --name MyNodePool --current-node-vm-size Standard_D2s_v3 --node-vm-size Standard_D8s_v3 --min-count 2 --max-count 4
+"""
+
+helps["aks nodepool auto-scale delete"] = """
+    type: command
+    short-summary: Delete an existing autoscale profile from a VirtualMachines agentpool in the managed Kubernetes cluster.
+    parameters:
+        - name: --current-node-vm-size
+          type: string
+          short-summary: The VM size of the autoscale profile to be deleted.
+    examples:
+        - name: Delete an autoscale profile from a VirtualMachines agentpool
+          text: az aks nodepool auto-scale delete -g MyResourceGroup --cluster-name MyMC --name MyNodePool --current-node-vm-size Standard_D2s_v3
 """
 
 helps["aks show"] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -1231,6 +1231,20 @@ def load_arguments(self, _):
     with self.argument_context("aks nodepool manual-scale delete") as c:
         c.argument("current_vm_sizes")
 
+    with self.argument_context("aks nodepool auto-scale add") as c:
+        c.argument("node_vm_size")
+        c.argument("min_count", type=int)
+        c.argument("max_count", type=int)
+
+    with self.argument_context("aks nodepool auto-scale update") as c:
+        c.argument("current_node_vm_size")
+        c.argument("node_vm_size")
+        c.argument("min_count", type=int)
+        c.argument("max_count", type=int)
+
+    with self.argument_context("aks nodepool auto-scale delete") as c:
+        c.argument("current_node_vm_size")
+
     with self.argument_context('aks command invoke') as c:
         c.argument('command_string', options_list=[
                    "--command", "-c"], help='the command to run')

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -1106,15 +1106,17 @@ class AKSAgentPoolContext(BaseAKSContext):
             decorator_mode=DecoratorMode.UPDATE,
         )
 
-        autoscale_profile = None
-        manual_scale_profile = None
-        if (
-            self.agentpool and
+        autoscale_profile = (
             self.agentpool.virtual_machines_profile and
-            self.agentpool.virtual_machines_profile.scale
-        ):
-            autoscale_profile = self.agentpool.virtual_machines_profile.scale.autoscale
-            manual_scale_profile = self.agentpool.virtual_machines_profile.scale.manual
+            self.agentpool.virtual_machines_profile.scale and
+            self.agentpool.virtual_machines_profile.scale.autoscale
+        )
+
+        manual_scale_profile = (
+            self.agentpool.virtual_machines_profile and
+            self.agentpool.virtual_machines_profile.scale and
+            self.agentpool.virtual_machines_profile.scale.manual
+        )
 
         # if enabling cluster autoscaler
         if enable_cluster_autoscaler:

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -909,6 +909,42 @@ class AKSAgentPoolContext(BaseAKSContext):
         )
         return node_count, enable_cluster_autoscaler, min_count, max_count
 
+    def get_node_count_and_enable_cluster_autoscaler_min_max_count_vms(
+        self,
+    ) -> Tuple[int, bool, Union[int, None], Union[int, None]]:
+        """Obtain the value of node_count, enable_cluster_autoscaler, min_count and max_count.
+
+        This function will verify the parameters through function "__validate_counts_in_autoscaler" by default.
+
+        This function is for Virtual Machines nodepool only.
+
+        :return: a tuple containing four elements: node_count of int type, enable_cluster_autoscaler of bool type,
+        min_count of int type or None and max_count of int type or None
+        """
+        # node_count
+        # read the original value passed by the command
+        node_count = self.raw_param.get("node_count")
+        # enable_cluster_autoscaler
+        # read the original value passed by the command
+        enable_cluster_autoscaler = self.raw_param.get("enable_cluster_autoscaler", False)
+        # min_count
+        # read the original value passed by the command
+        min_count = self.raw_param.get("min_count")
+        # max_count
+        # read the original value passed by the command
+        max_count = self.raw_param.get("max_count")
+
+        # validation
+        self.__validate_counts_in_autoscaler(
+            node_count,
+            enable_cluster_autoscaler,
+            min_count,
+            max_count,
+            mode=self.get_mode(),
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        return node_count, enable_cluster_autoscaler, min_count, max_count
+
     def get_update_enable_disable_cluster_autoscaler_and_min_max_count(
         self,
     ) -> Tuple[bool, bool, bool, Union[int, None], Union[int, None]]:
@@ -997,21 +1033,20 @@ class AKSAgentPoolContext(BaseAKSContext):
 
         return update_cluster_autoscaler, enable_cluster_autoscaler, disable_cluster_autoscaler, min_count, max_count
 
-    def get_node_count_from_vms_agentpool(self, agentpool: AgentPool) -> int:
-        """Get the total node count of a VirtualMachines agent pool by summing counts across all manual scale profiles.
+    def get_node_count_from_vms_agentpool(self, agentpool: AgentPool) -> Union[int, None]:
+        """Get current node count for vms agentpool.
 
-        :return: int
+        :return: the node count of the vms agentpool
         """
-        node_count = 0
-        if (
-            agentpool.virtual_machines_profile and
-            agentpool.virtual_machines_profile.scale and
-            agentpool.virtual_machines_profile.scale.manual
-        ):
-            for m in agentpool.virtual_machines_profile.scale.manual:
-                if m.count is not None:
-                    node_count += m.count
-        return node_count
+        count = 0
+        if agentpool.virtual_machine_nodes_status:
+            for node_status in agentpool.virtual_machine_nodes_status:
+                if node_status.count is not None:
+                    count += node_status.count
+        if count == 0:
+            # If no node status is available, return None
+            return None
+        return count
 
     def get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms(
         self,
@@ -1040,6 +1075,15 @@ class AKSAgentPoolContext(BaseAKSContext):
         min_count = self.raw_param.get("min_count")
         max_count = self.raw_param.get("max_count")
         vm_size = self.raw_param.get("node_vm_size")
+
+        # validation
+        if self.agentpool_decorator_mode == AgentPoolDecoratorMode.MANAGED_CLUSTER:
+            # For multi-agent pool, use the az aks nodepool command
+            if (enable_cluster_autoscaler or update_cluster_autoscaler) and len(self._agentpools) > 1:
+                raise ArgumentUsageError(
+                    'There are more than one node pool in the cluster. Please use "az aks nodepool" command '
+                    "to update per node pool auto scaler settings"
+                )
 
         if enable_cluster_autoscaler + update_cluster_autoscaler + disable_cluster_autoscaler > 1:
             raise MutuallyExclusiveArgumentError(
@@ -1089,9 +1133,13 @@ class AKSAgentPoolContext(BaseAKSContext):
             )
             raise DecoratorEarlyExitException()
 
-        # default vm_size for backward compatibility when no manual/autoscale profile exists
-        if vm_size is None and manual_scale_profile:
-            vm_size = manual_scale_profile[0].size
+        # if vm_size is not specified, use the size from the existing agentpool profile
+        if vm_size is None:
+            if autoscale_profile:
+                vm_size = autoscale_profile[0].size
+
+            if manual_scale_profile:
+                vm_size = manual_scale_profile[0].size
 
         return (
             enable_cluster_autoscaler,
@@ -2380,11 +2428,11 @@ class AKSAgentPoolAddDecorator:
             return agentpool
 
         (
-            count,
+            node_count,
             enable_auto_scaling,
             min_count,
             max_count,
-        ) = self.context.get_node_count_and_enable_cluster_autoscaler_min_max_count()
+        ) = self.context.get_node_count_and_enable_cluster_autoscaler_min_max_count_vms()
 
         if enable_auto_scaling:
             agentpool.virtual_machines_profile = self.models.VirtualMachinesProfile(
@@ -2404,15 +2452,14 @@ class AKSAgentPoolAddDecorator:
                     manual=[
                         self.models.ManualScaleProfile(
                             size=sizes[0],
-                            count=count,
+                            count=node_count,
                         )
                     ]
                 )
             )
 
-        # EnableAutoScaling, MinCount and MaxCount are VMSS-specific properties and must not
-        # be set for VirtualMachines agent pools; the autoscale intent is expressed through
-        # virtualMachinesProfile.scale.autoscale instead.
+        # properties that doesn't need to be set for virtual machines agentpool
+        # they are for vmss only
         agentpool.vm_size = None
         agentpool.count = None
         agentpool.enable_auto_scaling = False
@@ -2632,8 +2679,9 @@ class AKSAgentPoolUpdateDecorator:
         """
         self._ensure_agentpool(agentpool)
 
-        if agentpool.type_properties_type == CONST_VIRTUAL_MACHINES:
-            return self.update_auto_scaler_properties_vms(agentpool)
+        # skip it for virtual machines pool
+        if self.context.get_vm_set_type() == CONST_VIRTUAL_MACHINES:
+            return agentpool
 
         (
             update_cluster_autoscaler,
@@ -2664,6 +2712,10 @@ class AKSAgentPoolUpdateDecorator:
         :return: the Agentpool object
         """
         self._ensure_agentpool(agentpool)
+
+        # for virtual machines agentpool only, skip for other agentpool types
+        if self.context.get_vm_set_type() != CONST_VIRTUAL_MACHINES:
+            return agentpool
 
         (
             enable_cluster_autoscaler,
@@ -2920,6 +2972,8 @@ class AKSAgentPoolUpdateDecorator:
         agentpool = self.fetch_agentpool(agentpools)
         # update auto scaler properties
         agentpool = self.update_auto_scaler_properties(agentpool)
+        # update auto scaler properties for vms pool
+        agentpool = self.update_auto_scaler_properties_vms(agentpool)
         # update label, tag, taint
         agentpool = self.update_label_tag_taint(agentpool)
         # update upgrade settings

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -2374,24 +2374,50 @@ class AKSAgentPoolAddDecorator:
         # validate vm_sizes first, then skip if not Virtual Machines
         sizes = self.context.get_vm_sizes()
         if len(sizes) != 1:
-            raise InvalidArgumentValueError(f"We only accept single sku size for manual profile. {sizes} is invalid.")
+            raise InvalidArgumentValueError(f"We only accept single sku size for scale profile. {sizes} is invalid.")
 
         if self.context.get_vm_set_type() != CONST_VIRTUAL_MACHINES:
             return agentpool
 
-        count, _, _, _ = self.context.get_node_count_and_enable_cluster_autoscaler_min_max_count()
-        agentpool.virtual_machines_profile = self.models.VirtualMachinesProfile(
-            scale=self.models.ScaleProfile(
-                manual=[
-                    self.models.ManualScaleProfile(
-                        size=sizes[0],
-                        count=count,
-                    )
-                ]
+        (
+            count,
+            enable_auto_scaling,
+            min_count,
+            max_count,
+        ) = self.context.get_node_count_and_enable_cluster_autoscaler_min_max_count()
+
+        if enable_auto_scaling:
+            agentpool.virtual_machines_profile = self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    autoscale=[
+                        self.models.AutoScaleProfile(
+                            size=sizes[0],
+                            min_count=min_count,
+                            max_count=max_count,
+                        )
+                    ]
+                )
             )
-        )
+        else:
+            agentpool.virtual_machines_profile = self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    manual=[
+                        self.models.ManualScaleProfile(
+                            size=sizes[0],
+                            count=count,
+                        )
+                    ]
+                )
+            )
+
+        # EnableAutoScaling, MinCount and MaxCount are VMSS-specific properties and must not
+        # be set for VirtualMachines agent pools; the autoscale intent is expressed through
+        # virtualMachinesProfile.scale.autoscale instead.
         agentpool.vm_size = None
         agentpool.count = None
+        agentpool.enable_auto_scaling = False
+        agentpool.min_count = None
+        agentpool.max_count = None
 
         return agentpool
 

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -1015,7 +1015,7 @@ class AKSAgentPoolContext(BaseAKSContext):
 
     def get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms(
         self,
-    ) -> Tuple[bool, bool, Union[int, None], Union[int, None], str]:
+    ) -> Tuple[bool, bool, Union[int, None], Union[int, None], Union[str, None]]:
         """Obtain the value of enable_cluster_autoscaler, disable_cluster_autoscaler,
         min_count and max_count, and vm size.
 
@@ -1032,7 +1032,7 @@ class AKSAgentPoolContext(BaseAKSContext):
 
         :return: a tuple containing five elements: enable_cluster_autoscaler of bool type,
         disable_cluster_autoscaler of bool type, min_count of int type or None, max_count of int type
-        or None, and vm_size of str type
+        or None, and vm_size of str type or None
         """
         update_cluster_autoscaler = self.raw_param.get("update_cluster_autoscaler", False)
         enable_cluster_autoscaler = self.raw_param.get("enable_cluster_autoscaler", False)
@@ -1053,7 +1053,7 @@ class AKSAgentPoolContext(BaseAKSContext):
                 'Please use "az aks nodepool auto-scale update" to update individual autoscale profiles.'
             )
 
-        self._AKSAgentPoolContext__validate_counts_in_autoscaler(
+        self.__validate_counts_in_autoscaler(
             None,
             enable_cluster_autoscaler,
             min_count,

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -997,6 +997,110 @@ class AKSAgentPoolContext(BaseAKSContext):
 
         return update_cluster_autoscaler, enable_cluster_autoscaler, disable_cluster_autoscaler, min_count, max_count
 
+    def get_node_count_from_vms_agentpool(self, agentpool: AgentPool) -> int:
+        """Get the total node count of a VirtualMachines agent pool by summing counts across all manual scale profiles.
+
+        :return: int
+        """
+        node_count = 0
+        if (
+            agentpool.virtual_machines_profile and
+            agentpool.virtual_machines_profile.scale and
+            agentpool.virtual_machines_profile.scale.manual
+        ):
+            for m in agentpool.virtual_machines_profile.scale.manual:
+                if m.count is not None:
+                    node_count += m.count
+        return node_count
+
+    def get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms(
+        self,
+    ) -> Tuple[bool, bool, Union[int, None], Union[int, None], str]:
+        """Obtain the value of enable_cluster_autoscaler, disable_cluster_autoscaler,
+        min_count and max_count, and vm size.
+
+        This function is for VMs agentpool only.
+
+        This function will verify the parameters through function "__validate_counts_in_autoscaler"
+        by default.
+        If update_cluster_autoscaler is specified, an InvalidArgumentValueError will be raised directing
+        users to use "az aks nodepool auto-scale update" instead.
+        If enable_cluster_autoscaler is specified and autoscaler is already enabled in `ap`,
+        it will output warning messages and exit with code 0.
+        If disable_cluster_autoscaler is specified and autoscaler is not enabled in `ap`,
+        it will output warning messages and exit with code 0.
+
+        :return: a tuple containing five elements: enable_cluster_autoscaler of bool type,
+        disable_cluster_autoscaler of bool type, min_count of int type or None, max_count of int type
+        or None, and vm_size of str type
+        """
+        update_cluster_autoscaler = self.raw_param.get("update_cluster_autoscaler", False)
+        enable_cluster_autoscaler = self.raw_param.get("enable_cluster_autoscaler", False)
+        disable_cluster_autoscaler = self.raw_param.get("disable_cluster_autoscaler", False)
+        min_count = self.raw_param.get("min_count")
+        max_count = self.raw_param.get("max_count")
+        vm_size = self.raw_param.get("node_vm_size")
+
+        if enable_cluster_autoscaler + update_cluster_autoscaler + disable_cluster_autoscaler > 1:
+            raise MutuallyExclusiveArgumentError(
+                "Can only specify one of --enable-cluster-autoscaler, --update-cluster-autoscaler and "
+                "--disable-cluster-autoscaler"
+            )
+
+        if update_cluster_autoscaler:
+            raise InvalidArgumentValueError(
+                "--update-cluster-autoscaler is not supported for VirtualMachines node pools.\n"
+                'Please use "az aks nodepool auto-scale update" to update individual autoscale profiles.'
+            )
+
+        self._AKSAgentPoolContext__validate_counts_in_autoscaler(
+            None,
+            enable_cluster_autoscaler,
+            min_count,
+            max_count,
+            mode=self.get_mode(),
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+
+        autoscale_profile = None
+        manual_scale_profile = None
+        if (
+            self.agentpool and
+            self.agentpool.virtual_machines_profile and
+            self.agentpool.virtual_machines_profile.scale
+        ):
+            autoscale_profile = self.agentpool.virtual_machines_profile.scale.autoscale
+            manual_scale_profile = self.agentpool.virtual_machines_profile.scale.manual
+
+        # if enabling cluster autoscaler
+        if enable_cluster_autoscaler:
+            if autoscale_profile:
+                logger.warning(
+                    "Cluster autoscaler is already enabled for this node pool.\n"
+                    'Please use "az aks nodepool auto-scale update" '
+                    "to update individual autoscale profiles."
+                )
+                raise DecoratorEarlyExitException()
+
+        # if disabling cluster autoscaler
+        if disable_cluster_autoscaler and not autoscale_profile:
+            logger.warning(
+                "Cluster autoscaler is already disabled for this node pool."
+            )
+            raise DecoratorEarlyExitException()
+
+        # default vm_size for backward compatibility when no manual/autoscale profile exists
+        if vm_size is None and manual_scale_profile:
+            vm_size = manual_scale_profile[0].size
+
+        return (
+            enable_cluster_autoscaler,
+            disable_cluster_autoscaler,
+            min_count,
+            max_count,
+            vm_size,
+        )
+
     def get_priority(self) -> str:
         """Obtain the value of priority, default value is CONST_SCALE_SET_PRIORITY_REGULAR.
 
@@ -2502,6 +2606,9 @@ class AKSAgentPoolUpdateDecorator:
         """
         self._ensure_agentpool(agentpool)
 
+        if agentpool.type_properties_type == CONST_VIRTUAL_MACHINES:
+            return self.update_auto_scaler_properties_vms(agentpool)
+
         (
             update_cluster_autoscaler,
             enable_cluster_autoscaler,
@@ -2521,6 +2628,83 @@ class AKSAgentPoolUpdateDecorator:
             agentpool.enable_auto_scaling = False
             agentpool.min_count = None
             agentpool.max_count = None
+        return agentpool
+
+    def update_auto_scaler_properties_vms(self, agentpool: AgentPool) -> AgentPool:
+        """Update auto scaler related properties for a VirtualMachines Agentpool object.
+
+        Converts between manual and autoscale profiles based on the user's request.
+
+        :return: the Agentpool object
+        """
+        self._ensure_agentpool(agentpool)
+
+        (
+            enable_cluster_autoscaler,
+            disable_cluster_autoscaler,
+            min_count,
+            max_count,
+            vm_size,
+        ) = (
+            self.context.get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms()
+        )
+
+        if enable_cluster_autoscaler:
+            # Convert all manual profiles to autoscale profiles using the same min/max counts
+            manual_profiles = (
+                agentpool.virtual_machines_profile and
+                agentpool.virtual_machines_profile.scale and
+                agentpool.virtual_machines_profile.scale.manual
+            )
+            if manual_profiles:
+                autoscale_profiles = [
+                    self.models.AutoScaleProfile(
+                        size=m.size,
+                        min_count=min_count,
+                        max_count=max_count,
+                    )
+                    for m in manual_profiles
+                ]
+            else:
+                autoscale_profiles = [self.models.AutoScaleProfile(
+                    size=vm_size,
+                    min_count=min_count,
+                    max_count=max_count,
+                )]
+            agentpool.virtual_machines_profile = self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    autoscale=autoscale_profiles
+                )
+            )
+
+        if disable_cluster_autoscaler:
+            current_node_count = self.context.get_node_count_from_vms_agentpool(agentpool)
+            autoscale_profiles = (
+                agentpool.virtual_machines_profile and
+                agentpool.virtual_machines_profile.scale and
+                agentpool.virtual_machines_profile.scale.autoscale
+            )
+            if autoscale_profiles:
+                manual_profiles = [
+                    self.models.ManualScaleProfile(
+                        size=a.size,
+                        count=a.min_count if a.min_count is not None else current_node_count,
+                    )
+                    for a in autoscale_profiles
+                ]
+            else:
+                manual_profiles = [
+                    self.models.ManualScaleProfile(
+                        size=vm_size,
+                        count=current_node_count,
+                    )
+                ]
+            agentpool.virtual_machines_profile = self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    manual=manual_profiles
+                )
+            )
+
         return agentpool
 
     def update_label_tag_taint(self, agentpool: AgentPool) -> AgentPool:

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -213,6 +213,12 @@ def load_command_table(self, _):
         g.custom_command("update", "aks_agentpool_manual_scale_update", supports_no_wait=True)
         g.custom_command("delete", "aks_agentpool_manual_scale_delete", supports_no_wait=True, confirmation=True)
 
+    # AKS nodepool auto-scale command
+    with self.command_group('aks nodepool auto-scale', agent_pools_sdk, client_factory=cf_agent_pools) as g:
+        g.custom_command("add", "aks_agentpool_auto_scale_add", supports_no_wait=True)
+        g.custom_command("update", "aks_agentpool_auto_scale_update", supports_no_wait=True)
+        g.custom_command("delete", "aks_agentpool_auto_scale_delete", supports_no_wait=True, confirmation=True)
+
     with self.command_group('aks command', managed_clusters_sdk, client_factory=cf_managed_clusters) as g:
         g.custom_command('invoke', 'aks_runcommand', supports_no_wait=True,
                          table_transformer=aks_run_command_result_format)

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3647,6 +3647,120 @@ def aks_agentpool_manual_scale_delete(cmd,    # pylint: disable=unused-argument
     )
 
 
+def aks_agentpool_auto_scale_add(cmd,
+                                 client,
+                                 resource_group_name,
+                                 cluster_name,
+                                 nodepool_name,
+                                 node_vm_size,
+                                 min_count,
+                                 max_count,
+                                 no_wait=False):
+    instance = client.get(resource_group_name, cluster_name, nodepool_name)
+    if instance.properties.type_properties_type != CONST_VIRTUAL_MACHINES:
+        raise ClientRequestError("Cannot add autoscale profile to a non-virtualmachines node pool.")
+
+    AutoScaleProfile = cmd.get_models(
+        "AutoScaleProfile",
+        resource_type=ResourceType.MGMT_CONTAINERSERVICE,
+        operation_group="managed_clusters",
+    )
+    new_autoscale_profile = AutoScaleProfile(
+        size=node_vm_size,
+        min_count=int(min_count),
+        max_count=int(max_count),
+    )
+    if instance.virtual_machines_profile.scale.autoscale is None:
+        instance.virtual_machines_profile.scale.autoscale = []
+    instance.virtual_machines_profile.scale.autoscale.append(new_autoscale_profile)
+
+    return sdk_no_wait(
+        no_wait,
+        client.begin_create_or_update,
+        resource_group_name,
+        cluster_name,
+        nodepool_name,
+        instance
+    )
+
+
+def aks_agentpool_auto_scale_update(cmd,    # pylint: disable=unused-argument
+                                    client,
+                                    resource_group_name,
+                                    cluster_name,
+                                    nodepool_name,
+                                    current_node_vm_size,
+                                    node_vm_size=None,
+                                    min_count=None,
+                                    max_count=None,
+                                    no_wait=False):
+    if node_vm_size is None and min_count is None and max_count is None:
+        raise RequiredArgumentMissingError(
+            "specify --node-vm-size, --min-count, or --max-count (or a combination)."
+        )
+
+    instance = client.get(resource_group_name, cluster_name, nodepool_name)
+    if instance.properties.type_properties_type != CONST_VIRTUAL_MACHINES:
+        raise ClientRequestError("Cannot update autoscale profile in a non-virtualmachines node pool.")
+
+    autoscale_exists = False
+    for a in instance.virtual_machines_profile.scale.autoscale or []:
+        if a.size == current_node_vm_size:
+            autoscale_exists = True
+            if node_vm_size is not None:
+                a.size = node_vm_size
+            if min_count is not None:
+                a.min_count = int(min_count)
+            if max_count is not None:
+                a.max_count = int(max_count)
+            break
+    if not autoscale_exists:
+        raise InvalidArgumentValueError(
+            f"Autoscale profile with size {current_node_vm_size} doesn't exist in node pool {nodepool_name}."
+        )
+
+    return sdk_no_wait(
+        no_wait,
+        client.begin_create_or_update,
+        resource_group_name,
+        cluster_name,
+        nodepool_name,
+        instance
+    )
+
+
+def aks_agentpool_auto_scale_delete(cmd,    # pylint: disable=unused-argument
+                                    client,
+                                    resource_group_name,
+                                    cluster_name,
+                                    nodepool_name,
+                                    current_node_vm_size,
+                                    no_wait=False):
+    instance = client.get(resource_group_name, cluster_name, nodepool_name)
+    if instance.properties.type_properties_type != CONST_VIRTUAL_MACHINES:
+        raise ClientRequestError("Cannot delete autoscale profile from a non-virtualmachines node pool.")
+
+    autoscale_exists = False
+    for a in instance.virtual_machines_profile.scale.autoscale or []:
+        if a.size == current_node_vm_size:
+            autoscale_exists = True
+            instance.virtual_machines_profile.scale.autoscale.remove(a)
+            break
+    if not autoscale_exists:
+        raise InvalidArgumentValueError(
+            f"Autoscale profile with size {current_node_vm_size} doesn't exist in node pool {nodepool_name}."
+        )
+
+    return sdk_no_wait(
+        no_wait,
+        client.begin_create_or_update,
+        resource_group_name,
+        cluster_name,
+        nodepool_name,
+        instance
+    )
+
+
 def aks_agentpool_show(cmd, client, resource_group_name, cluster_name, nodepool_name):
     instance = client.get(resource_group_name, cluster_name, nodepool_name)
     return instance

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_autoscaler_then_update_vms_pool.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_autoscaler_then_update_vms_pool.yaml
@@ -1,0 +1,3266 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002?api-version=2026-05-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ContainerService/managedClusters/cliakstest000002''
+        under resource group ''clitest000001'' was not found. For more details please
+        go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 28 Jul 2026 06:22:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+      x-msedge-ref:
+      - 'Ref A: 5595E60771FF4A9F943D560B5CBC35BD Ref B: BN1AA2051014045 Ref C: 2026-07-28T06:22:24Z'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"location": "westus2", "properties": {"agentPoolProfiles": [{"name": "nodepool1",
+      "orchestratorVersion": "", "osType": "Linux", "enableNodePublicIP": false, "enableAutoScaling":
+      false, "scaleSetPriority": "Regular", "nodeTaints": [], "upgradeSettings": {},
+      "type": "VirtualMachines", "enableEncryptionAtHost": false, "enableUltraSSD":
+      false, "enableFIPS": false, "mode": "System", "virtualMachinesProfile": {"scale":
+      {"autoscale": [{"size": "standard_d2s_v3", "minCount": 1, "maxCount": 3}]}}}],
+      "kubernetesVersion": "", "dnsPrefix": "cliakstest-clitest6ntmtm7po-79a739",
+      "disableLocalAccounts": false, "enableRBAC": true, "linuxProfile": {"adminUsername":
+      "azureuser", "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCyvMwWFxUsg4krJno+UQH/nu/Ca/U22VfaTf9FlrVX7/S+h/iLui0rXjAlLcYGc7JiSx7Uuq8ocMSZ1qdUqmbaeAPMaF3lzHIsFrk6/LEtEPhXDNXXmKoeSUHxizc7edI5G/XfjV9RzTwaQlAdWV8bkIs68TSlOEm20uoHSiCby4pEY9RzBkvnecif9uQHhS03MZxJoM1/MPhnTZS9XjN0EE/Uvceu8GZHPu8YptI7SxTubCZ23EHDYPjTZJb6oHcjFBXY+SZfs3qIROco0FoIC+xIdg+zwws06dYuwLEVmb9Ph6hqKXvG8i8Q0p5NJPnev76XMScIvvbzsqimDih7
+      azcli_aks_live_test@example.com\n"}]}}, "networkProfile": {"loadBalancerSku":
+      "standard", "outboundType": "loadBalancer"}, "addonProfiles": {}, "storageProfile":
+      {}, "bootstrapProfile": {"artifactSource": "Direct"}}, "identity": {"type":
+      "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/e2e-managed-identity-pool/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cp-97":
+      {}}}, "sku": {"name": "Base", "tier": "Free"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1576'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002\"\
+        ,\n \"location\": \"westus2\",\n \"name\": \"cliakstest000002\",\n \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n \"kind\": \"Base\",\n\
+        \ \"properties\": {\n  \"provisioningState\": \"Creating\",\n  \"powerState\"\
+        : {\n   \"code\": \"Running\"\n  },\n  \"kubernetesVersion\": \"1.35\",\n\
+        \  \"currentKubernetesVersion\": \"1.35.6\",\n  \"dnsPrefix\": \"cliakstest-clitest6ntmtm7po-79a739\"\
+        ,\n  \"fqdn\": \"cliakstest-clitest6ntmtm7po-79a739-7fvnvgfn.hcp.westus2.azmk8s.io\"\
+        ,\n  \"azurePortalFQDN\": \"cliakstest-clitest6ntmtm7po-79a739-7fvnvgfn.portal.hcp.westus2.azmk8s.io\"\
+        ,\n  \"agentPoolProfiles\": [\n   {\n    \"name\": \"nodepool1\",\n    \"\
+        count\": null,\n    \"vmSize\": \"\",\n    \"osDiskSizeGB\": 128,\n    \"\
+        osDiskType\": \"Managed\",\n    \"kubeletDiskType\": \"OS\",\n    \"maxPods\"\
+        : 250,\n    \"type\": \"VirtualMachines\",\n    \"enableAutoScaling\": false,\n\
+        \    \"scaleDownMode\": \"Delete\",\n    \"provisioningState\": \"Creating\"\
+        ,\n    \"powerState\": {\n     \"code\": \"Running\"\n    },\n    \"orchestratorVersion\"\
+        : \"1.35\",\n    \"currentOrchestratorVersion\": \"1.35.6\",\n    \"enableNodePublicIP\"\
+        : false,\n    \"nodeLabels\": {},\n    \"mode\": \"System\",\n    \"enableEncryptionAtHost\"\
+        : false,\n    \"enableUltraSSD\": false,\n    \"osType\": \"Linux\",\n   \
+        \ \"osSKU\": \"Ubuntu\",\n    \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\"\
+        ,\n    \"upgradeSettings\": {\n     \"maxSurge\": \"10%\",\n     \"maxUnavailable\"\
+        : \"0\"\n    },\n    \"enableFIPS\": false,\n    \"securityProfile\": {\n\
+        \     \"sshAccess\": \"LocalUser\",\n     \"enableVTPM\": false,\n     \"\
+        enableSecureBoot\": false\n    },\n    \"virtualMachinesProfile\": {\n   \
+        \  \"scale\": {\n      \"autoscale\": [\n       {\n        \"size\": \"standard_d2s_v3\"\
+        ,\n        \"minCount\": 1,\n        \"maxCount\": 3\n       }\n      ]\n\
+        \     }\n    }\n   }\n  ],\n  \"linuxProfile\": {\n   \"adminUsername\": \"\
+        azureuser\",\n   \"ssh\": {\n    \"publicKeys\": [\n     {\n      \"keyData\"\
+        : \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCyvMwWFxUsg4krJno+UQH/nu/Ca/U22VfaTf9FlrVX7/S+h/iLui0rXjAlLcYGc7JiSx7Uuq8ocMSZ1qdUqmbaeAPMaF3lzHIsFrk6/LEtEPhXDNXXmKoeSUHxizc7edI5G/XfjV9RzTwaQlAdWV8bkIs68TSlOEm20uoHSiCby4pEY9RzBkvnecif9uQHhS03MZxJoM1/MPhnTZS9XjN0EE/Uvceu8GZHPu8YptI7SxTubCZ23EHDYPjTZJb6oHcjFBXY+SZfs3qIROco0FoIC+xIdg+zwws06dYuwLEVmb9Ph6hqKXvG8i8Q0p5NJPnev76XMScIvvbzsqimDih7\
+        \ azcli_aks_live_test@example.com\\n\"\n     }\n    ]\n   }\n  },\n  \"servicePrincipalProfile\"\
+        : {\n   \"clientId\":\"00000000-0000-0000-0000-000000000001\"\n  },\n  \"\
+        nodeResourceGroup\": \"MC_clitest000001_cliakstest000002_westus2\",\n  \"\
+        enableRBAC\": true,\n  \"supportPlan\": \"KubernetesOfficial\",\n  \"networkProfile\"\
+        : {\n   \"networkPlugin\": \"azure\",\n   \"networkPluginMode\": \"overlay\"\
+        ,\n   \"networkPolicy\": \"none\",\n   \"networkDataplane\": \"azure\",\n\
+        \   \"loadBalancerSku\": \"standard\",\n   \"loadBalancerProfile\": {\n  \
+        \  \"managedOutboundIPs\": {\n     \"count\": 1\n    },\n    \"backendPoolType\"\
+        : \"nodeIPConfiguration\"\n   },\n   \"podCidr\": \"10.244.0.0/16\",\n   \"\
+        serviceCidr\": \"10.0.0.0/16\",\n   \"dnsServiceIP\": \"10.0.0.10\",\n   \"\
+        outboundType\": \"loadBalancer\",\n   \"podCidrs\": [\n    \"10.244.0.0/16\"\
+        \n   ],\n   \"serviceCidrs\": [\n    \"10.0.0.0/16\"\n   ],\n   \"ipFamilies\"\
+        : [\n    \"IPv4\"\n   ]\n  },\n  \"maxAgentPools\": 100,\n  \"autoUpgradeProfile\"\
+        : {\n   \"nodeOSUpgradeChannel\": \"NodeImage\"\n  },\n  \"disableLocalAccounts\"\
+        : false,\n  \"securityProfile\": {},\n  \"storageProfile\": {\n   \"diskCSIDriver\"\
+        : {\n    \"enabled\": true\n   },\n   \"fileCSIDriver\": {\n    \"enabled\"\
+        : true\n   },\n   \"snapshotController\": {\n    \"enabled\": true\n   }\n\
+        \  },\n  \"oidcIssuerProfile\": {\n   \"enabled\": true,\n   \"issuerURL\"\
+        : \"https://westus2.oic.prod-aks.azure.com/72f988bf-86f1-41af-91ab-2d7cd011db47/0d70cefa-d1bf-482e-8aaa-38e0b9cbfd8d/\"\
+        \n  },\n  \"workloadAutoScalerProfile\": {},\n  \"resourceUID\": \"6a684aaa737f4c00018f6fae\"\
+        ,\n  \"metricsProfile\": {\n   \"costAnalysis\": {\n    \"enabled\": false\n\
+        \   }\n  },\n  \"nodeProvisioningProfile\": {\n   \"mode\": \"Manual\"\n \
+        \ },\n  \"bootstrapProfile\": {\n   \"artifactSource\": \"Direct\"\n  },\n\
+        \  \"hostedSystemProfile\": {\n   \"enabled\": false\n  }\n },\n \"identity\"\
+        : {\n  \"type\": \"UserAssigned\",\n  \"userAssignedIdentities\": {\n   \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/e2e-managed-identity-pool/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cp-97\"\
+        : {\n    \"principalId\":\"00000000-0000-0000-0000-000000000001\"\n   }\n\
+        \  }\n },\n \"sku\": {\n  \"name\": \"Base\",\n  \"tier\": \"Free\"\n }\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+      cache-control:
+      - no-cache
+      content-length:
+      - '4347'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:22:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/6f4bb45f-9834-4e75-9697-2866b066ef5e
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 88B2C863171B4261BCB254FE9E0AB467 Ref B: BN1AA2051014029 Ref C: 2026-07-28T06:22:24Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"InProgress\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:22:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/44f24d7f-72a5-4138-8a04-caa3ae1a6024
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 54D87331EEB1403699DB9CFD0C5CF87E Ref B: BN1AA2051012029 Ref C: 2026-07-28T06:22:35Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"ProvisioningNetworkResources\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '140'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:23:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/fe60b515-a1e4-46ac-8f5e-846182b9f5a9
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4FF058C7C05A4A76B4066D17B91EE2FB Ref B: BN1AA2051013035 Ref C: 2026-07-28T06:23:05Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"ProvisioningControlPlane\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '136'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:23:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/8854dabb-1c9d-4d55-ac03-3b3554a3dbc2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 961330E68ADD4C9A9C66F185FEEE9D7E Ref B: BN1AA2051013021 Ref C: 2026-07-28T06:23:36Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"ProvisioningControlPlane\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '136'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:24:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/540480b3-7169-4867-b3c1-61c1515fffe8
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: FC63EA44E14B485EB84194E300243C0E Ref B: BN1AA2051014019 Ref C: 2026-07-28T06:24:07Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"ProvisioningControlPlane\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '136'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:24:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/1c02237a-091d-4399-8bd5-ec3850d85fa3
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 00CDB95A2C944A0A9D7159FDD7971045 Ref B: BN1AA2051013021 Ref C: 2026-07-28T06:24:37Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"CreatingAgentPools\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '130'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:25:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/3bb66ffe-a14a-4384-9a29-01001f71710b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F6F6EE6E206F454BA443405B76CFD865 Ref B: BN1AA2051014049 Ref C: 2026-07-28T06:25:08Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"CreatingAgentPools: 0/0 nodes completed\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '151'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:25:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/c35257bd-b945-4c33-82f2-fd675963e0da
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3E869B5D9E694BD18F76E0B828045180 Ref B: BN1AA2051014035 Ref C: 2026-07-28T06:25:39Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"CreatingAgentPools: 0/0 nodes completed\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '151'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:26:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/ac49aa86-6734-439e-8e63-b2b5c67c15d4
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: AF210A5A8E7A469AAD67039349D7B451 Ref B: BN1AA2051015035 Ref C: 2026-07-28T06:26:09Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"CreatingAgentPools: 1/0 nodes completed\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '151'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:26:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/173096a9-ab21-43b4-8c9e-c3bbbe934514
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E1474F345BED4853B3D647E62C9D0FA7 Ref B: BN1AA2051012021 Ref C: 2026-07-28T06:26:40Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"ReconcilingAddons\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '129'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:27:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/ff5b9466-0a6e-4ed1-b783-341599f72731
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 1754E273DBA24DD5AAB7E9A20417A117 Ref B: BN1AA2051015051 Ref C: 2026-07-28T06:27:11Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/9bcd0a9c-a52a-4510-b82a-f9da5af42425?api-version=2025-03-01&t=639208165550788454&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ROO4-DRxuR3fXrcv78JucX3Gnq_W-Tbk2DaQIIVBfvEau1jpLY3ti0ZR0J0v8cGWHR_GBlLjZ2lf6ZXOuDPgqoLWttUcXcjb8yYYgsfjSTp7ljH9RMSAL0HAVEa5TYPrWzVjapnTEcaKJyy730dL_XmGxOsC5ruzOgz00fwILB1YypeVqgsCQ8uNgSDdQ8GS2dWYSrGeRlOtRFG5L4IIIsz7YqC9eoow95nVKJqx_CjyklQ5JmqwUQW_jg_2LWzk-kxsxBaG-jHbiGglrppcH4Yz9P6T5m3INdppYLdYcz4ZaLGLAnDNwA3TzgNlZWvfY2hcLRjXvt7dE21Y1zCMqQ&h=NNMo35ZDLRY2FmlbUsKWrbXr2N4uR1iwSsAKoZstLEw
+  response:
+    body:
+      string: "{\n \"name\": \"9bcd0a9c-a52a-4510-b82a-f9da5af42425\",\n \"status\"\
+        : \"Succeeded\",\n \"startTime\": \"2026-07-28T06:22:34.8889303Z\",\n \"endTime\"\
+        : \"2026-07-28T06:27:15.888592Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '164'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:27:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/57222b73-4c5f-47ae-a247-5cde911e50ae
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8CA33E5508794B5AA3128E2223C155CB Ref B: BN1AA2051014049 Ref C: 2026-07-28T06:27:41Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --location --ssh-key-value --vm-set-type --enable-cluster-autoscaler
+        --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002\"\
+        ,\n \"location\": \"westus2\",\n \"name\": \"cliakstest000002\",\n \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n \"kind\": \"Base\",\n\
+        \ \"properties\": {\n  \"provisioningState\": \"Succeeded\",\n  \"powerState\"\
+        : {\n   \"code\": \"Running\"\n  },\n  \"kubernetesVersion\": \"1.35\",\n\
+        \  \"currentKubernetesVersion\": \"1.35.6\",\n  \"dnsPrefix\": \"cliakstest-clitest6ntmtm7po-79a739\"\
+        ,\n  \"fqdn\": \"cliakstest-clitest6ntmtm7po-79a739-7fvnvgfn.hcp.westus2.azmk8s.io\"\
+        ,\n  \"azurePortalFQDN\": \"cliakstest-clitest6ntmtm7po-79a739-7fvnvgfn.portal.hcp.westus2.azmk8s.io\"\
+        ,\n  \"agentPoolProfiles\": [\n   {\n    \"name\": \"nodepool1\",\n    \"\
+        count\": null,\n    \"vmSize\": \"\",\n    \"osDiskSizeGB\": 128,\n    \"\
+        osDiskType\": \"Managed\",\n    \"kubeletDiskType\": \"OS\",\n    \"maxPods\"\
+        : 250,\n    \"type\": \"VirtualMachines\",\n    \"enableAutoScaling\": false,\n\
+        \    \"scaleDownMode\": \"Delete\",\n    \"provisioningState\": \"Succeeded\"\
+        ,\n    \"powerState\": {\n     \"code\": \"Running\"\n    },\n    \"orchestratorVersion\"\
+        : \"1.35\",\n    \"currentOrchestratorVersion\": \"1.35.6\",\n    \"enableNodePublicIP\"\
+        : false,\n    \"mode\": \"System\",\n    \"enableEncryptionAtHost\": false,\n\
+        \    \"enableUltraSSD\": false,\n    \"osType\": \"Linux\",\n    \"osSKU\"\
+        : \"Ubuntu\",\n    \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\"\
+        ,\n    \"upgradeSettings\": {\n     \"maxSurge\": \"10%\",\n     \"maxUnavailable\"\
+        : \"0\"\n    },\n    \"enableFIPS\": false,\n    \"securityProfile\": {\n\
+        \     \"sshAccess\": \"LocalUser\",\n     \"enableVTPM\": false,\n     \"\
+        enableSecureBoot\": false\n    },\n    \"virtualMachinesProfile\": {\n   \
+        \  \"scale\": {\n      \"autoscale\": [\n       {\n        \"size\": \"standard_d2s_v3\"\
+        ,\n        \"minCount\": 1,\n        \"maxCount\": 3\n       }\n      ]\n\
+        \     }\n    },\n    \"virtualMachineNodesStatus\": [\n     {\n      \"size\"\
+        : \"Standard_D2s_v3\",\n      \"count\": 1\n     }\n    ],\n    \"eTag\":\
+        \ \"6abb598b-11c1-45b7-a00e-ded46d62f666\"\n   }\n  ],\n  \"linuxProfile\"\
+        : {\n   \"adminUsername\": \"azureuser\",\n   \"ssh\": {\n    \"publicKeys\"\
+        : [\n     {\n      \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCyvMwWFxUsg4krJno+UQH/nu/Ca/U22VfaTf9FlrVX7/S+h/iLui0rXjAlLcYGc7JiSx7Uuq8ocMSZ1qdUqmbaeAPMaF3lzHIsFrk6/LEtEPhXDNXXmKoeSUHxizc7edI5G/XfjV9RzTwaQlAdWV8bkIs68TSlOEm20uoHSiCby4pEY9RzBkvnecif9uQHhS03MZxJoM1/MPhnTZS9XjN0EE/Uvceu8GZHPu8YptI7SxTubCZ23EHDYPjTZJb6oHcjFBXY+SZfs3qIROco0FoIC+xIdg+zwws06dYuwLEVmb9Ph6hqKXvG8i8Q0p5NJPnev76XMScIvvbzsqimDih7\
+        \ azcli_aks_live_test@example.com\\n\"\n     }\n    ]\n   }\n  },\n  \"servicePrincipalProfile\"\
+        : {\n   \"clientId\":\"00000000-0000-0000-0000-000000000001\"\n  },\n  \"\
+        nodeResourceGroup\": \"MC_clitest000001_cliakstest000002_westus2\",\n  \"\
+        enableRBAC\": true,\n  \"supportPlan\": \"KubernetesOfficial\",\n  \"networkProfile\"\
+        : {\n   \"networkPlugin\": \"azure\",\n   \"networkPluginMode\": \"overlay\"\
+        ,\n   \"networkPolicy\": \"none\",\n   \"networkDataplane\": \"azure\",\n\
+        \   \"loadBalancerSku\": \"standard\",\n   \"loadBalancerProfile\": {\n  \
+        \  \"managedOutboundIPs\": {\n     \"count\": 1\n    },\n    \"effectiveOutboundIPs\"\
+        : [\n     {\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000002_westus2/providers/Microsoft.Network/publicIPAddresses/d9a3de11-8b60-4e19-9cab-2f2abc3de2c3\"\
+        \n     }\n    ],\n    \"backendPoolType\": \"nodeIPConfiguration\"\n   },\n\
+        \   \"podCidr\": \"10.244.0.0/16\",\n   \"serviceCidr\": \"10.0.0.0/16\",\n\
+        \   \"dnsServiceIP\": \"10.0.0.10\",\n   \"outboundType\": \"loadBalancer\"\
+        ,\n   \"podCidrs\": [\n    \"10.244.0.0/16\"\n   ],\n   \"serviceCidrs\":\
+        \ [\n    \"10.0.0.0/16\"\n   ],\n   \"ipFamilies\": [\n    \"IPv4\"\n   ]\n\
+        \  },\n  \"maxAgentPools\": 100,\n  \"identityProfile\": {\n   \"kubeletidentity\"\
+        : {\n    \"resourceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_clitest000001_cliakstest000002_westus2/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cliakstest000002-agentpool\"\
+        ,\n    \"clientId\":\"00000000-0000-0000-0000-000000000001\",\n    \"objectId\"\
+        :\"00000000-0000-0000-0000-000000000001\"\n   }\n  },\n  \"autoScalerProfile\"\
+        : {\n   \"balance-similar-node-groups\": \"false\",\n   \"daemonset-eviction-for-empty-nodes\"\
+        : false,\n   \"daemonset-eviction-for-occupied-nodes\": true,\n   \"expander\"\
+        : \"random\",\n   \"ignore-daemonsets-utilization\": false,\n   \"max-empty-bulk-delete\"\
+        : \"10\",\n   \"max-graceful-termination-sec\": \"600\",\n   \"max-node-provision-time\"\
+        : \"15m\",\n   \"max-total-unready-percentage\": \"45\",\n   \"new-pod-scale-up-delay\"\
+        : \"0s\",\n   \"ok-total-unready-count\": \"3\",\n   \"scale-down-delay-after-add\"\
+        : \"10m\",\n   \"scale-down-delay-after-delete\": \"10s\",\n   \"scale-down-delay-after-failure\"\
+        : \"3m\",\n   \"scale-down-unneeded-time\": \"10m\",\n   \"scale-down-unready-time\"\
+        : \"20m\",\n   \"scale-down-utilization-threshold\": \"0.5\",\n   \"scan-interval\"\
+        : \"10s\",\n   \"skip-nodes-with-local-storage\": \"false\",\n   \"skip-nodes-with-system-pods\"\
+        : \"true\"\n  },\n  \"autoUpgradeProfile\": {\n   \"nodeOSUpgradeChannel\"\
+        : \"NodeImage\"\n  },\n  \"disableLocalAccounts\": false,\n  \"securityProfile\"\
+        : {},\n  \"storageProfile\": {\n   \"diskCSIDriver\": {\n    \"enabled\":\
+        \ true\n   },\n   \"fileCSIDriver\": {\n    \"enabled\": true\n   },\n   \"\
+        snapshotController\": {\n    \"enabled\": true\n   }\n  },\n  \"oidcIssuerProfile\"\
+        : {\n   \"enabled\": true,\n   \"issuerURL\": \"https://westus2.oic.prod-aks.azure.com/72f988bf-86f1-41af-91ab-2d7cd011db47/0d70cefa-d1bf-482e-8aaa-38e0b9cbfd8d/\"\
+        \n  },\n  \"workloadAutoScalerProfile\": {},\n  \"resourceUID\": \"6a684aaa737f4c00018f6fae\"\
+        ,\n  \"metricsProfile\": {\n   \"costAnalysis\": {\n    \"enabled\": false\n\
+        \   }\n  },\n  \"nodeProvisioningProfile\": {\n   \"mode\": \"Manual\"\n \
+        \ },\n  \"bootstrapProfile\": {\n   \"artifactSource\": \"Direct\"\n  },\n\
+        \  \"hostedSystemProfile\": {\n   \"enabled\": false\n  }\n },\n \"identity\"\
+        : {\n  \"type\": \"UserAssigned\",\n  \"userAssignedIdentities\": {\n   \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/e2e-managed-identity-pool/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cp-97\"\
+        : {\n    \"clientId\":\"00000000-0000-0000-0000-000000000001\",\n    \"principalId\"\
+        :\"00000000-0000-0000-0000-000000000001\"\n   }\n  }\n },\n \"sku\": {\n \
+        \ \"name\": \"Base\",\n  \"tier\": \"Free\"\n },\n \"eTag\": \"f792b244-88f0-4150-9715-9b23a46f0e01\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '6050'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:27:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B36D0AD93AAF4922B0ED7881AC4F4499 Ref B: BN1AA2051013017 Ref C: 2026-07-28T06:27:42Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --vm-set-type --mode --node-vm-size --enable-cluster-autoscaler
+        --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"value\": [\n  {\n   \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/nodepool1\"\
+        ,\n   \"name\": \"nodepool1\",\n   \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n   \"properties\": {\n    \"count\": null,\n    \"vmSize\": \"\",\n   \
+        \ \"osDiskSizeGB\": 128,\n    \"osDiskType\": \"Managed\",\n    \"kubeletDiskType\"\
+        : \"OS\",\n    \"maxPods\": 250,\n    \"type\": \"VirtualMachines\",\n   \
+        \ \"enableAutoScaling\": false,\n    \"scaleDownMode\": \"Delete\",\n    \"\
+        provisioningState\": \"Succeeded\",\n    \"powerState\": {\n     \"code\"\
+        : \"Running\"\n    },\n    \"orchestratorVersion\": \"1.35\",\n    \"currentOrchestratorVersion\"\
+        : \"1.35.6\",\n    \"enableNodePublicIP\": false,\n    \"mode\": \"System\"\
+        ,\n    \"enableEncryptionAtHost\": false,\n    \"enableUltraSSD\": false,\n\
+        \    \"osType\": \"Linux\",\n    \"osSKU\": \"Ubuntu\",\n    \"nodeImageVersion\"\
+        : \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n    \"upgradeSettings\":\
+        \ {\n     \"maxSurge\": \"10%\",\n     \"maxUnavailable\": \"0\"\n    },\n\
+        \    \"enableFIPS\": false,\n    \"securityProfile\": {\n     \"sshAccess\"\
+        : \"LocalUser\",\n     \"enableVTPM\": false,\n     \"enableSecureBoot\":\
+        \ false\n    },\n    \"virtualMachinesProfile\": {\n     \"scale\": {\n  \
+        \    \"autoscale\": [\n       {\n        \"size\": \"standard_d2s_v3\",\n\
+        \        \"minCount\": 1,\n        \"maxCount\": 3\n       }\n      ]\n  \
+        \   }\n    },\n    \"virtualMachineNodesStatus\": [\n     {\n      \"size\"\
+        : \"Standard_D2s_v3\",\n      \"count\": 1\n     }\n    ],\n    \"eTag\":\
+        \ \"6abb598b-11c1-45b7-a00e-ded46d62f666\"\n   }\n  }\n ],\n \"nextLink\"\
+        : \"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools?%24skipToken=7616245\\\
+        u0026api-version=2026-05-01\\u0026skipToken=7616245\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1814'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:27:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/bc6acdeb-e36c-455e-9a5f-06d0bc5aeae6
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CAD06DBDA33A45A4B629D6C5246E6EE5 Ref B: BN1AA2051012033 Ref C: 2026-07-28T06:27:43Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --vm-set-type --mode --node-vm-size --enable-cluster-autoscaler
+        --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools?$skipToken=7616245&api-version=2026-05-01&skipToken=7616245
+  response:
+    body:
+      string: "{\n \"value\": []\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '16'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:27:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/bc6fc33d-539b-48d1-b436-e96dd2d81729
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DCA6DA7CDB7C4994975B45792229E25C Ref B: BN1AA2051012037 Ref C: 2026-07-28T06:27:44Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"osType": "Linux", "enableNodePublicIP": false, "enableAutoScaling":
+      false, "scaleSetPriority": "Regular", "nodeTaints": [], "upgradeSettings": {"undrainableNodeBehavior":
+      "Schedule"}, "type": "VirtualMachines", "enableEncryptionAtHost": false, "enableUltraSSD":
+      false, "enableFIPS": false, "mode": "User", "scaleDownMode": "Delete", "virtualMachinesProfile":
+      {"scale": {"autoscale": [{"size": "standard_d2s_v3", "minCount": 0, "maxCount":
+      3}]}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool add
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '463'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --cluster-name -n --vm-set-type --mode --node-vm-size --enable-cluster-autoscaler
+        --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Creating\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d2s_v3\"\
+        ,\n      \"minCount\": 0,\n      \"maxCount\": 3\n     }\n    ]\n   }\n  },\n\
+        \  \"eTag\": \"29fa215f-bf4f-43f9-b1c6-d6e47a31b670\"\n }\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/2bd27134-dde2-4f4e-a74c-fbc8351f2a9b?api-version=2025-03-01&t=639208168746313616&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=vWvHHdnf6iLnIVvgoJSaF3_u9JaeipQkS__t6ac0ikZUveJyTGB9LF7NO-KyNrPjnYieJtYN6nHOjZ8r9WwWTatiBg-Hz9exH46YHqPfi2wHis6GLv4DLwtept8P82M_fMKEL0fWhzNmq7yjrHu3l8W8GJXzJtMLmeLA1kqmjOHypxq65e6QzOW5Ev1LpHnoTHZ7-cNLHHBoAVX7qjAuIK8h3E7MLYXJzAKfZBhGD31tTC2k0HdhGvHiaySzscQ_-GtQoVpJWDqcpcpYr-PQp9AU045mJ1Vw9bY17Y6_i2CMnHbhSN70GnITS6JlcM4B5o7tdQVq1poPpJXRr_vM-g&h=mgeT4eNRwnr6A89swbvw09kPoD-gldqb-dl3olHFSKA
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:27:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/5a30c147-c6f5-4ec0-b423-a25bc5dc4def
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: A31674AAA2B84E198464EC917C9533A8 Ref B: BN1AA2051012029 Ref C: 2026-07-28T06:27:45Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --vm-set-type --mode --node-vm-size --enable-cluster-autoscaler
+        --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/2bd27134-dde2-4f4e-a74c-fbc8351f2a9b?api-version=2025-03-01&t=639208168746313616&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=vWvHHdnf6iLnIVvgoJSaF3_u9JaeipQkS__t6ac0ikZUveJyTGB9LF7NO-KyNrPjnYieJtYN6nHOjZ8r9WwWTatiBg-Hz9exH46YHqPfi2wHis6GLv4DLwtept8P82M_fMKEL0fWhzNmq7yjrHu3l8W8GJXzJtMLmeLA1kqmjOHypxq65e6QzOW5Ev1LpHnoTHZ7-cNLHHBoAVX7qjAuIK8h3E7MLYXJzAKfZBhGD31tTC2k0HdhGvHiaySzscQ_-GtQoVpJWDqcpcpYr-PQp9AU045mJ1Vw9bY17Y6_i2CMnHbhSN70GnITS6JlcM4B5o7tdQVq1poPpJXRr_vM-g&h=mgeT4eNRwnr6A89swbvw09kPoD-gldqb-dl3olHFSKA
+  response:
+    body:
+      string: "{\n \"name\": \"2bd27134-dde2-4f4e-a74c-fbc8351f2a9b\",\n \"status\"\
+        : \"InProgress\",\n \"startTime\": \"2026-07-28T06:27:54.5134682Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:27:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/3fcfde91-85f2-4d7c-a3eb-b86eacbae1d6
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CC46CF8A5C474BB9905D70CC1F3EA5C2 Ref B: BN1AA2051012019 Ref C: 2026-07-28T06:27:55Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --vm-set-type --mode --node-vm-size --enable-cluster-autoscaler
+        --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/2bd27134-dde2-4f4e-a74c-fbc8351f2a9b?api-version=2025-03-01&t=639208168746313616&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=vWvHHdnf6iLnIVvgoJSaF3_u9JaeipQkS__t6ac0ikZUveJyTGB9LF7NO-KyNrPjnYieJtYN6nHOjZ8r9WwWTatiBg-Hz9exH46YHqPfi2wHis6GLv4DLwtept8P82M_fMKEL0fWhzNmq7yjrHu3l8W8GJXzJtMLmeLA1kqmjOHypxq65e6QzOW5Ev1LpHnoTHZ7-cNLHHBoAVX7qjAuIK8h3E7MLYXJzAKfZBhGD31tTC2k0HdhGvHiaySzscQ_-GtQoVpJWDqcpcpYr-PQp9AU045mJ1Vw9bY17Y6_i2CMnHbhSN70GnITS6JlcM4B5o7tdQVq1poPpJXRr_vM-g&h=mgeT4eNRwnr6A89swbvw09kPoD-gldqb-dl3olHFSKA
+  response:
+    body:
+      string: "{\n \"name\": \"2bd27134-dde2-4f4e-a74c-fbc8351f2a9b\",\n \"status\"\
+        : \"Succeeded\",\n \"startTime\": \"2026-07-28T06:27:54.5134682Z\",\n \"endTime\"\
+        : \"2026-07-28T06:28:17.8954578Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '165'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:28:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/f871348f-eab9-4534-959e-bf67a9515428
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5B630B1033B8492995D342638EC9E69D Ref B: BN1AA2051013027 Ref C: 2026-07-28T06:28:25Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --vm-set-type --mode --node-vm-size --enable-cluster-autoscaler
+        --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d2s_v3\"\
+        ,\n      \"minCount\": 0,\n      \"maxCount\": 3\n     }\n    ]\n   }\n  },\n\
+        \  \"eTag\": \"23388b8c-9d4f-4655-bd9f-0f9b27d76a1d\"\n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1345'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:28:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/b7b4151e-63d4-4475-ad23-0217244e1857
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 80241C3A827B4AA5B3C69DF3D63078F4 Ref B: BN1AA2051015023 Ref C: 2026-07-28T06:28:26Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d2s_v3\"\
+        ,\n      \"minCount\": 0,\n      \"maxCount\": 3\n     }\n    ]\n   }\n  },\n\
+        \  \"eTag\": \"23388b8c-9d4f-4655-bd9f-0f9b27d76a1d\"\n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1345'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:28:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/cabac37a-8366-4979-b954-d9c9e09eca36
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 790354F49BCE49DC88A4A30DD4506DC1 Ref B: BN1AA2051015009 Ref C: 2026-07-28T06:28:27Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"count": null, "vmSize": "", "osDiskSizeGB": 128, "osDiskType":
+      "Managed", "kubeletDiskType": "OS", "maxPods": 250, "type": "VirtualMachines",
+      "enableAutoScaling": false, "scaleDownMode": "Delete", "powerState": {"code":
+      "Running"}, "orchestratorVersion": "1.35", "enableNodePublicIP": false, "mode":
+      "User", "enableEncryptionAtHost": false, "enableUltraSSD": false, "osType":
+      "Linux", "osSKU": "Ubuntu", "nodeImageVersion": "AKSUbuntu-2404gen2containerd-202607.09.0",
+      "upgradeSettings": {"maxSurge": "10%", "undrainableNodeBehavior": "Schedule",
+      "maxUnavailable": "0"}, "enableFIPS": false, "securityProfile": {"sshAccess":
+      "LocalUser", "enableVTPM": false, "enableSecureBoot": false}, "virtualMachinesProfile":
+      {"scale": {"autoscale": [{"size": "standard_d4s_v3", "minCount": 1, "maxCount":
+      5}]}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '816'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Updating\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     }\n    ]\n   }\n  },\n\
+        \  \"eTag\": \"383d131e-c8d5-4222-9a8d-8a3e2be6b35e\"\n }\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e401e4db-24bd-43eb-9ea2-95bcf063fd43?api-version=2025-03-01&t=639208169170393102&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WS64pWUnnQ8Y3UQs1i9VXqbwRk4wfhYJyw1lcRPJvNNlu6sYe-r0GWv0PyskMAA_NF433sFjZZYWDZ_Wup89fRHbYiIlxv9rRVMJLdxdFNQef1dvBMLIMEIOcKKREAxEROk_bsrurS0Gg59IPRMkm6hQ3kkpeQ_YVlaxJH1jt9RSg7pAnMQTw8fi77T9vLL5DTLLtihhZiGHqH-cGVYEBht0wgekvCEpcqHlbJ8XohYpft4tvBwGFQooOGUHfi03XkCivgKeJJgeISCD-up03YWGk4GkpsIzzgbPmpshI0z5ia7KgM4ecY8VTG1RWJJDt6blIETWs08LckycAOJ7sA&h=SrZH9MVvuCC56jR12ojIz669_3HaB9f-KatGlGKW-ic
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:28:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/25551fed-9d81-4790-93f6-ddd2d462aa1d
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: C4F946141C0B4B3F9DA991E3D3B03A5B Ref B: BN1AA2051014021 Ref C: 2026-07-28T06:28:28Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e401e4db-24bd-43eb-9ea2-95bcf063fd43?api-version=2025-03-01&t=639208169170393102&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WS64pWUnnQ8Y3UQs1i9VXqbwRk4wfhYJyw1lcRPJvNNlu6sYe-r0GWv0PyskMAA_NF433sFjZZYWDZ_Wup89fRHbYiIlxv9rRVMJLdxdFNQef1dvBMLIMEIOcKKREAxEROk_bsrurS0Gg59IPRMkm6hQ3kkpeQ_YVlaxJH1jt9RSg7pAnMQTw8fi77T9vLL5DTLLtihhZiGHqH-cGVYEBht0wgekvCEpcqHlbJ8XohYpft4tvBwGFQooOGUHfi03XkCivgKeJJgeISCD-up03YWGk4GkpsIzzgbPmpshI0z5ia7KgM4ecY8VTG1RWJJDt6blIETWs08LckycAOJ7sA&h=SrZH9MVvuCC56jR12ojIz669_3HaB9f-KatGlGKW-ic
+  response:
+    body:
+      string: "{\n \"name\": \"e401e4db-24bd-43eb-9ea2-95bcf063fd43\",\n \"status\"\
+        : \"InProgress\",\n \"startTime\": \"2026-07-28T06:28:36.9565545Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:28:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/a79699bc-e036-4caa-9381-40f26476107b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 699F4DB14C2C456D8DF5932D67CDA34F Ref B: BN1AA2051014027 Ref C: 2026-07-28T06:28:37Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e401e4db-24bd-43eb-9ea2-95bcf063fd43?api-version=2025-03-01&t=639208169170393102&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WS64pWUnnQ8Y3UQs1i9VXqbwRk4wfhYJyw1lcRPJvNNlu6sYe-r0GWv0PyskMAA_NF433sFjZZYWDZ_Wup89fRHbYiIlxv9rRVMJLdxdFNQef1dvBMLIMEIOcKKREAxEROk_bsrurS0Gg59IPRMkm6hQ3kkpeQ_YVlaxJH1jt9RSg7pAnMQTw8fi77T9vLL5DTLLtihhZiGHqH-cGVYEBht0wgekvCEpcqHlbJ8XohYpft4tvBwGFQooOGUHfi03XkCivgKeJJgeISCD-up03YWGk4GkpsIzzgbPmpshI0z5ia7KgM4ecY8VTG1RWJJDt6blIETWs08LckycAOJ7sA&h=SrZH9MVvuCC56jR12ojIz669_3HaB9f-KatGlGKW-ic
+  response:
+    body:
+      string: "{\n \"name\": \"e401e4db-24bd-43eb-9ea2-95bcf063fd43\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:28:36.9565545Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '139'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:29:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/9c1fce34-798d-4abe-95ff-9fe3844bf910
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0EC27D40B1A043B0A2FF84F528B0FA54 Ref B: BN1AA2051013031 Ref C: 2026-07-28T06:29:07Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e401e4db-24bd-43eb-9ea2-95bcf063fd43?api-version=2025-03-01&t=639208169170393102&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WS64pWUnnQ8Y3UQs1i9VXqbwRk4wfhYJyw1lcRPJvNNlu6sYe-r0GWv0PyskMAA_NF433sFjZZYWDZ_Wup89fRHbYiIlxv9rRVMJLdxdFNQef1dvBMLIMEIOcKKREAxEROk_bsrurS0Gg59IPRMkm6hQ3kkpeQ_YVlaxJH1jt9RSg7pAnMQTw8fi77T9vLL5DTLLtihhZiGHqH-cGVYEBht0wgekvCEpcqHlbJ8XohYpft4tvBwGFQooOGUHfi03XkCivgKeJJgeISCD-up03YWGk4GkpsIzzgbPmpshI0z5ia7KgM4ecY8VTG1RWJJDt6blIETWs08LckycAOJ7sA&h=SrZH9MVvuCC56jR12ojIz669_3HaB9f-KatGlGKW-ic
+  response:
+    body:
+      string: "{\n \"name\": \"e401e4db-24bd-43eb-9ea2-95bcf063fd43\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:28:36.9565545Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '139'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:29:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/c66a3e11-e5ee-4909-854a-7c0341bbe2f6
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9FF897355C48417EB26A5193931F6302 Ref B: BN1AA2051012035 Ref C: 2026-07-28T06:29:38Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e401e4db-24bd-43eb-9ea2-95bcf063fd43?api-version=2025-03-01&t=639208169170393102&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WS64pWUnnQ8Y3UQs1i9VXqbwRk4wfhYJyw1lcRPJvNNlu6sYe-r0GWv0PyskMAA_NF433sFjZZYWDZ_Wup89fRHbYiIlxv9rRVMJLdxdFNQef1dvBMLIMEIOcKKREAxEROk_bsrurS0Gg59IPRMkm6hQ3kkpeQ_YVlaxJH1jt9RSg7pAnMQTw8fi77T9vLL5DTLLtihhZiGHqH-cGVYEBht0wgekvCEpcqHlbJ8XohYpft4tvBwGFQooOGUHfi03XkCivgKeJJgeISCD-up03YWGk4GkpsIzzgbPmpshI0z5ia7KgM4ecY8VTG1RWJJDt6blIETWs08LckycAOJ7sA&h=SrZH9MVvuCC56jR12ojIz669_3HaB9f-KatGlGKW-ic
+  response:
+    body:
+      string: "{\n \"name\": \"e401e4db-24bd-43eb-9ea2-95bcf063fd43\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:28:36.9565545Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '139'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:30:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/5e061d8f-c544-4fa0-a316-41b0e615f24a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3C4ABD0A75EA418A99D9C00ECCCC1464 Ref B: BN1AA2051014033 Ref C: 2026-07-28T06:30:08Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e401e4db-24bd-43eb-9ea2-95bcf063fd43?api-version=2025-03-01&t=639208169170393102&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WS64pWUnnQ8Y3UQs1i9VXqbwRk4wfhYJyw1lcRPJvNNlu6sYe-r0GWv0PyskMAA_NF433sFjZZYWDZ_Wup89fRHbYiIlxv9rRVMJLdxdFNQef1dvBMLIMEIOcKKREAxEROk_bsrurS0Gg59IPRMkm6hQ3kkpeQ_YVlaxJH1jt9RSg7pAnMQTw8fi77T9vLL5DTLLtihhZiGHqH-cGVYEBht0wgekvCEpcqHlbJ8XohYpft4tvBwGFQooOGUHfi03XkCivgKeJJgeISCD-up03YWGk4GkpsIzzgbPmpshI0z5ia7KgM4ecY8VTG1RWJJDt6blIETWs08LckycAOJ7sA&h=SrZH9MVvuCC56jR12ojIz669_3HaB9f-KatGlGKW-ic
+  response:
+    body:
+      string: "{\n \"name\": \"e401e4db-24bd-43eb-9ea2-95bcf063fd43\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:28:36.9565545Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '139'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:30:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/329877c1-18c5-4dca-a23e-04429d1a1b6e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E98EF833207542139E8FC0C1A87EA5A1 Ref B: BN1AA2051013051 Ref C: 2026-07-28T06:30:39Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e401e4db-24bd-43eb-9ea2-95bcf063fd43?api-version=2025-03-01&t=639208169170393102&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WS64pWUnnQ8Y3UQs1i9VXqbwRk4wfhYJyw1lcRPJvNNlu6sYe-r0GWv0PyskMAA_NF433sFjZZYWDZ_Wup89fRHbYiIlxv9rRVMJLdxdFNQef1dvBMLIMEIOcKKREAxEROk_bsrurS0Gg59IPRMkm6hQ3kkpeQ_YVlaxJH1jt9RSg7pAnMQTw8fi77T9vLL5DTLLtihhZiGHqH-cGVYEBht0wgekvCEpcqHlbJ8XohYpft4tvBwGFQooOGUHfi03XkCivgKeJJgeISCD-up03YWGk4GkpsIzzgbPmpshI0z5ia7KgM4ecY8VTG1RWJJDt6blIETWs08LckycAOJ7sA&h=SrZH9MVvuCC56jR12ojIz669_3HaB9f-KatGlGKW-ic
+  response:
+    body:
+      string: "{\n \"name\": \"e401e4db-24bd-43eb-9ea2-95bcf063fd43\",\n \"status\"\
+        : \"Succeeded\",\n \"startTime\": \"2026-07-28T06:28:36.9565545Z\",\n \"endTime\"\
+        : \"2026-07-28T06:30:40.6477737Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '165'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:31:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/0b7592a1-e99e-48a8-8e12-0df5f2921c76
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F876EB7C5A914C7E81CDF0656FED87EC Ref B: BN1AA2051015011 Ref C: 2026-07-28T06:31:09Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     }\n    ]\n   }\n  },\n\
+        \  \"virtualMachineNodesStatus\": [\n   {\n    \"size\": \"Standard_D4s_v3\"\
+        ,\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"da16a644-25b5-4cfc-a489-1d4d2d18c630\"\
+        \n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1439'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:31:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/1df18747-d8c1-4973-b05b-995b92e7ace4
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2C86F791A2954022B013EB85CF5D616F Ref B: BN1AA2051012021 Ref C: 2026-07-28T06:31:10Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     }\n    ]\n   }\n  },\n\
+        \  \"virtualMachineNodesStatus\": [\n   {\n    \"size\": \"Standard_D4s_v3\"\
+        ,\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"da16a644-25b5-4cfc-a489-1d4d2d18c630\"\
+        \n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1439'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:31:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/5a478c8f-e2e1-4e4b-ad48-35e79788ee8a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9E4E494918DF4B999C53EB514B195E4F Ref B: BN1AA2051013025 Ref C: 2026-07-28T06:31:11Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"count": null, "vmSize": "", "osDiskSizeGB": 128, "osDiskType":
+      "Managed", "kubeletDiskType": "OS", "maxPods": 250, "type": "VirtualMachines",
+      "enableAutoScaling": false, "scaleDownMode": "Delete", "powerState": {"code":
+      "Running"}, "orchestratorVersion": "1.35", "enableNodePublicIP": false, "mode":
+      "User", "enableEncryptionAtHost": false, "enableUltraSSD": false, "osType":
+      "Linux", "osSKU": "Ubuntu", "nodeImageVersion": "AKSUbuntu-2404gen2containerd-202607.09.0",
+      "upgradeSettings": {"maxSurge": "10%", "undrainableNodeBehavior": "Schedule",
+      "maxUnavailable": "0"}, "enableFIPS": false, "securityProfile": {"sshAccess":
+      "LocalUser", "enableVTPM": false, "enableSecureBoot": false}, "virtualMachinesProfile":
+      {"scale": {"autoscale": [{"size": "standard_d4s_v3", "minCount": 1, "maxCount":
+      5}, {"size": "standard_d2s_v3", "minCount": 1, "maxCount": 3}]}}, "virtualMachineNodesStatus":
+      [{"size": "Standard_D4s_v3", "count": 1}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '947'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Updating\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     },\n     {\n      \"\
+        size\": \"standard_d2s_v3\",\n      \"minCount\": 1,\n      \"maxCount\":\
+        \ 3\n     }\n    ]\n   }\n  },\n  \"virtualMachineNodesStatus\": [\n   {\n\
+        \    \"size\": \"Standard_D4s_v3\",\n    \"count\": 1\n   }\n  ],\n  \"eTag\"\
+        : \"f951c8d3-94b6-4e24-b790-8e8363976a5e\"\n }\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/dc68bca9-bd9a-4a25-8bb6-dbbd735fca30?api-version=2025-03-01&t=639208170811824488&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ftBsOVU7z21xvuN5SY2296FoyWzdyxWPwgw3t_JPh4vHs7YA_PjzWAdOdvpPlwQzksAGh2lMPlrki7LqSM404IRkfaSqkuAXy8p0HxxOconEe4OtOq6F7VvM5lQp7DO5ChPbs5iobjFwhWcSSUVb04F27d6R5D2r-lC2MlnPVyPToZn9Z5fYM2d9DHjAqvWpxtZHux2sws21oj58EPRwJhdfuknHOtMo72G-t_WKyPeW1Yykrae55nSwPucCkyCHT7ElyrTTql8FoEEhJZF4fBeH1awz1mfEV8WbaSDCV6qPxXpFaj6jYP7Fvx1SUUC5lTziTfcB2HpTQACRLsrF6Q&h=MQR91knT2XPa3c8ZaawDWw62-tK09iTTpJ5IuHtTrwg
+      cache-control:
+      - no-cache
+      content-length:
+      - '1527'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:31:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/bf93c51c-5a5e-4882-8c7e-fcd5c7833f6d
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: FF29561520444A5BBCCFC26767D493F7 Ref B: BN1AA2051013025 Ref C: 2026-07-28T06:31:12Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/dc68bca9-bd9a-4a25-8bb6-dbbd735fca30?api-version=2025-03-01&t=639208170811824488&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ftBsOVU7z21xvuN5SY2296FoyWzdyxWPwgw3t_JPh4vHs7YA_PjzWAdOdvpPlwQzksAGh2lMPlrki7LqSM404IRkfaSqkuAXy8p0HxxOconEe4OtOq6F7VvM5lQp7DO5ChPbs5iobjFwhWcSSUVb04F27d6R5D2r-lC2MlnPVyPToZn9Z5fYM2d9DHjAqvWpxtZHux2sws21oj58EPRwJhdfuknHOtMo72G-t_WKyPeW1Yykrae55nSwPucCkyCHT7ElyrTTql8FoEEhJZF4fBeH1awz1mfEV8WbaSDCV6qPxXpFaj6jYP7Fvx1SUUC5lTziTfcB2HpTQACRLsrF6Q&h=MQR91knT2XPa3c8ZaawDWw62-tK09iTTpJ5IuHtTrwg
+  response:
+    body:
+      string: "{\n \"name\": \"dc68bca9-bd9a-4a25-8bb6-dbbd735fca30\",\n \"status\"\
+        : \"InProgress\",\n \"startTime\": \"2026-07-28T06:31:21.09366Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '120'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:31:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/4efa3b35-5538-443a-8cac-60b94ddf1616
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 16D1EE72F8A545A0938C5EDBEC74A26F Ref B: BN1AA2051013029 Ref C: 2026-07-28T06:31:21Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/dc68bca9-bd9a-4a25-8bb6-dbbd735fca30?api-version=2025-03-01&t=639208170811824488&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ftBsOVU7z21xvuN5SY2296FoyWzdyxWPwgw3t_JPh4vHs7YA_PjzWAdOdvpPlwQzksAGh2lMPlrki7LqSM404IRkfaSqkuAXy8p0HxxOconEe4OtOq6F7VvM5lQp7DO5ChPbs5iobjFwhWcSSUVb04F27d6R5D2r-lC2MlnPVyPToZn9Z5fYM2d9DHjAqvWpxtZHux2sws21oj58EPRwJhdfuknHOtMo72G-t_WKyPeW1Yykrae55nSwPucCkyCHT7ElyrTTql8FoEEhJZF4fBeH1awz1mfEV8WbaSDCV6qPxXpFaj6jYP7Fvx1SUUC5lTziTfcB2HpTQACRLsrF6Q&h=MQR91knT2XPa3c8ZaawDWw62-tK09iTTpJ5IuHtTrwg
+  response:
+    body:
+      string: "{\n \"name\": \"dc68bca9-bd9a-4a25-8bb6-dbbd735fca30\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:31:21.09366Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '137'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:31:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/c632378a-b7d2-483d-8c1a-9ef605697deb
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DC6B0B9FB5E64CAC9C27D285DD825FDB Ref B: BN1AA2051015039 Ref C: 2026-07-28T06:31:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/dc68bca9-bd9a-4a25-8bb6-dbbd735fca30?api-version=2025-03-01&t=639208170811824488&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ftBsOVU7z21xvuN5SY2296FoyWzdyxWPwgw3t_JPh4vHs7YA_PjzWAdOdvpPlwQzksAGh2lMPlrki7LqSM404IRkfaSqkuAXy8p0HxxOconEe4OtOq6F7VvM5lQp7DO5ChPbs5iobjFwhWcSSUVb04F27d6R5D2r-lC2MlnPVyPToZn9Z5fYM2d9DHjAqvWpxtZHux2sws21oj58EPRwJhdfuknHOtMo72G-t_WKyPeW1Yykrae55nSwPucCkyCHT7ElyrTTql8FoEEhJZF4fBeH1awz1mfEV8WbaSDCV6qPxXpFaj6jYP7Fvx1SUUC5lTziTfcB2HpTQACRLsrF6Q&h=MQR91knT2XPa3c8ZaawDWw62-tK09iTTpJ5IuHtTrwg
+  response:
+    body:
+      string: "{\n \"name\": \"dc68bca9-bd9a-4a25-8bb6-dbbd735fca30\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:31:21.09366Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '137'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:32:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/2820bf63-e9b6-405a-92d4-21bdb783fd26
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DB976E38C41C41D580BDC258C5C339B7 Ref B: BN1AA2051015009 Ref C: 2026-07-28T06:32:22Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/dc68bca9-bd9a-4a25-8bb6-dbbd735fca30?api-version=2025-03-01&t=639208170811824488&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ftBsOVU7z21xvuN5SY2296FoyWzdyxWPwgw3t_JPh4vHs7YA_PjzWAdOdvpPlwQzksAGh2lMPlrki7LqSM404IRkfaSqkuAXy8p0HxxOconEe4OtOq6F7VvM5lQp7DO5ChPbs5iobjFwhWcSSUVb04F27d6R5D2r-lC2MlnPVyPToZn9Z5fYM2d9DHjAqvWpxtZHux2sws21oj58EPRwJhdfuknHOtMo72G-t_WKyPeW1Yykrae55nSwPucCkyCHT7ElyrTTql8FoEEhJZF4fBeH1awz1mfEV8WbaSDCV6qPxXpFaj6jYP7Fvx1SUUC5lTziTfcB2HpTQACRLsrF6Q&h=MQR91knT2XPa3c8ZaawDWw62-tK09iTTpJ5IuHtTrwg
+  response:
+    body:
+      string: "{\n \"name\": \"dc68bca9-bd9a-4a25-8bb6-dbbd735fca30\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:31:21.09366Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '137'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:32:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/ac762eac-b89a-4961-bc1c-2d067a339011
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: A0EFB02536354669A3113C88CEC401A5 Ref B: BN1AA2051015037 Ref C: 2026-07-28T06:32:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/dc68bca9-bd9a-4a25-8bb6-dbbd735fca30?api-version=2025-03-01&t=639208170811824488&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ftBsOVU7z21xvuN5SY2296FoyWzdyxWPwgw3t_JPh4vHs7YA_PjzWAdOdvpPlwQzksAGh2lMPlrki7LqSM404IRkfaSqkuAXy8p0HxxOconEe4OtOq6F7VvM5lQp7DO5ChPbs5iobjFwhWcSSUVb04F27d6R5D2r-lC2MlnPVyPToZn9Z5fYM2d9DHjAqvWpxtZHux2sws21oj58EPRwJhdfuknHOtMo72G-t_WKyPeW1Yykrae55nSwPucCkyCHT7ElyrTTql8FoEEhJZF4fBeH1awz1mfEV8WbaSDCV6qPxXpFaj6jYP7Fvx1SUUC5lTziTfcB2HpTQACRLsrF6Q&h=MQR91knT2XPa3c8ZaawDWw62-tK09iTTpJ5IuHtTrwg
+  response:
+    body:
+      string: "{\n \"name\": \"dc68bca9-bd9a-4a25-8bb6-dbbd735fca30\",\n \"status\"\
+        : \"Succeeded\",\n \"startTime\": \"2026-07-28T06:31:21.09366Z\",\n \"endTime\"\
+        : \"2026-07-28T06:33:18.5660753Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '163'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:33:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/fbc48a75-33fb-47b8-9123-6e26085a6572
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 876C19EE963445D18F6E52C9884B9950 Ref B: BN1AA2051012049 Ref C: 2026-07-28T06:33:23Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --node-vm-size --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     },\n     {\n      \"\
+        size\": \"standard_d2s_v3\",\n      \"minCount\": 1,\n      \"maxCount\":\
+        \ 3\n     }\n    ]\n   }\n  },\n  \"virtualMachineNodesStatus\": [\n   {\n\
+        \    \"size\": \"Standard_D4s_v3\",\n    \"count\": 1\n   },\n   {\n    \"\
+        size\": \"Standard_D2s_v3\",\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"\
+        f1d156bf-187a-4e84-85f0-db0fd1adb8e9\"\n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1585'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:33:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/3006c8ec-4c34-4a87-aff1-3e87e981669b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F14D5263836A4E66B90871D2993D1C4E Ref B: BN1AA2051013029 Ref C: 2026-07-28T06:33:23Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --yes
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     },\n     {\n      \"\
+        size\": \"standard_d2s_v3\",\n      \"minCount\": 1,\n      \"maxCount\":\
+        \ 3\n     }\n    ]\n   }\n  },\n  \"virtualMachineNodesStatus\": [\n   {\n\
+        \    \"size\": \"Standard_D4s_v3\",\n    \"count\": 1\n   },\n   {\n    \"\
+        size\": \"Standard_D2s_v3\",\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"\
+        f1d156bf-187a-4e84-85f0-db0fd1adb8e9\"\n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1585'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:33:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/c8db7611-da02-430d-9ab2-4383eb820fa7
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 7B5200E0305B4309B63490B15DA995AD Ref B: BN1AA2051014051 Ref C: 2026-07-28T06:33:25Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"count": null, "vmSize": "", "osDiskSizeGB": 128, "osDiskType":
+      "Managed", "kubeletDiskType": "OS", "maxPods": 250, "type": "VirtualMachines",
+      "enableAutoScaling": false, "scaleDownMode": "Delete", "powerState": {"code":
+      "Running"}, "orchestratorVersion": "1.35", "enableNodePublicIP": false, "mode":
+      "User", "enableEncryptionAtHost": false, "enableUltraSSD": false, "osType":
+      "Linux", "osSKU": "Ubuntu", "nodeImageVersion": "AKSUbuntu-2404gen2containerd-202607.09.0",
+      "upgradeSettings": {"maxSurge": "10%", "undrainableNodeBehavior": "Schedule",
+      "maxUnavailable": "0"}, "enableFIPS": false, "securityProfile": {"sshAccess":
+      "LocalUser", "enableVTPM": false, "enableSecureBoot": false}, "virtualMachinesProfile":
+      {"scale": {"autoscale": [{"size": "standard_d4s_v3", "minCount": 1, "maxCount":
+      5}]}}, "virtualMachineNodesStatus": [{"size": "Standard_D4s_v3", "count": 1},
+      {"size": "Standard_D2s_v3", "count": 1}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '929'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --yes
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Updating\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     }\n    ]\n   }\n  },\n\
+        \  \"virtualMachineNodesStatus\": [\n   {\n    \"size\": \"Standard_D4s_v3\"\
+        ,\n    \"count\": 1\n   },\n   {\n    \"size\": \"Standard_D2s_v3\",\n   \
+        \ \"count\": 1\n   }\n  ],\n  \"eTag\": \"60eb01bc-fd70-457c-b6cf-b9e644e93b04\"\
+        \n }\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/caee3f17-ab60-4c61-8650-049409743bc9?api-version=2025-03-01&t=639208172152963987&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=aD5gJniWqr0LmwmUcyf6IoOqkJBkAI7SjwwAjzah-ynw9AldPCKIPDUNcvqI7RGdir1yirdWQZkkNlE-0MhBjNliHAob1nyAf02PqQnYJMds565Zkk8WmJ__lfFhJTizfo9xyxelpZE5MNFO6jU1P7BgL2UQHEv34bxyb5G08z6EyECN-bAuJ5cao2AsC50bKk0uohxwEUTdXQj_b00ZCanPg2ceZTnWB1gh3u6C-EojePOrt48OvU0Mk6cAz_Q46od2al78GDio6o7AKlYRYau10AFVhAkVCUe3MXWAj9i6EHJQ3iQ5fi1xfeSvFJiaiH281JPTh_hJ2oCbxVsPSQ&h=wM_L-2phC8BejpiLkmqFIdhiTEiuQxkR5CDmNNeFoXs
+      cache-control:
+      - no-cache
+      content-length:
+      - '1495'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:33:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/f287b5ee-d681-4008-8956-0611d26bec6e
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 8C69666837104747B89CE67785B701E2 Ref B: BN1AA2051014047 Ref C: 2026-07-28T06:33:26Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --yes
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/caee3f17-ab60-4c61-8650-049409743bc9?api-version=2025-03-01&t=639208172152963987&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=aD5gJniWqr0LmwmUcyf6IoOqkJBkAI7SjwwAjzah-ynw9AldPCKIPDUNcvqI7RGdir1yirdWQZkkNlE-0MhBjNliHAob1nyAf02PqQnYJMds565Zkk8WmJ__lfFhJTizfo9xyxelpZE5MNFO6jU1P7BgL2UQHEv34bxyb5G08z6EyECN-bAuJ5cao2AsC50bKk0uohxwEUTdXQj_b00ZCanPg2ceZTnWB1gh3u6C-EojePOrt48OvU0Mk6cAz_Q46od2al78GDio6o7AKlYRYau10AFVhAkVCUe3MXWAj9i6EHJQ3iQ5fi1xfeSvFJiaiH281JPTh_hJ2oCbxVsPSQ&h=wM_L-2phC8BejpiLkmqFIdhiTEiuQxkR5CDmNNeFoXs
+  response:
+    body:
+      string: "{\n \"name\": \"caee3f17-ab60-4c61-8650-049409743bc9\",\n \"status\"\
+        : \"InProgress\",\n \"startTime\": \"2026-07-28T06:33:35.169557Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:33:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/eb82c972-7c3c-4301-b9dd-f52376c7d24c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9A23FE54FB564FE08F63102CE7DCEC29 Ref B: BN1AA2051014011 Ref C: 2026-07-28T06:33:35Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --yes
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/caee3f17-ab60-4c61-8650-049409743bc9?api-version=2025-03-01&t=639208172152963987&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=aD5gJniWqr0LmwmUcyf6IoOqkJBkAI7SjwwAjzah-ynw9AldPCKIPDUNcvqI7RGdir1yirdWQZkkNlE-0MhBjNliHAob1nyAf02PqQnYJMds565Zkk8WmJ__lfFhJTizfo9xyxelpZE5MNFO6jU1P7BgL2UQHEv34bxyb5G08z6EyECN-bAuJ5cao2AsC50bKk0uohxwEUTdXQj_b00ZCanPg2ceZTnWB1gh3u6C-EojePOrt48OvU0Mk6cAz_Q46od2al78GDio6o7AKlYRYau10AFVhAkVCUe3MXWAj9i6EHJQ3iQ5fi1xfeSvFJiaiH281JPTh_hJ2oCbxVsPSQ&h=wM_L-2phC8BejpiLkmqFIdhiTEiuQxkR5CDmNNeFoXs
+  response:
+    body:
+      string: "{\n \"name\": \"caee3f17-ab60-4c61-8650-049409743bc9\",\n \"status\"\
+        : \"ReconcilingAppSecurityGroup\",\n \"startTime\": \"2026-07-28T06:33:35.169557Z\"\
+        \n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '138'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:34:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/968012ab-6ad4-42d1-bc00-a4f032aa3d59
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4189ED98BB0E4B32AD09CCF67AF93108 Ref B: BN1AA2051014045 Ref C: 2026-07-28T06:34:06Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --yes
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/caee3f17-ab60-4c61-8650-049409743bc9?api-version=2025-03-01&t=639208172152963987&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=aD5gJniWqr0LmwmUcyf6IoOqkJBkAI7SjwwAjzah-ynw9AldPCKIPDUNcvqI7RGdir1yirdWQZkkNlE-0MhBjNliHAob1nyAf02PqQnYJMds565Zkk8WmJ__lfFhJTizfo9xyxelpZE5MNFO6jU1P7BgL2UQHEv34bxyb5G08z6EyECN-bAuJ5cao2AsC50bKk0uohxwEUTdXQj_b00ZCanPg2ceZTnWB1gh3u6C-EojePOrt48OvU0Mk6cAz_Q46od2al78GDio6o7AKlYRYau10AFVhAkVCUe3MXWAj9i6EHJQ3iQ5fi1xfeSvFJiaiH281JPTh_hJ2oCbxVsPSQ&h=wM_L-2phC8BejpiLkmqFIdhiTEiuQxkR5CDmNNeFoXs
+  response:
+    body:
+      string: "{\n \"name\": \"caee3f17-ab60-4c61-8650-049409743bc9\",\n \"status\"\
+        : \"Succeeded\",\n \"startTime\": \"2026-07-28T06:33:35.169557Z\",\n \"endTime\"\
+        : \"2026-07-28T06:34:10.2235959Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '164'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:34:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/fe8d85e3-5d83-4bc9-ac74-254161fa2d79
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9F6F9212D96D4123BEE9CC348F6540C3 Ref B: BN1AA2051013027 Ref C: 2026-07-28T06:34:36Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool auto-scale delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --current-node-vm-size --yes
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     }\n    ]\n   }\n  },\n\
+        \  \"virtualMachineNodesStatus\": [\n   {\n    \"size\": \"Standard_D4s_v3\"\
+        ,\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"95598f8b-4f3d-4135-87a1-6def5447dd26\"\
+        \n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1439'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:34:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/dacb5018-a4a4-4798-95e1-bab111c1bd23
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 89CEFD72F9734417B759CF169A2E1A9F Ref B: BN1AA2051012027 Ref C: 2026-07-28T06:34:37Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --disable-cluster-autoscaler
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 5\n     }\n    ]\n   }\n  },\n\
+        \  \"virtualMachineNodesStatus\": [\n   {\n    \"size\": \"Standard_D4s_v3\"\
+        ,\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"95598f8b-4f3d-4135-87a1-6def5447dd26\"\
+        \n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1439'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:34:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/fb0d97b7-a181-4e89-bcf5-7d579f2af49e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D99F26890F68450B82ACA0A179C34747 Ref B: BN1AA2051012021 Ref C: 2026-07-28T06:34:38Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"count": null, "vmSize": "", "osDiskSizeGB": 128, "osDiskType":
+      "Managed", "kubeletDiskType": "OS", "maxPods": 250, "type": "VirtualMachines",
+      "enableAutoScaling": false, "scaleDownMode": "Delete", "powerState": {"code":
+      "Running"}, "orchestratorVersion": "1.35", "enableNodePublicIP": false, "mode":
+      "User", "enableEncryptionAtHost": false, "enableUltraSSD": false, "osType":
+      "Linux", "osSKU": "Ubuntu", "nodeImageVersion": "AKSUbuntu-2404gen2containerd-202607.09.0",
+      "upgradeSettings": {"maxSurge": "10%", "undrainableNodeBehavior": "Schedule",
+      "maxUnavailable": "0"}, "enableFIPS": false, "securityProfile": {"sshAccess":
+      "LocalUser", "enableVTPM": false, "enableSecureBoot": false}, "virtualMachinesProfile":
+      {"scale": {"manual": [{"size": "standard_d4s_v3", "count": 1}]}}, "virtualMachineNodesStatus":
+      [{"size": "Standard_D4s_v3", "count": 1}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '867'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --cluster-name -n --disable-cluster-autoscaler
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Scaling\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"manual\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"count\": 1\n     }\n    ]\n   }\n  },\n  \"virtualMachineNodesStatus\"\
+        : [\n   {\n    \"size\": \"Standard_D4s_v3\",\n    \"count\": 1\n   }\n  ],\n\
+        \  \"eTag\": \"245c984c-a5e3-46ab-b49b-a8ce206a3f98\"\n }\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/09a2b4ed-bc32-4ed1-a746-11f7e31944b4?api-version=2025-03-01&t=639208172896646742&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WKXyoYEeieJRZvRacYosURLakD4AZNPJDonPnPA0I7lukKrIDR_lDtLRTHW44FytyVyJkmIJaLtQxPEjOj71Sk_GdU7JTmJ93m3QCvoG-rTZ-kwG2jXvVna3XMC_7FRW2gnkL2VKDnrwCkJPuFUHc9ZsxU8WpoiqSdhVlCOPTCAhD7deQEUuz1vEkKFc4qoT1FRsncCdZwDR9orB5zth0OiI_DQxCfdlmCTNOjgQjHuhz17MpkSEOhQSj647DVgSg7Z3kErqrRgUgAtY4UfYD9R5y-QZByJT6QwMTOf4cFaP4yapjs82N7fIzS1wc-L5hlHnKLlEk-uvmCvVYjCbSQ&h=lq0lIx4swLCA-Ht2gTTd2apdP5bA6UhusDqRlPA-drE
+      cache-control:
+      - no-cache
+      content-length:
+      - '1410'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:34:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/61ce025f-4781-4ce0-ba99-72494e9a310a
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 955FF6318BBC4D3FA557336DA6805841 Ref B: BN1AA2051012025 Ref C: 2026-07-28T06:34:39Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --disable-cluster-autoscaler
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/09a2b4ed-bc32-4ed1-a746-11f7e31944b4?api-version=2025-03-01&t=639208172896646742&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WKXyoYEeieJRZvRacYosURLakD4AZNPJDonPnPA0I7lukKrIDR_lDtLRTHW44FytyVyJkmIJaLtQxPEjOj71Sk_GdU7JTmJ93m3QCvoG-rTZ-kwG2jXvVna3XMC_7FRW2gnkL2VKDnrwCkJPuFUHc9ZsxU8WpoiqSdhVlCOPTCAhD7deQEUuz1vEkKFc4qoT1FRsncCdZwDR9orB5zth0OiI_DQxCfdlmCTNOjgQjHuhz17MpkSEOhQSj647DVgSg7Z3kErqrRgUgAtY4UfYD9R5y-QZByJT6QwMTOf4cFaP4yapjs82N7fIzS1wc-L5hlHnKLlEk-uvmCvVYjCbSQ&h=lq0lIx4swLCA-Ht2gTTd2apdP5bA6UhusDqRlPA-drE
+  response:
+    body:
+      string: "{\n \"name\": \"09a2b4ed-bc32-4ed1-a746-11f7e31944b4\",\n \"status\"\
+        : \"InProgress\",\n \"startTime\": \"2026-07-28T06:34:49.5825079Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:34:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/92438a2c-6344-428d-b113-f34932787481
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9F20EEE88BE0470B81D12A214FCA2BE3 Ref B: BN1AA2051015039 Ref C: 2026-07-28T06:34:49Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --disable-cluster-autoscaler
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/09a2b4ed-bc32-4ed1-a746-11f7e31944b4?api-version=2025-03-01&t=639208172896646742&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WKXyoYEeieJRZvRacYosURLakD4AZNPJDonPnPA0I7lukKrIDR_lDtLRTHW44FytyVyJkmIJaLtQxPEjOj71Sk_GdU7JTmJ93m3QCvoG-rTZ-kwG2jXvVna3XMC_7FRW2gnkL2VKDnrwCkJPuFUHc9ZsxU8WpoiqSdhVlCOPTCAhD7deQEUuz1vEkKFc4qoT1FRsncCdZwDR9orB5zth0OiI_DQxCfdlmCTNOjgQjHuhz17MpkSEOhQSj647DVgSg7Z3kErqrRgUgAtY4UfYD9R5y-QZByJT6QwMTOf4cFaP4yapjs82N7fIzS1wc-L5hlHnKLlEk-uvmCvVYjCbSQ&h=lq0lIx4swLCA-Ht2gTTd2apdP5bA6UhusDqRlPA-drE
+  response:
+    body:
+      string: "{\n \"name\": \"09a2b4ed-bc32-4ed1-a746-11f7e31944b4\",\n \"status\"\
+        : \"Succeeded\",\n \"startTime\": \"2026-07-28T06:34:49.5825079Z\",\n \"endTime\"\
+        : \"2026-07-28T06:35:10.815674Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '164'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:35:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/642f3b07-f53c-4545-8231-ce92f63e7216
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B8C182E8FDDF45D481CB3FD929350BC7 Ref B: BN1AA2051013019 Ref C: 2026-07-28T06:35:20Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --disable-cluster-autoscaler
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"manual\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"count\": 1\n     }\n    ]\n   }\n  },\n  \"virtualMachineNodesStatus\"\
+        : [\n   {\n    \"size\": \"Standard_D4s_v3\",\n    \"count\": 1\n   }\n  ],\n\
+        \  \"eTag\": \"fc45b94d-8ba3-4a57-b560-96c3e7ba9d14\"\n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1412'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:35:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/e9f2626e-04fe-45a3-986a-274cbc0c2fe1
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4F7F5BA0FA524CA484CA1E1F973114CF Ref B: BN1AA2051012051 Ref C: 2026-07-28T06:35:21Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --enable-cluster-autoscaler --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"manual\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"count\": 1\n     }\n    ]\n   }\n  },\n  \"virtualMachineNodesStatus\"\
+        : [\n   {\n    \"size\": \"Standard_D4s_v3\",\n    \"count\": 1\n   }\n  ],\n\
+        \  \"eTag\": \"fc45b94d-8ba3-4a57-b560-96c3e7ba9d14\"\n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1412'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:35:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/f6516ff8-383f-4fa8-9d69-1da9b32d1cba
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DDDFF7B81A0B477EBF0EC5BFC876D1FD Ref B: BN1AA2051012011 Ref C: 2026-07-28T06:35:22Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"count": null, "vmSize": "", "osDiskSizeGB": 128, "osDiskType":
+      "Managed", "kubeletDiskType": "OS", "maxPods": 250, "type": "VirtualMachines",
+      "enableAutoScaling": false, "scaleDownMode": "Delete", "powerState": {"code":
+      "Running"}, "orchestratorVersion": "1.35", "enableNodePublicIP": false, "mode":
+      "User", "enableEncryptionAtHost": false, "enableUltraSSD": false, "osType":
+      "Linux", "osSKU": "Ubuntu", "nodeImageVersion": "AKSUbuntu-2404gen2containerd-202607.09.0",
+      "upgradeSettings": {"maxSurge": "10%", "undrainableNodeBehavior": "Schedule",
+      "maxUnavailable": "0"}, "enableFIPS": false, "securityProfile": {"sshAccess":
+      "LocalUser", "enableVTPM": false, "enableSecureBoot": false}, "virtualMachinesProfile":
+      {"scale": {"autoscale": [{"size": "standard_d4s_v3", "minCount": 1, "maxCount":
+      3}]}}, "virtualMachineNodesStatus": [{"size": "Standard_D4s_v3", "count": 1}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '888'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --cluster-name -n --enable-cluster-autoscaler --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Updating\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 3\n     }\n    ]\n   }\n  },\n\
+        \  \"virtualMachineNodesStatus\": [\n   {\n    \"size\": \"Standard_D4s_v3\"\
+        ,\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"60870041-5713-445a-b7c5-fee289c51592\"\
+        \n }\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/212e006a-5a5a-4813-8429-5497fa68da2b?api-version=2025-03-01&t=639208173331954606&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=I-EODlnofx01K026RXDr89GjxhB55M8_pgA5yL9p0C7SjAlQHQgIRCrYLDGQBfwzzoEEoeLkStv87iuHwmNz1BT0aIQ_TsHpMULybOp2KNdbqa9H8YlNJZS-TDelUADOpAz6rBOrsrtxmbX7efS9cZWkMkhtZaJpqGIgkKlNLLYWZzlFrjHEDBOeODKE57pvKmlWT6s9OjOU9jQT15Ajj-G9i6egzhZQOkApmen13Mw7BRnsA6UfGgKt7ZvCaLNZwaWdDpSdT4XjNDsBh4i_FVnxfEC7IPiPlcJMbvUAF0FYWSGuR7kmDlUvG8IdEFT7_D4oNrDrOFjGuGjxsDqnPA&h=9ZGcBS4u9UAv0dGSj5QuOfLPK3I-Nx9doYzUk2EJ1IY
+      cache-control:
+      - no-cache
+      content-length:
+      - '1438'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:35:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/a7b6ea96-a807-4d77-9f4d-062e883d31fd
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 566567D999774A0E8294430BC298600F Ref B: BN1AA2051014021 Ref C: 2026-07-28T06:35:23Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --enable-cluster-autoscaler --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/212e006a-5a5a-4813-8429-5497fa68da2b?api-version=2025-03-01&t=639208173331954606&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=I-EODlnofx01K026RXDr89GjxhB55M8_pgA5yL9p0C7SjAlQHQgIRCrYLDGQBfwzzoEEoeLkStv87iuHwmNz1BT0aIQ_TsHpMULybOp2KNdbqa9H8YlNJZS-TDelUADOpAz6rBOrsrtxmbX7efS9cZWkMkhtZaJpqGIgkKlNLLYWZzlFrjHEDBOeODKE57pvKmlWT6s9OjOU9jQT15Ajj-G9i6egzhZQOkApmen13Mw7BRnsA6UfGgKt7ZvCaLNZwaWdDpSdT4XjNDsBh4i_FVnxfEC7IPiPlcJMbvUAF0FYWSGuR7kmDlUvG8IdEFT7_D4oNrDrOFjGuGjxsDqnPA&h=9ZGcBS4u9UAv0dGSj5QuOfLPK3I-Nx9doYzUk2EJ1IY
+  response:
+    body:
+      string: "{\n \"name\": \"212e006a-5a5a-4813-8429-5497fa68da2b\",\n \"status\"\
+        : \"InProgress\",\n \"startTime\": \"2026-07-28T06:35:33.0712658Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:35:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus/aeb5723d-bc96-4c71-b369-73007523def8
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 68222C336CC248018C61692E2DB59D61 Ref B: BN1AA2051013033 Ref C: 2026-07-28T06:35:33Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --enable-cluster-autoscaler --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/212e006a-5a5a-4813-8429-5497fa68da2b?api-version=2025-03-01&t=639208173331954606&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=I-EODlnofx01K026RXDr89GjxhB55M8_pgA5yL9p0C7SjAlQHQgIRCrYLDGQBfwzzoEEoeLkStv87iuHwmNz1BT0aIQ_TsHpMULybOp2KNdbqa9H8YlNJZS-TDelUADOpAz6rBOrsrtxmbX7efS9cZWkMkhtZaJpqGIgkKlNLLYWZzlFrjHEDBOeODKE57pvKmlWT6s9OjOU9jQT15Ajj-G9i6egzhZQOkApmen13Mw7BRnsA6UfGgKt7ZvCaLNZwaWdDpSdT4XjNDsBh4i_FVnxfEC7IPiPlcJMbvUAF0FYWSGuR7kmDlUvG8IdEFT7_D4oNrDrOFjGuGjxsDqnPA&h=9ZGcBS4u9UAv0dGSj5QuOfLPK3I-Nx9doYzUk2EJ1IY
+  response:
+    body:
+      string: "{\n \"name\": \"212e006a-5a5a-4813-8429-5497fa68da2b\",\n \"status\"\
+        : \"Succeeded\",\n \"startTime\": \"2026-07-28T06:35:33.0712658Z\",\n \"endTime\"\
+        : \"2026-07-28T06:35:52.1605405Z\"\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '165'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:36:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/eastus2/f5fd3900-b217-4840-9e1a-36e7a1ba7014
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E13172829FDF4AFAAA9157D8A65CCC9B Ref B: BN1AA2051012037 Ref C: 2026-07-28T06:36:04Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks nodepool update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --cluster-name -n --enable-cluster-autoscaler --min-count --max-count
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool?api-version=2026-05-01
+  response:
+    body:
+      string: "{\n \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002/agentPools/vmspool\"\
+        ,\n \"name\": \"vmspool\",\n \"type\": \"Microsoft.ContainerService/managedClusters/agentPools\"\
+        ,\n \"properties\": {\n  \"count\": null,\n  \"vmSize\": \"\",\n  \"osDiskSizeGB\"\
+        : 128,\n  \"osDiskType\": \"Managed\",\n  \"kubeletDiskType\": \"OS\",\n \
+        \ \"maxPods\": 250,\n  \"type\": \"VirtualMachines\",\n  \"enableAutoScaling\"\
+        : false,\n  \"scaleDownMode\": \"Delete\",\n  \"provisioningState\": \"Succeeded\"\
+        ,\n  \"powerState\": {\n   \"code\": \"Running\"\n  },\n  \"orchestratorVersion\"\
+        : \"1.35\",\n  \"currentOrchestratorVersion\": \"1.35.6\",\n  \"enableNodePublicIP\"\
+        : false,\n  \"mode\": \"User\",\n  \"enableEncryptionAtHost\": false,\n  \"\
+        enableUltraSSD\": false,\n  \"osType\": \"Linux\",\n  \"osSKU\": \"Ubuntu\"\
+        ,\n  \"nodeImageVersion\": \"AKSUbuntu-2404gen2containerd-202607.09.0\",\n\
+        \  \"upgradeSettings\": {\n   \"maxSurge\": \"10%\",\n   \"undrainableNodeBehavior\"\
+        : \"Schedule\",\n   \"maxUnavailable\": \"0\"\n  },\n  \"enableFIPS\": false,\n\
+        \  \"securityProfile\": {\n   \"sshAccess\": \"LocalUser\",\n   \"enableVTPM\"\
+        : false,\n   \"enableSecureBoot\": false\n  },\n  \"virtualMachinesProfile\"\
+        : {\n   \"scale\": {\n    \"autoscale\": [\n     {\n      \"size\": \"standard_d4s_v3\"\
+        ,\n      \"minCount\": 1,\n      \"maxCount\": 3\n     }\n    ]\n   }\n  },\n\
+        \  \"virtualMachineNodesStatus\": [\n   {\n    \"size\": \"Standard_D4s_v3\"\
+        ,\n    \"count\": 1\n   }\n  ],\n  \"eTag\": \"57a10606-c044-44fa-ae18-62e74b6ec56a\"\
+        \n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1439'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Jul 2026 06:36:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/8e28dec1-86e4-45e3-9ced-1097fa78621c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 101756737D6B491B8465F2B180AF5B0C Ref B: BN1AA2051014029 Ref C: 2026-07-28T06:36:04Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --yes --no-wait
+      User-Agent:
+      - AZURECLI/2.88.0 (DOCKER) azsdk-python-core/1.39.0 Python/3.12.9 (Linux-6.8.0-1062-azure-x86_64-with-glibc2.38)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000002?api-version=2026-05-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operations/e74cf846-0589-4f8e-944f-94d53471b593?api-version=2025-03-01&t=639208173684047913&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=tUWy6L1YO3O75I0KYVOD4zd1_vGdey8lImJZMxfWiSWmIWhbS-hktULYzNRuNP7LYNAYyPRrmRbPrlIxo6hgDFSeGe5dLbjylyibQsxWA1U-iM7dxY6sxu-v7Kmjzq6bAWCj6pLTFnQg4sfEq2tSfYEEsaGIkEoe5NkeLCndtjjQ6eDQAKqlx9sNUywYU4k-hnOjN4ZsFA93J2Fjoa41gwgy1x3fRDpPu4IOewhj6TCIQUrE9MuEW_DqVBmz96cZl73dV4MYi1l4khJr-vgQ1-zqRSRKU-i_1fe4DT5Ws-RkflwJlG_ss085Lk6AAva2rR4m6RprhcmaDp4qCmRbFA&h=eKE_mUv3iKMcY7PLMOqWpDiecF5oqge0wqr1RSP3wkk
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 28 Jul 2026 06:36:08 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/westus2/operationresults/e74cf846-0589-4f8e-944f-94d53471b593?api-version=2025-03-01&t=639208173684360403&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=JrO4BdWWFXUa8DQhzM76SHs-YTvgdfhoFy-Y-M42jNjDb-8zbTnBRYkYP99tjVfElU6Jws0n8KIN-1LYmkft9NikRb0e0vAczgXmnmhiIuBgERqUYuMBN9wTGOqd1MQjpwrKlR_JXFrgw255q4xzbKn-zb1cbLvieDsJ8DR7qRPgLDSyI6VHoNmaXGSG4qhg_l5RWtFVhPzAnwZ304gmSnJIoIeiPcto_A0TEM65mi4QfcuCiGRKWF5gn1WBewuFqohBxnyyjE8g3_6kJMEosv8ExUY0kpYtQgMGXMjU_FboRDb8MsUtFqL-pNpdTsffPrNg9gYF0hzWLdoIwPzTyw&h=97Mfkv1VNw9Wn2wHflrr4aH3QYHIrBuVsL-1aW7l7jk
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - appId=705ac000-bf67-4eed-9ba0-9ee723df283a,tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=5af09b5f-af8f-4912-b9fb-db5c227ad834/westus2/d06893be-6a2a-44fa-a000-5738f62d7d92
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '799'
+      x-ms-ratelimit-remaining-subscription-global-deletes:
+      - '11999'
+      x-msedge-ref:
+      - 'Ref A: E26E1B22CE224F5DB6F75FC67A04A93A Ref B: BN1AA2051013053 Ref C: 2026-07-28T06:36:07Z'
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -1034,6 +1034,82 @@ class AKSAgentPoolContextCommonTestCase(unittest.TestCase):
         with self.assertRaises(DecoratorEarlyExitException):
             ctx_6.get_update_enable_disable_cluster_autoscaler_and_min_max_count()
 
+    def common_get_node_count_from_vms_agentpool(self):
+        ctx = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict({}),
+            self.models,
+            DecoratorMode.UPDATE,
+            self.agentpool_decorator_mode,
+        )
+        agentpool = self.create_initialized_agentpool_instance(
+            type_properties_type=CONST_VIRTUAL_MACHINES,
+            virtual_machines_profile=self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    manual=[
+                        self.models.ManualScaleProfile(size="Standard_D2s_v3", count=2),
+                        self.models.ManualScaleProfile(size="Standard_D4s_v3", count=3),
+                    ]
+                )
+            ),
+        )
+        ctx.attach_agentpool(agentpool)
+        self.assertEqual(ctx.get_node_count_from_vms_agentpool(agentpool), 5)
+
+    def common_get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms(self):
+        # enable autoscaler: default vm size should come from existing manual profile
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict(
+                {
+                    "update_cluster_autoscaler": False,
+                    "enable_cluster_autoscaler": True,
+                    "disable_cluster_autoscaler": False,
+                    "min_count": 1,
+                    "max_count": 3,
+                    "node_vm_size": None,
+                }
+            ),
+            self.models,
+            DecoratorMode.UPDATE,
+            self.agentpool_decorator_mode,
+        )
+        agentpool_1 = self.create_initialized_agentpool_instance(
+            type_properties_type=CONST_VIRTUAL_MACHINES,
+            virtual_machines_profile=self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    manual=[
+                        self.models.ManualScaleProfile(size="Standard_D2s_v3", count=2),
+                    ]
+                )
+            ),
+        )
+        ctx_1.attach_agentpool(agentpool_1)
+        self.assertEqual(
+            ctx_1.get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms(),
+            (True, False, 1, 3, "Standard_D2s_v3"),
+        )
+
+        # update-cluster-autoscaler is rejected for VirtualMachines pools
+        ctx_2 = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict(
+                {
+                    "update_cluster_autoscaler": True,
+                    "enable_cluster_autoscaler": False,
+                    "disable_cluster_autoscaler": False,
+                    "min_count": 1,
+                    "max_count": 3,
+                }
+            ),
+            self.models,
+            DecoratorMode.UPDATE,
+            self.agentpool_decorator_mode,
+        )
+        ctx_2.attach_agentpool(agentpool_1)
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx_2.get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms()
+
     def common_get_priority(self):
         # default
         ctx_1 = AKSAgentPoolContext(
@@ -1960,6 +2036,12 @@ class AKSAgentPoolContextStandaloneModeTestCase(AKSAgentPoolContextCommonTestCas
     def test_get_update_enable_disable_cluster_autoscaler_and_min_max_count(self):
         self.common_get_update_enable_disable_cluster_autoscaler_and_min_max_count()
 
+    def test_get_node_count_from_vms_agentpool(self):
+        self.common_get_node_count_from_vms_agentpool()
+
+    def test_get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms(self):
+        self.common_get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms()
+
     def test_get_priority(self):
         self.common_get_priority()
 
@@ -2161,6 +2243,12 @@ class AKSAgentPoolContextManagedClusterModeTestCase(AKSAgentPoolContextCommonTes
 
     def test_get_update_enable_disable_cluster_autoscaler_and_min_max_count(self):
         self.common_get_update_enable_disable_cluster_autoscaler_and_min_max_count()
+
+    def test_get_node_count_from_vms_agentpool(self):
+        self.common_get_node_count_from_vms_agentpool()
+
+    def test_get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms(self):
+        self.common_get_update_enable_disable_cluster_autoscaler_and_min_max_count_vmsize_vms()
 
     def test_get_priority(self):
         self.common_get_priority()
@@ -3263,6 +3351,75 @@ class AKSAgentPoolUpdateDecoratorCommonTestCase(unittest.TestCase):
         )
         self.assertEqual(dec_agentpool_2, grond_truth_agentpool_2)
 
+    def common_update_auto_scaler_properties_vms(self):
+        # enable autoscaler on VirtualMachines pool: manual -> autoscale conversion
+        dec_1 = AKSAgentPoolUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_cluster_autoscaler": True,
+                "disable_cluster_autoscaler": False,
+                "update_cluster_autoscaler": False,
+                "min_count": 1,
+                "max_count": 4,
+            },
+            self.resource_type,
+            self.agentpool_decorator_mode,
+        )
+        agentpool_1 = self.create_initialized_agentpool_instance(
+            type_properties_type=CONST_VIRTUAL_MACHINES,
+            virtual_machines_profile=self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    manual=[
+                        self.models.ManualScaleProfile(size="Standard_D2s_v3", count=2),
+                        self.models.ManualScaleProfile(size="Standard_D4s_v3", count=1),
+                    ]
+                )
+            ),
+        )
+        dec_1.context.attach_agentpool(agentpool_1)
+        dec_agentpool_1 = dec_1.update_auto_scaler_properties(agentpool_1)
+        self.assertEqual(len(dec_agentpool_1.virtual_machines_profile.scale.autoscale), 2)
+        self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[0].size, "Standard_D2s_v3")
+        self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[0].min_count, 1)
+        self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[0].max_count, 4)
+        self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[1].size, "Standard_D4s_v3")
+        self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[1].min_count, 1)
+        self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[1].max_count, 4)
+
+        # disable autoscaler on VirtualMachines pool: autoscale -> manual conversion
+        dec_2 = AKSAgentPoolUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_cluster_autoscaler": False,
+                "disable_cluster_autoscaler": True,
+                "update_cluster_autoscaler": False,
+                "min_count": None,
+                "max_count": None,
+            },
+            self.resource_type,
+            self.agentpool_decorator_mode,
+        )
+        agentpool_2 = self.create_initialized_agentpool_instance(
+            type_properties_type=CONST_VIRTUAL_MACHINES,
+            virtual_machines_profile=self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    autoscale=[
+                        self.models.AutoScaleProfile(size="Standard_D2s_v3", min_count=2, max_count=5),
+                        self.models.AutoScaleProfile(size="Standard_D4s_v3", min_count=1, max_count=4),
+                    ]
+                )
+            ),
+        )
+        dec_2.context.attach_agentpool(agentpool_2)
+        dec_agentpool_2 = dec_2.update_auto_scaler_properties(agentpool_2)
+        self.assertEqual(len(dec_agentpool_2.virtual_machines_profile.scale.manual), 2)
+        self.assertEqual(dec_agentpool_2.virtual_machines_profile.scale.manual[0].size, "Standard_D2s_v3")
+        self.assertEqual(dec_agentpool_2.virtual_machines_profile.scale.manual[0].count, 2)
+        self.assertEqual(dec_agentpool_2.virtual_machines_profile.scale.manual[1].size, "Standard_D4s_v3")
+        self.assertEqual(dec_agentpool_2.virtual_machines_profile.scale.manual[1].count, 1)
+
     def common_update_label_tag_taint(self):
         dec_1 = AKSAgentPoolUpdateDecorator(
             self.cmd,
@@ -3672,6 +3829,9 @@ class AKSAgentPoolUpdateDecoratorStandaloneModeTestCase(AKSAgentPoolUpdateDecora
     def test_update_auto_scaler_properties(self):
         self.common_update_auto_scaler_properties()
 
+    def test_update_auto_scaler_properties_vms(self):
+        self.common_update_auto_scaler_properties_vms()
+
     def test_update_label_tag_taint(self):
         self.common_update_label_tag_taint()
 
@@ -3808,6 +3968,9 @@ class AKSAgentPoolUpdateDecoratorManagedClusterModeTestCase(AKSAgentPoolUpdateDe
 
     def test_update_auto_scaler_properties(self):
         self.common_update_auto_scaler_properties()
+
+    def test_update_auto_scaler_properties_vms(self):
+        self.common_update_auto_scaler_properties_vms()
 
     def test_update_label_tag_taint(self):
         self.common_update_label_tag_taint()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -1044,14 +1044,10 @@ class AKSAgentPoolContextCommonTestCase(unittest.TestCase):
         )
         agentpool = self.create_initialized_agentpool_instance(
             type_properties_type=CONST_VIRTUAL_MACHINES,
-            virtual_machines_profile=self.models.VirtualMachinesProfile(
-                scale=self.models.ScaleProfile(
-                    manual=[
-                        self.models.ManualScaleProfile(size="Standard_D2s_v3", count=2),
-                        self.models.ManualScaleProfile(size="Standard_D4s_v3", count=3),
-                    ]
-                )
-            ),
+            virtual_machine_nodes_status=[
+                self.models.VirtualMachineNodes(size="Standard_D2s_v3", count=2),
+                self.models.VirtualMachineNodes(size="Standard_D4s_v3", count=3),
+            ],
         )
         ctx.attach_agentpool(agentpool)
         self.assertEqual(ctx.get_node_count_from_vms_agentpool(agentpool), 5)
@@ -3413,7 +3409,6 @@ class AKSAgentPoolUpdateDecoratorCommonTestCase(unittest.TestCase):
             self.agentpool_decorator_mode,
         )
         agentpool_1 = self.create_initialized_agentpool_instance(
-            type_properties_type=CONST_VIRTUAL_MACHINES,
             virtual_machines_profile=self.models.VirtualMachinesProfile(
                 scale=self.models.ScaleProfile(
                     manual=[
@@ -3423,8 +3418,14 @@ class AKSAgentPoolUpdateDecoratorCommonTestCase(unittest.TestCase):
                 )
             ),
         )
+        if self.agentpool_decorator_mode == AgentPoolDecoratorMode.MANAGED_CLUSTER:
+            agentpool_1.type = CONST_VIRTUAL_MACHINES
+        else:
+            if agentpool_1.properties is None:
+                agentpool_1.properties = self.models.AgentPoolManagedClusterAgentPoolProfileProperties()
+            agentpool_1.properties.type_properties_type = CONST_VIRTUAL_MACHINES
         dec_1.context.attach_agentpool(agentpool_1)
-        dec_agentpool_1 = dec_1.update_auto_scaler_properties(agentpool_1)
+        dec_agentpool_1 = dec_1.update_auto_scaler_properties_vms(agentpool_1)
         self.assertEqual(len(dec_agentpool_1.virtual_machines_profile.scale.autoscale), 2)
         self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[0].size, "Standard_D2s_v3")
         self.assertEqual(dec_agentpool_1.virtual_machines_profile.scale.autoscale[0].min_count, 1)
@@ -3448,7 +3449,6 @@ class AKSAgentPoolUpdateDecoratorCommonTestCase(unittest.TestCase):
             self.agentpool_decorator_mode,
         )
         agentpool_2 = self.create_initialized_agentpool_instance(
-            type_properties_type=CONST_VIRTUAL_MACHINES,
             virtual_machines_profile=self.models.VirtualMachinesProfile(
                 scale=self.models.ScaleProfile(
                     autoscale=[
@@ -3458,8 +3458,14 @@ class AKSAgentPoolUpdateDecoratorCommonTestCase(unittest.TestCase):
                 )
             ),
         )
+        if self.agentpool_decorator_mode == AgentPoolDecoratorMode.MANAGED_CLUSTER:
+            agentpool_2.type = CONST_VIRTUAL_MACHINES
+        else:
+            if agentpool_2.properties is None:
+                agentpool_2.properties = self.models.AgentPoolManagedClusterAgentPoolProfileProperties()
+            agentpool_2.properties.type_properties_type = CONST_VIRTUAL_MACHINES
         dec_2.context.attach_agentpool(agentpool_2)
-        dec_agentpool_2 = dec_2.update_auto_scaler_properties(agentpool_2)
+        dec_agentpool_2 = dec_2.update_auto_scaler_properties_vms(agentpool_2)
         self.assertEqual(len(dec_agentpool_2.virtual_machines_profile.scale.manual), 2)
         self.assertEqual(dec_agentpool_2.virtual_machines_profile.scale.manual[0].size, "Standard_D2s_v3")
         self.assertEqual(dec_agentpool_2.virtual_machines_profile.scale.manual[0].count, 2)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -2908,6 +2908,9 @@ class AKSAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
             type=CONST_VIRTUAL_MACHINES,
             count=None,
             vm_size=None,
+            enable_auto_scaling=False,
+            min_count=None,
+            max_count=None,
             virtual_machines_profile=self.models.VirtualMachinesProfile(
                 scale=self.models.ScaleProfile(
                     manual=[
@@ -2920,6 +2923,49 @@ class AKSAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
             )
         )
         self.assertEqual(dec_agentpool_1, ground_truth_agentpool_1)
+
+        # VirtualMachines pool with cluster autoscaler enabled should be expressed through
+        # virtualMachinesProfile.scale.autoscale, not the VMSS-only enable_auto_scaling/min/max fields
+        dec_autoscale = AKSAgentPoolAddDecorator(
+            self.cmd,
+            self.client,
+            {
+                "vm_set_type": "VirtualMachines",
+                "vm_sizes": "Standard_D4s_v3",
+                "node_count": 3,
+                "enable_cluster_autoscaler": True,
+                "min_count": 2,
+                "max_count": 5,
+            },
+            self.resource_type,
+            self.agentpool_decorator_mode,
+        )
+        agentpool_autoscale = self.create_initialized_agentpool_instance(
+            type=CONST_VIRTUAL_MACHINES, restore_defaults=False
+        )
+        dec_autoscale.context.attach_agentpool(agentpool_autoscale)
+        dec_agentpool_autoscale = dec_autoscale.set_up_virtual_machines_profile(agentpool_autoscale)
+        dec_agentpool_autoscale = self._restore_defaults_in_agentpool(dec_agentpool_autoscale)
+        ground_truth_agentpool_autoscale = self.create_initialized_agentpool_instance(
+            type=CONST_VIRTUAL_MACHINES,
+            count=None,
+            vm_size=None,
+            enable_auto_scaling=False,
+            min_count=None,
+            max_count=None,
+            virtual_machines_profile=self.models.VirtualMachinesProfile(
+                scale=self.models.ScaleProfile(
+                    autoscale=[
+                        self.models.AutoScaleProfile(
+                            size="Standard_D4s_v3",
+                            min_count=2,
+                            max_count=5,
+                        )
+                    ]
+                )
+            )
+        )
+        self.assertEqual(dec_agentpool_autoscale, ground_truth_agentpool_autoscale)
 
         # fail on passing more than 1 vm_sizes
         dec_2 = AKSAgentPoolAddDecorator(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -15323,234 +15323,95 @@ spec:
 
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix="clitest", location="westus2")
-    def test_vms_cluster_create_and_add_autoscale_mode(self, resource_group, resource_group_location):
-        aks_name = self.create_random_name("cliakstest", 16)
-        autoscaled_pool_name = self.create_random_name("ap", 6)
+    def test_aks_create_autoscaler_then_update_vms_pool(self, resource_group, resource_group_location):
+        aks_name = self.create_random_name('cliakstest', 16)
+        self.kwargs.update({
+            'name': aks_name,
+            'resource_group': resource_group,
+            'nodepool_name': "vmspool",
+            "location": resource_group_location,
+            'node_vm_size1': "standard_d2s_v3",
+            'node_vm_size2': "standard_d4s_v3",
+            'ssh_key_value': self.generate_ssh_keys()
+        })
 
-        self.kwargs.update(
-            {
-                "resource_group": resource_group,
-                "name": aks_name,
-                "location": resource_group_location,
-                "ssh_key_value": self.generate_ssh_keys(),
-                "autoscaled_pool_name": autoscaled_pool_name,
-            }
-        )
+        # create cluster with autoscaler enabled
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
+                     '--ssh-key-value={ssh_key_value} ' \
+                     '--vm-set-type VirtualMachines ' \
+                     '--enable-cluster-autoscaler ' \
+                     '--node-vm-size={node_vm_size1} ' \
+                     '--min-count 1 --max-count 3'
+        self.cmd(create_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check("agentPoolProfiles[0].type", "VirtualMachines"),
+            self.check('agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].size', 'standard_d2s_v3'),
+            self.check('agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].minCount', 1),
+            self.check('agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
+        ])
 
-        # create cluster with VirtualMachines system node pool in autoscale mode
-        self.cmd(
-            "aks create "
-            "--resource-group {resource_group} "
-            "--name {name} "
-            "--location {location} "
-            "--ssh-key-value {ssh_key_value} "
-            "--vm-set-type VirtualMachines "
-            "--node-vm-size Standard_D4s_v3 "
-            "--enable-cluster-autoscaler "
-            "--min-count 2 "
-            "--max-count 5",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("agentPoolProfiles[0].type", "VirtualMachines"),
-                self.check("agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].size", "Standard_D4s_v3", False),
-                self.check("agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].minCount", "2"),
-                self.check("agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].maxCount", "5"),
-            ],
-        )
+        # add another vms nodepool with autoscaler enabled
+        add_nodepool_cmd = 'aks nodepool add -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
+                           '--vm-set-type VirtualMachines --mode user ' \
+                           '--node-vm-size {node_vm_size1} ' \
+                           '--enable-cluster-autoscaler ' \
+                           '--min-count 0 --max-count 3'
+        self.cmd(add_nodepool_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('virtualMachinesProfile.scale.autoscale[0].size', 'standard_d2s_v3'),
+            self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 0),
+            self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
+        ])
 
-        # add autoscaled VirtualMachines user nodepool
-        self.cmd(
-            "aks nodepool add "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {autoscaled_pool_name} "
-            "--vm-set-type VirtualMachines "
-            "--node-vm-size Standard_D4s_v3 "
-            "--enable-cluster-autoscaler "
-            "--min-count 2 "
-            "--max-count 5",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("typePropertiesType", "VirtualMachines"),
-                self.check("virtualMachinesProfile.scale.autoscale[0].size", "Standard_D4s_v3", False),
-                self.check("virtualMachinesProfile.scale.autoscale[0].minCount", "2"),
-                self.check("virtualMachinesProfile.scale.autoscale[0].maxCount", "5"),
-            ],
-        )
+        # update an existing autoscale profile using auto-scale update
+        update_autoscale_cmd = 'aks nodepool auto-scale update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
+                               '--current-node-vm-size {node_vm_size1} ' \
+                               '--node-vm-size {node_vm_size2} ' \
+                               '--min-count 1 --max-count 5'
+        self.cmd(update_autoscale_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('virtualMachinesProfile.scale.autoscale[0].size', 'standard_d4s_v3'),
+            self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 1),
+            self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 5),
+        ])
 
-        self.cmd(
-            "aks delete --resource-group {resource_group} --name {name} --yes --no-wait",
-            checks=[
-                self.is_empty(),
-            ],
-        )
+        # add a second autoscale profile
+        add_autoscale_cmd = 'aks nodepool auto-scale add -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
+                            '--node-vm-size {node_vm_size1} ' \
+                            '--min-count 1 --max-count 3'
+        self.cmd(add_autoscale_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('virtualMachinesProfile.scale.autoscale[1].size', 'standard_d2s_v3'),
+            self.check('virtualMachinesProfile.scale.autoscale[1].minCount', 1),
+            self.check('virtualMachinesProfile.scale.autoscale[1].maxCount', 3),
+        ])
 
-    @AllowLargeResponse()
-    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix="clitest", location="westus2")
-    def test_vms_agentpool_autoscale_commands(self, resource_group, resource_group_location):
-        aks_name = self.create_random_name("cliakstest", 16)
-        vmss_pool_name = self.create_random_name("vmss", 6)
-        vms_pool_name = self.create_random_name("vms", 6)
+        # delete the second autoscale profile
+        delete_autoscale_cmd = 'aks nodepool auto-scale delete -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
+                               '--current-node-vm-size {node_vm_size1}'
+        np = self.cmd(delete_autoscale_cmd).get_output_in_json()
+        assert len(np["virtualMachinesProfile"]["scale"]["autoscale"]) == 1
 
-        self.kwargs.update(
-            {
-                "resource_group": resource_group,
-                "name": aks_name,
-                "location": resource_group_location,
-                "ssh_key_value": self.generate_ssh_keys(),
-                "vmss_pool_name": vmss_pool_name,
-                "vms_pool_name": vms_pool_name,
-            }
-        )
+        # disable autoscaler (auto to manual)
+        disable_autoscaler_cmd = 'aks nodepool update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
+                                 '--disable-cluster-autoscaler'
+        self.cmd(disable_autoscaler_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('virtualMachinesProfile.scale.manual[0].size', 'standard_d4s_v3'),
+        ])
 
-        self.cmd(
-            "aks create "
-            "--resource-group {resource_group} "
-            "--name {name} "
-            "--location {location} "
-            "--ssh-key-value {ssh_key_value} "
-            "--nodepool-name {vmss_pool_name} "
-            "--node-vm-size Standard_D2s_v3 "
-            "--node-count 1",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("agentPoolProfiles[0].name", "{vmss_pool_name}"),
-            ],
-        )
+        # enable autoscaler (manual to auto)
+        enable_autoscaler_cmd = 'aks nodepool update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
+                                '--enable-cluster-autoscaler --min-count 1 --max-count 3'
+        self.cmd(enable_autoscaler_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('virtualMachinesProfile.scale.autoscale[0].size', 'standard_d4s_v3'),
+            self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 1),
+            self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
+        ])
 
-        self.cmd(
-            "aks nodepool add "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--vm-set-type VirtualMachines "
-            "--vm-sizes Standard_D2s_v3 "
-            "--node-count 2",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("typePropertiesType", "VirtualMachines"),
-                self.check("virtualMachinesProfile.scale.manual[0].size", "Standard_D2s_v3", False),
-                self.check("virtualMachinesProfile.scale.manual[0].count", "2"),
-            ],
-        )
-
-        self.cmd(
-            "aks nodepool manual-scale add "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--vm-sizes Standard_DS2_v2 "
-            "--node-count 1",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("virtualMachinesProfile.scale.manual[1].size", "Standard_DS2_v2", False),
-                self.check("virtualMachinesProfile.scale.manual[1].count", "1"),
-            ],
-        )
-
-        # auto-scale command is valid only for VirtualMachines pools
-        self.cmd(
-            "aks nodepool auto-scale add "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vmss_pool_name} "
-            "--node-vm-size Standard_D4s_v3 "
-            "--min-count 1 "
-            "--max-count 3",
-            expect_failure=True,
-        )
-
-        self.cmd(
-            "aks nodepool update "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--enable-cluster-autoscaler "
-            "--min-count 1 "
-            "--max-count 4",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("virtualMachinesProfile.scale.autoscale[0].size", "Standard_D2s_v3", False),
-                self.check("virtualMachinesProfile.scale.autoscale[0].minCount", "1"),
-                self.check("virtualMachinesProfile.scale.autoscale[0].maxCount", "4"),
-                self.check("virtualMachinesProfile.scale.autoscale[1].size", "Standard_DS2_v2", False),
-                self.check("virtualMachinesProfile.scale.autoscale[1].minCount", "1"),
-                self.check("virtualMachinesProfile.scale.autoscale[1].maxCount", "4"),
-            ],
-        )
-
-        # update-cluster-autoscaler is not supported for VirtualMachines pools
-        self.cmd(
-            "aks nodepool update "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--update-cluster-autoscaler "
-            "--min-count 2 "
-            "--max-count 5",
-            expect_failure=True,
-        )
-
-        self.cmd(
-            "aks nodepool auto-scale add "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--node-vm-size Standard_D4s_v3 "
-            "--min-count 2 "
-            "--max-count 6",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("virtualMachinesProfile.scale.autoscale[2].size", "Standard_D4s_v3", False),
-                self.check("virtualMachinesProfile.scale.autoscale[2].minCount", "2"),
-                self.check("virtualMachinesProfile.scale.autoscale[2].maxCount", "6"),
-            ],
-        )
-
-        self.cmd(
-            "aks nodepool auto-scale update "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--current-node-vm-size Standard_D4s_v3 "
-            "--node-vm-size Standard_D8s_v3 "
-            "--min-count 3 "
-            "--max-count 7",
-            checks=[
-                self.check("provisioningState", "Succeeded"),
-                self.check("virtualMachinesProfile.scale.autoscale[2].size", "Standard_D8s_v3", False),
-                self.check("virtualMachinesProfile.scale.autoscale[2].minCount", "3"),
-                self.check("virtualMachinesProfile.scale.autoscale[2].maxCount", "7"),
-            ],
-        )
-
-        np = self.cmd(
-            "aks nodepool auto-scale delete "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--current-node-vm-size Standard_D8s_v3 "
-            "--yes"
-        ).get_output_in_json()
-        assert len(np["virtualMachinesProfile"]["scale"]["autoscale"]) == 2
-
-        np = self.cmd(
-            "aks nodepool update "
-            "--resource-group {resource_group} "
-            "--cluster-name {name} "
-            "--name {vms_pool_name} "
-            "--disable-cluster-autoscaler",
-        ).get_output_in_json()
-        assert len(np["virtualMachinesProfile"]["scale"]["manual"]) == 2
-        self.assertEqual(np["virtualMachinesProfile"]["scale"]["manual"][0]["count"], 1)
-        self.assertEqual(np["virtualMachinesProfile"]["scale"]["manual"][1]["count"], 1)
-
-        self.cmd(
-            "aks delete --resource-group {resource_group} --name {name} --yes --no-wait",
-            checks=[
-                self.is_empty(),
-            ],
-        )
+        # delete
+        self.cmd('aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
 
     @AllowLargeResponse()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -15388,7 +15388,7 @@ spec:
 
         # delete the second autoscale profile
         delete_autoscale_cmd = 'aks nodepool auto-scale delete -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
-                               '--current-node-vm-size {node_vm_size1}'
+                               '--current-node-vm-size {node_vm_size1} --yes'
         np = self.cmd(delete_autoscale_cmd).get_output_in_json()
         assert len(np["virtualMachinesProfile"]["scale"]["autoscale"]) == 1
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -15321,6 +15321,237 @@ spec:
             ],
         )
 
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix="clitest", location="westus2")
+    def test_vms_cluster_create_and_add_autoscale_mode(self, resource_group, resource_group_location):
+        aks_name = self.create_random_name("cliakstest", 16)
+        autoscaled_pool_name = self.create_random_name("ap", 6)
+
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "location": resource_group_location,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "autoscaled_pool_name": autoscaled_pool_name,
+            }
+        )
+
+        # create cluster with VirtualMachines system node pool in autoscale mode
+        self.cmd(
+            "aks create "
+            "--resource-group {resource_group} "
+            "--name {name} "
+            "--location {location} "
+            "--ssh-key-value {ssh_key_value} "
+            "--vm-set-type VirtualMachines "
+            "--node-vm-size Standard_D4s_v3 "
+            "--enable-cluster-autoscaler "
+            "--min-count 2 "
+            "--max-count 5",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("agentPoolProfiles[0].type", "VirtualMachines"),
+                self.check("agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].size", "Standard_D4s_v3", False),
+                self.check("agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].minCount", "2"),
+                self.check("agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].maxCount", "5"),
+            ],
+        )
+
+        # add autoscaled VirtualMachines user nodepool
+        self.cmd(
+            "aks nodepool add "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {autoscaled_pool_name} "
+            "--vm-set-type VirtualMachines "
+            "--node-vm-size Standard_D4s_v3 "
+            "--enable-cluster-autoscaler "
+            "--min-count 2 "
+            "--max-count 5",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("typePropertiesType", "VirtualMachines"),
+                self.check("virtualMachinesProfile.scale.autoscale[0].size", "Standard_D4s_v3", False),
+                self.check("virtualMachinesProfile.scale.autoscale[0].minCount", "2"),
+                self.check("virtualMachinesProfile.scale.autoscale[0].maxCount", "5"),
+            ],
+        )
+
+        self.cmd(
+            "aks delete --resource-group {resource_group} --name {name} --yes --no-wait",
+            checks=[
+                self.is_empty(),
+            ],
+        )
+
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix="clitest", location="westus2")
+    def test_vms_agentpool_autoscale_commands(self, resource_group, resource_group_location):
+        aks_name = self.create_random_name("cliakstest", 16)
+        vmss_pool_name = self.create_random_name("vmss", 6)
+        vms_pool_name = self.create_random_name("vms", 6)
+
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "location": resource_group_location,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "vmss_pool_name": vmss_pool_name,
+                "vms_pool_name": vms_pool_name,
+            }
+        )
+
+        self.cmd(
+            "aks create "
+            "--resource-group {resource_group} "
+            "--name {name} "
+            "--location {location} "
+            "--ssh-key-value {ssh_key_value} "
+            "--nodepool-name {vmss_pool_name} "
+            "--node-vm-size Standard_D2s_v3 "
+            "--node-count 1",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("agentPoolProfiles[0].name", "{vmss_pool_name}"),
+            ],
+        )
+
+        self.cmd(
+            "aks nodepool add "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--vm-set-type VirtualMachines "
+            "--vm-sizes Standard_D2s_v3 "
+            "--node-count 2",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("typePropertiesType", "VirtualMachines"),
+                self.check("virtualMachinesProfile.scale.manual[0].size", "Standard_D2s_v3", False),
+                self.check("virtualMachinesProfile.scale.manual[0].count", "2"),
+            ],
+        )
+
+        self.cmd(
+            "aks nodepool manual-scale add "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--vm-sizes Standard_DS2_v2 "
+            "--node-count 1",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("virtualMachinesProfile.scale.manual[1].size", "Standard_DS2_v2", False),
+                self.check("virtualMachinesProfile.scale.manual[1].count", "1"),
+            ],
+        )
+
+        # auto-scale command is valid only for VirtualMachines pools
+        self.cmd(
+            "aks nodepool auto-scale add "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vmss_pool_name} "
+            "--node-vm-size Standard_D4s_v3 "
+            "--min-count 1 "
+            "--max-count 3",
+            expect_failure=True,
+        )
+
+        self.cmd(
+            "aks nodepool update "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--enable-cluster-autoscaler "
+            "--min-count 1 "
+            "--max-count 4",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("virtualMachinesProfile.scale.autoscale[0].size", "Standard_D2s_v3", False),
+                self.check("virtualMachinesProfile.scale.autoscale[0].minCount", "1"),
+                self.check("virtualMachinesProfile.scale.autoscale[0].maxCount", "4"),
+                self.check("virtualMachinesProfile.scale.autoscale[1].size", "Standard_DS2_v2", False),
+                self.check("virtualMachinesProfile.scale.autoscale[1].minCount", "1"),
+                self.check("virtualMachinesProfile.scale.autoscale[1].maxCount", "4"),
+            ],
+        )
+
+        # update-cluster-autoscaler is not supported for VirtualMachines pools
+        self.cmd(
+            "aks nodepool update "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--update-cluster-autoscaler "
+            "--min-count 2 "
+            "--max-count 5",
+            expect_failure=True,
+        )
+
+        self.cmd(
+            "aks nodepool auto-scale add "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--node-vm-size Standard_D4s_v3 "
+            "--min-count 2 "
+            "--max-count 6",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("virtualMachinesProfile.scale.autoscale[2].size", "Standard_D4s_v3", False),
+                self.check("virtualMachinesProfile.scale.autoscale[2].minCount", "2"),
+                self.check("virtualMachinesProfile.scale.autoscale[2].maxCount", "6"),
+            ],
+        )
+
+        self.cmd(
+            "aks nodepool auto-scale update "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--current-node-vm-size Standard_D4s_v3 "
+            "--node-vm-size Standard_D8s_v3 "
+            "--min-count 3 "
+            "--max-count 7",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("virtualMachinesProfile.scale.autoscale[2].size", "Standard_D8s_v3", False),
+                self.check("virtualMachinesProfile.scale.autoscale[2].minCount", "3"),
+                self.check("virtualMachinesProfile.scale.autoscale[2].maxCount", "7"),
+            ],
+        )
+
+        np = self.cmd(
+            "aks nodepool auto-scale delete "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--current-node-vm-size Standard_D8s_v3 "
+            "--yes"
+        ).get_output_in_json()
+        assert len(np["virtualMachinesProfile"]["scale"]["autoscale"]) == 2
+
+        np = self.cmd(
+            "aks nodepool update "
+            "--resource-group {resource_group} "
+            "--cluster-name {name} "
+            "--name {vms_pool_name} "
+            "--disable-cluster-autoscaler",
+        ).get_output_in_json()
+        assert len(np["virtualMachinesProfile"]["scale"]["manual"]) == 2
+        self.assertEqual(np["virtualMachinesProfile"]["scale"]["manual"][0]["count"], 1)
+        self.assertEqual(np["virtualMachinesProfile"]["scale"]["manual"][1]["count"], 1)
+
+        self.cmd(
+            "aks delete --resource-group {resource_group} --name {name} --yes --no-wait",
+            checks=[
+                self.is_empty(),
+            ],
+        )
+
 
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -25,6 +25,9 @@ from azure.cli.command_modules.acs.addonconfiguration import (
 from azure.cli.command_modules.acs.custom import (
     _get_command_context,
     _update_addons,
+    aks_agentpool_auto_scale_add,
+    aks_agentpool_auto_scale_delete,
+    aks_agentpool_auto_scale_update,
     aks_agentpool_get_rollback_versions,
     aks_agentpool_rollback,
     aks_agentpool_upgrade,
@@ -57,7 +60,9 @@ from azure.mgmt.containerservice.models import (
     ManagedClusterAddonProfile,
 )
 from azure.cli.core.azclierror import (
+    ClientRequestError,
     InvalidArgumentValueError,
+    RequiredArgumentMissingError,
 )
 
 
@@ -1016,6 +1021,169 @@ class TestAKSCommand(unittest.TestCase):
         # Machines mode pool must not have orchestrator_version set; VMSS pool must be upgraded.
         self.assertIsNone(machines_pool.orchestrator_version)
         self.assertEqual(vmss_pool.orchestrator_version, "1.25.0")
+
+    @staticmethod
+    def _build_vms_agentpool(
+        pool_type="VirtualMachines",
+        manual_profiles=None,
+        autoscale_profiles=None,
+    ):
+        if manual_profiles is None:
+            manual_profiles = []
+        instance = mock.Mock()
+        instance.properties = mock.Mock()
+        instance.properties.type_properties_type = pool_type
+        instance.type_properties_type = pool_type
+        instance.virtual_machines_profile = mock.Mock()
+        instance.virtual_machines_profile.scale = mock.Mock()
+        instance.virtual_machines_profile.scale.manual = manual_profiles
+        instance.virtual_machines_profile.scale.autoscale = autoscale_profiles
+        return instance
+
+    def test_aks_agentpool_auto_scale_add_success(self):
+        class AutoScaleProfile:
+            def __init__(self, size, min_count, max_count):
+                self.size = size
+                self.min_count = min_count
+                self.max_count = max_count
+
+        instance = self._build_vms_agentpool(autoscale_profiles=None)
+        self.client.get = mock.Mock(return_value=instance)
+        self.client.begin_create_or_update = mock.Mock(return_value="ok")
+        self.cmd.get_models = mock.Mock(return_value=AutoScaleProfile)
+
+        result = aks_agentpool_auto_scale_add(
+            self.cmd,
+            self.client,
+            "rg",
+            "mc",
+            "np",
+            "Standard_D4s_v3",
+            2,
+            5,
+        )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(len(instance.virtual_machines_profile.scale.autoscale), 1)
+        profile = instance.virtual_machines_profile.scale.autoscale[0]
+        self.assertEqual(profile.size, "Standard_D4s_v3")
+        self.assertEqual(profile.min_count, 2)
+        self.assertEqual(profile.max_count, 5)
+
+    def test_aks_agentpool_auto_scale_add_non_vms_pool(self):
+        instance = self._build_vms_agentpool(pool_type="VirtualMachineScaleSets", autoscale_profiles=[])
+        self.client.get = mock.Mock(return_value=instance)
+
+        with self.assertRaises(ClientRequestError):
+            aks_agentpool_auto_scale_add(
+                self.cmd,
+                self.client,
+                "rg",
+                "mc",
+                "np",
+                "Standard_D4s_v3",
+                1,
+                3,
+            )
+
+    def test_aks_agentpool_auto_scale_update_missing_required(self):
+        with self.assertRaises(RequiredArgumentMissingError):
+            aks_agentpool_auto_scale_update(
+                self.cmd,
+                self.client,
+                "rg",
+                "mc",
+                "np",
+                "Standard_D2s_v3",
+            )
+
+    def test_aks_agentpool_auto_scale_update_profile_not_found(self):
+        profile = mock.Mock(size="Standard_D2s_v3", min_count=1, max_count=3)
+        instance = self._build_vms_agentpool(autoscale_profiles=[profile])
+        self.client.get = mock.Mock(return_value=instance)
+
+        with self.assertRaisesRegex(InvalidArgumentValueError, "doesn't exist"):
+            aks_agentpool_auto_scale_update(
+                self.cmd,
+                self.client,
+                "rg",
+                "mc",
+                "np",
+                "Standard_D4s_v3",
+                min_count=2,
+            )
+
+    def test_aks_agentpool_auto_scale_update_success(self):
+        profile = mock.Mock(size="Standard_D2s_v3", min_count=1, max_count=3)
+        instance = self._build_vms_agentpool(autoscale_profiles=[profile])
+        self.client.get = mock.Mock(return_value=instance)
+        self.client.begin_create_or_update = mock.Mock(return_value="ok")
+
+        result = aks_agentpool_auto_scale_update(
+            self.cmd,
+            self.client,
+            "rg",
+            "mc",
+            "np",
+            "Standard_D2s_v3",
+            node_vm_size="Standard_D8s_v3",
+            min_count=2,
+            max_count=6,
+        )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(profile.size, "Standard_D8s_v3")
+        self.assertEqual(profile.min_count, 2)
+        self.assertEqual(profile.max_count, 6)
+
+    def test_aks_agentpool_auto_scale_delete_non_vms_pool(self):
+        instance = self._build_vms_agentpool(pool_type="VirtualMachineScaleSets", autoscale_profiles=[])
+        self.client.get = mock.Mock(return_value=instance)
+
+        with self.assertRaises(ClientRequestError):
+            aks_agentpool_auto_scale_delete(
+                self.cmd,
+                self.client,
+                "rg",
+                "mc",
+                "np",
+                "Standard_D2s_v3",
+            )
+
+    def test_aks_agentpool_auto_scale_delete_profile_not_found(self):
+        profile = mock.Mock(size="Standard_D2s_v3", min_count=1, max_count=3)
+        instance = self._build_vms_agentpool(autoscale_profiles=[profile])
+        self.client.get = mock.Mock(return_value=instance)
+
+        with self.assertRaisesRegex(InvalidArgumentValueError, "doesn't exist"):
+            aks_agentpool_auto_scale_delete(
+                self.cmd,
+                self.client,
+                "rg",
+                "mc",
+                "np",
+                "Standard_D4s_v3",
+            )
+
+    def test_aks_agentpool_auto_scale_delete_success(self):
+        profile_1 = mock.Mock(size="Standard_D2s_v3", min_count=1, max_count=3)
+        profile_2 = mock.Mock(size="Standard_D4s_v3", min_count=2, max_count=5)
+        instance = self._build_vms_agentpool(autoscale_profiles=[profile_1, profile_2])
+        self.client.get = mock.Mock(return_value=instance)
+        self.client.begin_create_or_update = mock.Mock(return_value="ok")
+
+        result = aks_agentpool_auto_scale_delete(
+            self.cmd,
+            self.client,
+            "rg",
+            "mc",
+            "np",
+            "Standard_D4s_v3",
+        )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(len(instance.virtual_machines_profile.scale.autoscale), 1)
+        self.assertEqual(instance.virtual_machines_profile.scale.autoscale[0].size, "Standard_D2s_v3")
 
 
 class TestRunCommand(unittest.TestCase):


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes | Tests |
| :--: | :--: |
| ⚠️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>⚠️AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>⚠️acs</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|aks nodepool auto-scale|sub group `aks nodepool auto-scale` added||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

- az aks create --vm-set-type VirtualMachines --node-vm-size <size> --enable-cluster-autoscaler --min-count <n> --max-count <n>
- az aks nodepool add --vm-set-type VirtualMachines --node-vm-size <size> --enable-cluster-autoscaler --min-count <n> --max-count <n>
- az aks nodepool update --enable-cluster-autoscaler --min-count <n> --max-count <n>
- az aks nodepool update --disable-cluster-autoscaler
- az aks nodepool update --update-cluster-autoscaler (now blocked for VirtualMachines pools; use auto-scale update)
- az aks nodepool auto-scale add
- az aks nodepool auto-scale update
- az aks nodepool auto-scale delete

**Description**<!--Mandatory-->

This PR ports mixed-SKU cluster autoscaler (CAS) support for VirtualMachines (VMS) agent pools from aks-preview into azure-cli mainline ACS commands.

What is changed:

- Add new command group:
  - az aks nodepool auto-scale add
  - az aks nodepool auto-scale update
  - az aks nodepool auto-scale delete
- Add parameter wiring and help for the new auto-scale commands.
- Add VMS-specific autoscaler behavior in nodepool update:
  - --enable-cluster-autoscaler converts all manual scale profiles to autoscale profiles using the same min/max values.
  - --disable-cluster-autoscaler converts all autoscale profiles back to manual profiles, defaulting manual count from autoscale minCount.
  - --update-cluster-autoscaler is rejected for VMS pools with a clear guidance message to use az aks nodepool auto-scale update.
- Keep existing VMSS autoscaler behavior unchanged.
- Add scenario and unit tests in ACS test suites to validate command behavior and conversion logic.

Effect:

- Customers using VMS pools can now manage autoscale profiles directly (add/update/delete) and switch between manual and autoscale modes using supported commands.

**Testing Guide**

Example commands to validate behavior:

1. Create VMS cluster in autoscale mode

az aks create \
  --resource-group <rg> \
  --name <cluster> \
  --vm-set-type VirtualMachines \
  --node-vm-size Standard_D4s_v3 \
  --enable-cluster-autoscaler \
  --min-count 2 \
  --max-count 5

Expected: agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale is populated.

2. Add autoscaled VMS nodepool

az aks nodepool add \
  --resource-group <rg> \
  --cluster-name <cluster> \
  --name <pool> \
  --vm-set-type VirtualMachines \
  --node-vm-size Standard_D4s_v3 \
  --enable-cluster-autoscaler \
  --min-count 2 \
  --max-count 5

Expected: nodepool virtualMachinesProfile.scale.autoscale[0] exists.

3. Manual -> auto conversion

az aks nodepool update \
  --resource-group <rg> \
  --cluster-name <cluster> \
  --name <pool> \
  --enable-cluster-autoscaler \
  --min-count 2 \
  --max-count 5

Expected: all manual profiles are converted into autoscale profiles.

4. Auto -> manual conversion

az aks nodepool update \
  --resource-group <rg> \
  --cluster-name <cluster> \
  --name <pool> \
  --disable-cluster-autoscaler

Expected: autoscale profiles are converted to manual profiles; manual count defaults from minCount.

5. Manage individual autoscale profiles

az aks nodepool auto-scale add \
  --resource-group <rg> \
  --cluster-name <cluster> \
  --name <pool> \
  --node-vm-size Standard_D2s_v3 \
  --min-count 3 \
  --max-count 5

az aks nodepool auto-scale update \
  --resource-group <rg> \
  --cluster-name <cluster> \
  --name <pool> \
  --current-node-vm-size Standard_D2s_v3 \
  --node-vm-size Standard_D8s_v3 \
  --min-count 2 \
  --max-count 4

az aks nodepool auto-scale delete \
  --resource-group <rg> \
  --cluster-name <cluster> \
  --name <pool> \
  --current-node-vm-size Standard_D8s_v3

Expected: add/update/delete mutate virtualMachinesProfile.scale.autoscale as requested.

6. Guardrail behavior

az aks nodepool update \
  --resource-group <rg> \
  --cluster-name <cluster> \
  --name <pool> \
  --update-cluster-autoscaler \
  --min-count 2 \
  --max-count 5

Expected: validation failure for VMS pools directing to az aks nodepool auto-scale update.

Automated tests added/updated:

- src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
- src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
- src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py

**History Notes**

[AKS] `az aks create`, `az aks nodepool add`: Support `--enable-cluster-autoscaler` for VirtualMachines agent pools to create pools in autoscale mode
[AKS] `az aks nodepool update`: Support `--enable-cluster-autoscaler` for VirtualMachines agent pools by converting manual scale profiles to autoscale profiles
[AKS] `az aks nodepool update`: Support `--disable-cluster-autoscaler` for VirtualMachines agent pools by converting autoscale profiles back to manual profiles
[AKS] `az aks nodepool update`: Block `--update-cluster-autoscaler` for VirtualMachines agent pools and direct to `az aks nodepool auto-scale update`
[AKS] `az aks nodepool auto-scale add`: Add command to add an autoscale profile to a VirtualMachines agent pool
[AKS] `az aks nodepool auto-scale update`: Add command to update an autoscale profile of a VirtualMachines agent pool
[AKS] `az aks nodepool auto-scale delete`: Add command to delete an autoscale profile from a VirtualMachines agent pool

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).