### PR TITLE
[Storage] az storage blob allow empty blob with data

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -2102,9 +2102,10 @@ def validate_share_close_handle(namespace):
 
 def validate_upload_blob(namespace):
     from azure.cli.core.azclierror import InvalidArgumentValueError
-    if namespace.file_path and namespace.data:
+    has_data = namespace.data is not None
+    if namespace.file_path and has_data:
         raise InvalidArgumentValueError("usage error: please only specify one of --file and --data to upload.")
-    if not namespace.file_path and not namespace.data:
+    if not namespace.file_path and not has_data:
         raise InvalidArgumentValueError("usage error: please specify one of --file and --data to upload.")
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
@@ -20,7 +20,7 @@ from azure.cli.command_modules.storage._validators import (get_permission_valida
                                                            get_source_file_or_blob_service_client_track2,
                                                            validate_encryption_source, validate_source_uri,
                                                            validate_encryption_services, as_user_validator,
-                                                           get_not_none_validator)
+                                                           get_not_none_validator, validate_upload_blob)
 
 
 class MockCLI(CLI):
@@ -182,6 +182,19 @@ class TestCmdModuleStorageValidators(unittest.TestCase):
 
         validate_arg(cmd, Namespace(arg=0))
         validate_arg(cmd, Namespace(arg=False))
+
+    def test_validate_upload_blob(self):
+        from azure.cli.core.azclierror import InvalidArgumentValueError
+
+        validate_upload_blob(Namespace(file_path=None, data=''))
+        validate_upload_blob(Namespace(file_path=None, data='test data'))
+        validate_upload_blob(Namespace(file_path='test.txt', data=None))
+
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'please only specify one of --file and --data'):
+            validate_upload_blob(Namespace(file_path='test.txt', data=''))
+
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'please specify one of --file and --data'):
+            validate_upload_blob(Namespace(file_path=None, data=None))
 
 
 class TestEncryptionValidators(unittest.TestCase):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az storage blob upload

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix issue: https://github.com/Azure/azure-cli/issues/31852

Fixes `az storage blob upload --data ''` so an explicitly empty data value is treated as provided input and can be used to upload an empty blob.

The upload validator now checks whether `--data` is omitted by comparing against `None`, instead of relying on truthiness. This preserves the existing validation for missing input and mutually exclusive `--file` / `--data` arguments.

Added unit test coverage for empty `--data`, non-empty `--data`, file upload input, conflicting `--file` and `--data`, and missing upload input.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
