### PR TITLE
[Network] `az network public-ip create/update`: Add `--ddos-custom-policy` to attach a DDoS custom policy

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_slb_vmss_with_outbound_ip_then_update.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_slb_vmss_with_outbound_ip_then_update.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip1000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002","etag":"W/\"056b0b0a-2ea8-45b1-8d1c-d06fe0f54d84\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"bcb75aac-04ba-4d74-9faa-71226f9a1675","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -164,7 +164,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip1000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002","etag":"W/\"569506fa-0eb0-4278-890d-dcd5e9c2f49c\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"bcb75aac-04ba-4d74-9faa-71226f9a1675","ipAddress":"52.161.121.180","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -217,7 +217,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip2000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003","etag":"W/\"e03ec6a3-29dc-419d-a5f7-2a6978336c89\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"8dc2a670-ad6d-4a0a-8cd1-f983477a71c7","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -361,7 +361,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip2000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003","etag":"W/\"1a8f1fcd-2c15-4922-b382-150cbc30928e\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"8dc2a670-ad6d-4a0a-8cd1-f983477a71c7","ipAddress":"13.78.184.233","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_slb_vmss_with_outbound_ip_then_update_msi.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_slb_vmss_with_outbound_ip_then_update_msi.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip1000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002","etag":"W/\"1bdf3cc2-cfbb-4a00-bd2c-63711609f90e\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"f7003fc8-c164-47de-bc14-7462b71dc77b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -164,7 +164,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip1000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip1000002","etag":"W/\"24abb0fc-8ab8-4ec1-81a5-0eb7dca10da2\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f7003fc8-c164-47de-bc14-7462b71dc77b","ipAddress":"52.161.142.141","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -217,7 +217,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip2000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003","etag":"W/\"9b9dc802-e163-4bff-a3ed-c0c34b3a452d\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"234c2eaa-30b9-440b-9867-7b8d2e36d10e","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -361,7 +361,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.8.10 (Linux-6.5.0-1017-azure-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliaksslbip2000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliaksslbip2000003","etag":"W/\"62213989-1dad-4eb5-bb25-61ce63e92fbd\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"234c2eaa-30b9-440b-9867-7b8d2e36d10e","ipAddress":"52.161.165.48","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/computefleet/tests/latest/recordings/test_all_fleet_operations.yaml
+++ b/src/azure-cli/azure/cli/command_modules/computefleet/tests/latest/recordings/test_all_fleet_operations.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.14.6 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet_cli_rg_000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet_cli_rg_000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"FleetIP-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet_cli_rg_000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002","etag":"W/\"3012d0a4-2661-4795-b852-657d21092b0a\"","location":"westus3","properties":{"provisioningState":"Updating","resourceGuid":"5ca887f4-0fa3-4e3c-994b-6b7d701e5956","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -131,7 +131,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.14.6 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet_cli_rg_000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet_cli_rg_000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"FleetIP-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet_cli_rg_000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002","etag":"W/\"3424c90d-476f-40c8-a224-d814501e9515\"","location":"westus3","properties":{"provisioningState":"Succeeded","resourceGuid":"5ca887f4-0fa3-4e3c-994b-6b7d701e5956","ipAddress":"20.118.171.67","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/computefleet/tests/latest/recordings/test_all_fleet_operations_using_alias.yaml
+++ b/src/azure-cli/azure/cli/command_modules/computefleet/tests/latest/recordings/test_all_fleet_operations_using_alias.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.14.6 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_alias000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_alias000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"FleetIP-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_alias000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002","etag":"W/\"acb7950d-af3d-4976-ad25-fd6f391c1b01\"","location":"westus2","properties":{"provisioningState":"Updating","resourceGuid":"58c2c11c-371a-4aa0-911e-0dbf6df842f6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -131,7 +131,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.14.6 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_alias000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_alias000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"FleetIP-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_alias000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002","etag":"W/\"05c2f5e6-f55c-48e0-aeb1-9db4f8d44c66\"","location":"westus2","properties":{"provisioningState":"Succeeded","resourceGuid":"58c2c11c-371a-4aa0-911e-0dbf6df842f6","ipAddress":"4.155.105.222","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/computefleet/tests/latest/recordings/test_all_launch_fleet_operations.yaml
+++ b/src/azure-cli/azure/cli/command_modules/computefleet/tests/latest/recordings/test_all_launch_fleet_operations.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.14.6 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_launch000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_launch000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"FleetIP-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_launch000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002","etag":"W/\"1f198349-c7fa-49de-aa96-5507dcf0b4f1\"","location":"eastasia","properties":{"provisioningState":"Updating","resourceGuid":"4d306ecd-535e-42a2-b6ea-46fb3d759906","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -131,7 +131,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.14.6 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_launch000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_launch000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"FleetIP-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fleet-cli_launch000001/providers/Microsoft.Network/publicIPAddresses/FleetIP-000002","etag":"W/\"b3569961-1872-44ed-a9f4-27abf2cfda05\"","location":"eastasia","properties":{"provisioningState":"Succeeded","resourceGuid":"4d306ecd-535e-42a2-b6ea-46fb3d759906","ipAddress":"13.70.63.218","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_always_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_always_scenario.yaml
@@ -68,7 +68,7 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
@@ -176,7 +176,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
@@ -286,7 +286,7 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
@@ -394,7 +394,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"b9f4efce-4514-48fc-a8fc-3a362cbfc498\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"42c64e85-9808-48a8-b36a-7d431d0067cf","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"e8e99c66-d090-473b-b9a7-25b6537230fe\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"42c64e85-9808-48a8-b36a-7d431d0067cf","ipAddress":"172.184.104.24","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -273,7 +273,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2","etag":"W/\"fa561cba-dcf6-488c-96e9-2004e5a1a3fe\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"1553726b-fdb2-4a05-9a4b-514f07e6b901","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -379,7 +379,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2","etag":"W/\"76689714-674c-4b53-9349-b1f1eafd809b\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"1553726b-fdb2-4a05-9a4b-514f07e6b901","ipAddress":"172.184.176.98","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -626,6 +626,7 @@ def load_arguments(self, _):
         c.argument('protection_mode', options_list=['--ddos-protection-mode', '--protection-mode'],
                    help='The DDoS protection mode of the public IP', arg_type=get_enum_type(['Enabled', 'Disabled', 'VirtualNetworkInherited']))
         c.argument('ddos_protection_plan', help='Name or ID of a DDoS protection plan associated with the public IP. Can only be set if `--protection-mode` is Enabled.')
+        c.argument('ddos_custom_policy', help='Name or ID of a DDoS custom policy associated with the public IP. Note: A DDoS custom policy can only be attached to an instance-level public IP (a public IP associated with a NIC/VM) or a Load Balancer frontend IP configuration; attaching one to a standalone public IP is rejected by the service.')
 
     for scope in ['public-ip', 'lb frontend-ip', 'cross-region-lb frontend-ip']:
         with self.argument_context('network {}'.format(scope)) as c:

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_create.py
@@ -25,9 +25,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2025-07-01"],
         ]
     }
 
@@ -160,6 +160,16 @@ class Create(AAZCommand):
         zone = cls._args_schema.zone
         zone.Element = AAZStrArg()
 
+        # define Arg Group "DdosSettings"
+
+        _args_schema = cls._args_schema
+        _args_schema.ddos_custom_policy = AAZObjectArg(
+            options=["--ddos-custom-policy"],
+            arg_group="DdosSettings",
+            help="The DDoS custom policy associated with the public IP.",
+        )
+        cls._build_args_common_sub_resource_create(_args_schema.ddos_custom_policy)
+
         # define Arg Group "DnsSettings"
 
         # define Arg Group "Parameters"
@@ -167,125 +177,117 @@ class Create(AAZCommand):
         # define Arg Group "Properties"
         return cls._args_schema
 
-    _args_public_ip_address_create = None
+    _args_common_public_ip_address_create = None
 
     @classmethod
-    def _build_args_public_ip_address_create(cls, _schema):
-        if cls._args_public_ip_address_create is not None:
-            _schema.ddos_settings = cls._args_public_ip_address_create.ddos_settings
-            _schema.delete_option = cls._args_public_ip_address_create.delete_option
-            _schema.dns_settings = cls._args_public_ip_address_create.dns_settings
-            _schema.extended_location = cls._args_public_ip_address_create.extended_location
-            _schema.id = cls._args_public_ip_address_create.id
-            _schema.idle_timeout_in_minutes = cls._args_public_ip_address_create.idle_timeout_in_minutes
-            _schema.ip_address = cls._args_public_ip_address_create.ip_address
-            _schema.ip_tags = cls._args_public_ip_address_create.ip_tags
-            _schema.linked_public_ip_address = cls._args_public_ip_address_create.linked_public_ip_address
-            _schema.location = cls._args_public_ip_address_create.location
-            _schema.migration_phase = cls._args_public_ip_address_create.migration_phase
-            _schema.nat_gateway = cls._args_public_ip_address_create.nat_gateway
-            _schema.public_ip_address_version = cls._args_public_ip_address_create.public_ip_address_version
-            _schema.public_ip_allocation_method = cls._args_public_ip_address_create.public_ip_allocation_method
-            _schema.public_ip_prefix = cls._args_public_ip_address_create.public_ip_prefix
-            _schema.service_public_ip_address = cls._args_public_ip_address_create.service_public_ip_address
-            _schema.sku = cls._args_public_ip_address_create.sku
-            _schema.tags = cls._args_public_ip_address_create.tags
-            _schema.zones = cls._args_public_ip_address_create.zones
+    def _build_args_common_public_ip_address_create(cls, _schema):
+        if cls._args_common_public_ip_address_create is not None:
+            _schema.ddos_settings = cls._args_common_public_ip_address_create.ddos_settings
+            _schema.delete_option = cls._args_common_public_ip_address_create.delete_option
+            _schema.dns_settings = cls._args_common_public_ip_address_create.dns_settings
+            _schema.extended_location = cls._args_common_public_ip_address_create.extended_location
+            _schema.idle_timeout_in_minutes = cls._args_common_public_ip_address_create.idle_timeout_in_minutes
+            _schema.ip_address = cls._args_common_public_ip_address_create.ip_address
+            _schema.ip_tags = cls._args_common_public_ip_address_create.ip_tags
+            _schema.linked_public_ip_address = cls._args_common_public_ip_address_create.linked_public_ip_address
+            _schema.location = cls._args_common_public_ip_address_create.location
+            _schema.migration_phase = cls._args_common_public_ip_address_create.migration_phase
+            _schema.nat_gateway = cls._args_common_public_ip_address_create.nat_gateway
+            _schema.public_ip_address_version = cls._args_common_public_ip_address_create.public_ip_address_version
+            _schema.public_ip_allocation_method = cls._args_common_public_ip_address_create.public_ip_allocation_method
+            _schema.public_ip_prefix = cls._args_common_public_ip_address_create.public_ip_prefix
+            _schema.service_public_ip_address = cls._args_common_public_ip_address_create.service_public_ip_address
+            _schema.sku = cls._args_common_public_ip_address_create.sku
+            _schema.tags = cls._args_common_public_ip_address_create.tags
+            _schema.zones = cls._args_common_public_ip_address_create.zones
             return
 
-        cls._args_public_ip_address_create = AAZObjectArg()
+        cls._args_common_public_ip_address_create = AAZObjectArg()
 
-        public_ip_address_create = cls._args_public_ip_address_create
-        public_ip_address_create.extended_location = AAZObjectArg(
+        common_public_ip_address_create = cls._args_common_public_ip_address_create
+        common_public_ip_address_create.extended_location = AAZObjectArg(
             options=["extended-location"],
             help="The extended location of the public ip address.",
         )
-        public_ip_address_create.id = AAZResourceIdArg(
-            options=["id"],
-            help="Resource ID.",
-            fmt=AAZResourceIdArgFormat(
-                template="/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/publicIPAddresses/{}",
-            ),
-        )
-        public_ip_address_create.location = AAZResourceLocationArg(
+        common_public_ip_address_create.location = AAZResourceLocationArg(
             options=["l", "location"],
             help="Resource location.",
             fmt=AAZResourceLocationArgFormat(
                 resource_group_arg="resource_group",
             ),
         )
-        public_ip_address_create.ddos_settings = AAZObjectArg(
+        common_public_ip_address_create.ddos_settings = AAZObjectArg(
             options=["ddos-settings"],
             help="The DDoS protection custom policy associated with the public IP address.",
         )
-        public_ip_address_create.delete_option = AAZStrArg(
+        common_public_ip_address_create.delete_option = AAZStrArg(
             options=["delete-option"],
             help="Specify what happens to the public IP address when the VM using it is deleted",
             enum={"Delete": "Delete", "Detach": "Detach"},
         )
-        public_ip_address_create.dns_settings = AAZObjectArg(
+        common_public_ip_address_create.dns_settings = AAZObjectArg(
             options=["dns-settings"],
             help="The FQDN of the DNS record associated with the public IP address.",
         )
-        public_ip_address_create.idle_timeout_in_minutes = AAZIntArg(
+        common_public_ip_address_create.idle_timeout_in_minutes = AAZIntArg(
             options=["idle-timeout-in-minutes"],
             help="The idle timeout of the public IP address.",
         )
-        public_ip_address_create.ip_address = AAZStrArg(
+        common_public_ip_address_create.ip_address = AAZStrArg(
             options=["ip-address"],
             help="The IP address associated with the public IP address resource.",
         )
-        public_ip_address_create.ip_tags = AAZListArg(
+        common_public_ip_address_create.ip_tags = AAZListArg(
             options=["ip-tags"],
             help="The list of tags associated with the public IP address.",
         )
-        public_ip_address_create.linked_public_ip_address = AAZObjectArg(
+        common_public_ip_address_create.linked_public_ip_address = AAZObjectArg(
             options=["linked-public-ip-address"],
             help="The linked public IP address of the public IP address resource.",
         )
-        cls._build_args_public_ip_address_create(public_ip_address_create.linked_public_ip_address)
-        public_ip_address_create.migration_phase = AAZStrArg(
+        cls._build_args_common_public_ip_address_create(common_public_ip_address_create.linked_public_ip_address)
+        common_public_ip_address_create.migration_phase = AAZStrArg(
             options=["migration-phase"],
             help="Migration phase of Public IP Address.",
             enum={"Abort": "Abort", "Commit": "Commit", "Committed": "Committed", "None": "None", "Prepare": "Prepare"},
         )
-        public_ip_address_create.nat_gateway = AAZObjectArg(
+        common_public_ip_address_create.nat_gateway = AAZObjectArg(
             options=["nat-gateway"],
             help="The NatGateway for the Public IP address.",
         )
-        public_ip_address_create.public_ip_address_version = AAZStrArg(
+        common_public_ip_address_create.public_ip_address_version = AAZStrArg(
             options=["public-ip-address-version"],
             help="The public IP address version.",
             enum={"IPv4": "IPv4", "IPv6": "IPv6"},
         )
-        public_ip_address_create.public_ip_allocation_method = AAZStrArg(
+        common_public_ip_address_create.public_ip_allocation_method = AAZStrArg(
             options=["public-ip-allocation-method"],
             help="The public IP address allocation method.",
             enum={"Dynamic": "Dynamic", "Static": "Static"},
         )
-        public_ip_address_create.public_ip_prefix = AAZObjectArg(
+        common_public_ip_address_create.public_ip_prefix = AAZObjectArg(
             options=["public-ip-prefix"],
             help="The Public IP Prefix this Public IP Address should be allocated from.",
         )
-        public_ip_address_create.service_public_ip_address = AAZObjectArg(
+        common_public_ip_address_create.service_public_ip_address = AAZObjectArg(
             options=["service-public-ip-address"],
             help="The service public IP address of the public IP address resource.",
         )
-        cls._build_args_public_ip_address_create(public_ip_address_create.service_public_ip_address)
-        public_ip_address_create.sku = AAZObjectArg(
+        cls._build_args_common_public_ip_address_create(common_public_ip_address_create.service_public_ip_address)
+        common_public_ip_address_create.sku = AAZObjectArg(
             options=["sku"],
             help="The public IP address SKU.",
         )
-        public_ip_address_create.tags = AAZDictArg(
+        common_public_ip_address_create.tags = AAZDictArg(
             options=["tags"],
             help="Resource tags.",
         )
-        public_ip_address_create.zones = AAZListArg(
+        common_public_ip_address_create.zones = AAZListArg(
             options=["zones"],
             help="A list of availability zones denoting the IP allocated for the resource needs to come from.",
         )
 
-        extended_location = cls._args_public_ip_address_create.extended_location
+        extended_location = cls._args_common_public_ip_address_create.extended_location
         extended_location.name = AAZStrArg(
             options=["name"],
             help="The name of the extended location.",
@@ -296,7 +298,12 @@ class Create(AAZCommand):
             enum={"EdgeZone": "EdgeZone"},
         )
 
-        ddos_settings = cls._args_public_ip_address_create.ddos_settings
+        ddos_settings = cls._args_common_public_ip_address_create.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectArg(
+            options=["ddos-custom-policy"],
+            help="The DDoS custom policy associated with the public IP.",
+        )
+        cls._build_args_common_sub_resource_create(ddos_settings.ddos_custom_policy)
         ddos_settings.ddos_protection_plan = AAZObjectArg(
             options=["ddos-protection-plan"],
             help="The DDoS protection plan associated with the public IP. Can only be set if ProtectionMode is Enabled",
@@ -307,13 +314,13 @@ class Create(AAZCommand):
             enum={"Disabled": "Disabled", "Enabled": "Enabled", "VirtualNetworkInherited": "VirtualNetworkInherited"},
         )
 
-        ddos_protection_plan = cls._args_public_ip_address_create.ddos_settings.ddos_protection_plan
+        ddos_protection_plan = cls._args_common_public_ip_address_create.ddos_settings.ddos_protection_plan
         ddos_protection_plan.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
         )
 
-        dns_settings = cls._args_public_ip_address_create.dns_settings
+        dns_settings = cls._args_common_public_ip_address_create.dns_settings
         dns_settings.domain_name_label = AAZStrArg(
             options=["domain-name-label"],
             help="The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.",
@@ -332,10 +339,10 @@ class Create(AAZCommand):
             help="The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.",
         )
 
-        ip_tags = cls._args_public_ip_address_create.ip_tags
+        ip_tags = cls._args_common_public_ip_address_create.ip_tags
         ip_tags.Element = AAZObjectArg()
 
-        _element = cls._args_public_ip_address_create.ip_tags.Element
+        _element = cls._args_common_public_ip_address_create.ip_tags.Element
         _element.ip_tag_type = AAZStrArg(
             options=["ip-tag-type"],
             help="The IP tag type. Example: FirstPartyUsage.",
@@ -345,13 +352,10 @@ class Create(AAZCommand):
             help="The value of the IP tag associated with the public IP. Example: SQL.",
         )
 
-        nat_gateway = cls._args_public_ip_address_create.nat_gateway
+        nat_gateway = cls._args_common_public_ip_address_create.nat_gateway
         nat_gateway.id = AAZResourceIdArg(
             options=["id"],
             help="Resource ID.",
-            fmt=AAZResourceIdArgFormat(
-                template="/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/natGateways/{}",
-            ),
         )
         nat_gateway.location = AAZResourceLocationArg(
             options=["l", "location"],
@@ -364,9 +368,14 @@ class Create(AAZCommand):
             options=["idle-timeout-in-minutes"],
             help="The idle timeout of the nat gateway.",
         )
+        nat_gateway.nat64 = AAZStrArg(
+            options=["nat64"],
+            help="Whether Nat64 is enabled for the NAT gateway resource.",
+            enum={"Disabled": "Disabled", "Enabled": "Enabled", "None": "None"},
+        )
         nat_gateway.public_ip_addresses = AAZListArg(
             options=["public-ip-addresses"],
-            help="An array of public ip addresses associated with the nat gateway resource.",
+            help="An array of public ip addresses V4 associated with the nat gateway resource.",
         )
         nat_gateway.public_ip_addresses_v6 = AAZListArg(
             options=["public-ip-addresses-v6"],
@@ -374,17 +383,22 @@ class Create(AAZCommand):
         )
         nat_gateway.public_ip_prefixes = AAZListArg(
             options=["public-ip-prefixes"],
-            help="An array of public ip prefixes associated with the nat gateway resource.",
+            help="An array of public ip prefixes V4 associated with the nat gateway resource.",
         )
         nat_gateway.public_ip_prefixes_v6 = AAZListArg(
             options=["public-ip-prefixes-v6"],
             help="An array of public ip prefixes V6 associated with the nat gateway resource.",
         )
+        nat_gateway.service_gateway = AAZObjectArg(
+            options=["service-gateway"],
+            help="Reference to an existing service gateway.",
+        )
+        cls._build_args_common_sub_resource_create(nat_gateway.service_gateway)
         nat_gateway.source_virtual_network = AAZObjectArg(
             options=["source-virtual-network"],
             help="A reference to the source virtual network using this nat gateway resource.",
         )
-        cls._build_args_sub_resource_create(nat_gateway.source_virtual_network)
+        cls._build_args_common_sub_resource_create(nat_gateway.source_virtual_network)
         nat_gateway.sku = AAZObjectArg(
             options=["sku"],
             help="The nat gateway SKU.",
@@ -398,42 +412,42 @@ class Create(AAZCommand):
             help="A list of availability zones denoting the zone in which Nat Gateway should be deployed.",
         )
 
-        public_ip_addresses = cls._args_public_ip_address_create.nat_gateway.public_ip_addresses
+        public_ip_addresses = cls._args_common_public_ip_address_create.nat_gateway.public_ip_addresses
         public_ip_addresses.Element = AAZObjectArg()
-        cls._build_args_sub_resource_create(public_ip_addresses.Element)
+        cls._build_args_common_sub_resource_create(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = cls._args_public_ip_address_create.nat_gateway.public_ip_addresses_v6
+        public_ip_addresses_v6 = cls._args_common_public_ip_address_create.nat_gateway.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectArg()
-        cls._build_args_sub_resource_create(public_ip_addresses_v6.Element)
+        cls._build_args_common_sub_resource_create(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = cls._args_public_ip_address_create.nat_gateway.public_ip_prefixes
+        public_ip_prefixes = cls._args_common_public_ip_address_create.nat_gateway.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectArg()
-        cls._build_args_sub_resource_create(public_ip_prefixes.Element)
+        cls._build_args_common_sub_resource_create(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = cls._args_public_ip_address_create.nat_gateway.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = cls._args_common_public_ip_address_create.nat_gateway.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectArg()
-        cls._build_args_sub_resource_create(public_ip_prefixes_v6.Element)
+        cls._build_args_common_sub_resource_create(public_ip_prefixes_v6.Element)
 
-        sku = cls._args_public_ip_address_create.nat_gateway.sku
+        sku = cls._args_common_public_ip_address_create.nat_gateway.sku
         sku.name = AAZStrArg(
             options=["name"],
             help="Name of Nat Gateway SKU.",
             enum={"Standard": "Standard", "StandardV2": "StandardV2"},
         )
 
-        tags = cls._args_public_ip_address_create.nat_gateway.tags
+        tags = cls._args_common_public_ip_address_create.nat_gateway.tags
         tags.Element = AAZStrArg()
 
-        zones = cls._args_public_ip_address_create.nat_gateway.zones
+        zones = cls._args_common_public_ip_address_create.nat_gateway.zones
         zones.Element = AAZStrArg()
 
-        public_ip_prefix = cls._args_public_ip_address_create.public_ip_prefix
+        public_ip_prefix = cls._args_common_public_ip_address_create.public_ip_prefix
         public_ip_prefix.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
         )
 
-        sku = cls._args_public_ip_address_create.sku
+        sku = cls._args_common_public_ip_address_create.sku
         sku.name = AAZStrArg(
             options=["name"],
             help="Name of a public IP address SKU.",
@@ -445,53 +459,52 @@ class Create(AAZCommand):
             enum={"Global": "Global", "Regional": "Regional"},
         )
 
-        tags = cls._args_public_ip_address_create.tags
+        tags = cls._args_common_public_ip_address_create.tags
         tags.Element = AAZStrArg()
 
-        zones = cls._args_public_ip_address_create.zones
+        zones = cls._args_common_public_ip_address_create.zones
         zones.Element = AAZStrArg()
 
-        _schema.ddos_settings = cls._args_public_ip_address_create.ddos_settings
-        _schema.delete_option = cls._args_public_ip_address_create.delete_option
-        _schema.dns_settings = cls._args_public_ip_address_create.dns_settings
-        _schema.extended_location = cls._args_public_ip_address_create.extended_location
-        _schema.id = cls._args_public_ip_address_create.id
-        _schema.idle_timeout_in_minutes = cls._args_public_ip_address_create.idle_timeout_in_minutes
-        _schema.ip_address = cls._args_public_ip_address_create.ip_address
-        _schema.ip_tags = cls._args_public_ip_address_create.ip_tags
-        _schema.linked_public_ip_address = cls._args_public_ip_address_create.linked_public_ip_address
-        _schema.location = cls._args_public_ip_address_create.location
-        _schema.migration_phase = cls._args_public_ip_address_create.migration_phase
-        _schema.nat_gateway = cls._args_public_ip_address_create.nat_gateway
-        _schema.public_ip_address_version = cls._args_public_ip_address_create.public_ip_address_version
-        _schema.public_ip_allocation_method = cls._args_public_ip_address_create.public_ip_allocation_method
-        _schema.public_ip_prefix = cls._args_public_ip_address_create.public_ip_prefix
-        _schema.service_public_ip_address = cls._args_public_ip_address_create.service_public_ip_address
-        _schema.sku = cls._args_public_ip_address_create.sku
-        _schema.tags = cls._args_public_ip_address_create.tags
-        _schema.zones = cls._args_public_ip_address_create.zones
+        _schema.ddos_settings = cls._args_common_public_ip_address_create.ddos_settings
+        _schema.delete_option = cls._args_common_public_ip_address_create.delete_option
+        _schema.dns_settings = cls._args_common_public_ip_address_create.dns_settings
+        _schema.extended_location = cls._args_common_public_ip_address_create.extended_location
+        _schema.idle_timeout_in_minutes = cls._args_common_public_ip_address_create.idle_timeout_in_minutes
+        _schema.ip_address = cls._args_common_public_ip_address_create.ip_address
+        _schema.ip_tags = cls._args_common_public_ip_address_create.ip_tags
+        _schema.linked_public_ip_address = cls._args_common_public_ip_address_create.linked_public_ip_address
+        _schema.location = cls._args_common_public_ip_address_create.location
+        _schema.migration_phase = cls._args_common_public_ip_address_create.migration_phase
+        _schema.nat_gateway = cls._args_common_public_ip_address_create.nat_gateway
+        _schema.public_ip_address_version = cls._args_common_public_ip_address_create.public_ip_address_version
+        _schema.public_ip_allocation_method = cls._args_common_public_ip_address_create.public_ip_allocation_method
+        _schema.public_ip_prefix = cls._args_common_public_ip_address_create.public_ip_prefix
+        _schema.service_public_ip_address = cls._args_common_public_ip_address_create.service_public_ip_address
+        _schema.sku = cls._args_common_public_ip_address_create.sku
+        _schema.tags = cls._args_common_public_ip_address_create.tags
+        _schema.zones = cls._args_common_public_ip_address_create.zones
 
-    _args_sub_resource_create = None
+    _args_common_sub_resource_create = None
 
     @classmethod
-    def _build_args_sub_resource_create(cls, _schema):
-        if cls._args_sub_resource_create is not None:
-            _schema.id = cls._args_sub_resource_create.id
+    def _build_args_common_sub_resource_create(cls, _schema):
+        if cls._args_common_sub_resource_create is not None:
+            _schema.id = cls._args_common_sub_resource_create.id
             return
 
-        cls._args_sub_resource_create = AAZObjectArg()
+        cls._args_common_sub_resource_create = AAZObjectArg()
 
-        sub_resource_create = cls._args_sub_resource_create
-        sub_resource_create.id = AAZStrArg(
+        common_sub_resource_create = cls._args_common_sub_resource_create
+        common_sub_resource_create.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
         )
 
-        _schema.id = cls._args_sub_resource_create.id
+        _schema.id = cls._args_common_sub_resource_create.id
 
     def _execute_operations(self):
         self.pre_operations()
-        yield self.PublicIPAddressesCreateOrUpdate(ctx=self.ctx)()
+        yield self.PublicIpAddressOperationGroupCreateOrUpdate(ctx=self.ctx)()
         self.post_operations()
 
     @register_callback
@@ -506,7 +519,7 @@ class Create(AAZCommand):
         result = self.deserialize_output(self.ctx.vars.instance, client_flatten=True)
         return result
 
-    class PublicIPAddressesCreateOrUpdate(AAZHttpOperation):
+    class PublicIpAddressOperationGroupCreateOrUpdate(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -570,7 +583,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -620,6 +633,7 @@ class Create(AAZCommand):
 
             ddos_settings = _builder.get(".properties.ddosSettings")
             if ddos_settings is not None:
+                _CreateHelper._build_schema_common_sub_resource_create(ddos_settings.set_prop("ddosCustomPolicy", AAZObjectType, ".ddos_custom_policy"))
                 ddos_settings.set_prop("ddosProtectionPlan", AAZObjectType)
                 ddos_settings.set_prop("protectionMode", AAZStrType, ".ddos_protection_mode")
 
@@ -677,7 +691,7 @@ class Create(AAZCommand):
                 return cls._schema_on_200_201
 
             cls._schema_on_200_201 = AAZObjectType()
-            _CreateHelper._build_schema_public_ip_address_read(cls._schema_on_200_201)
+            _CreateHelper._build_schema_common_public_ip_address_read(cls._schema_on_200_201)
 
             return cls._schema_on_200_201
 
@@ -686,11 +700,10 @@ class _CreateHelper:
     """Helper class for Create"""
 
     @classmethod
-    def _build_schema_public_ip_address_create(cls, _builder):
+    def _build_schema_common_public_ip_address_create(cls, _builder):
         if _builder is None:
             return
         _builder.set_prop("extendedLocation", AAZObjectType, ".extended_location")
-        _builder.set_prop("id", AAZStrType, ".id")
         _builder.set_prop("location", AAZStrType, ".location")
         _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
         _builder.set_prop("sku", AAZObjectType, ".sku")
@@ -710,16 +723,17 @@ class _CreateHelper:
             properties.set_prop("idleTimeoutInMinutes", AAZIntType, ".idle_timeout_in_minutes")
             properties.set_prop("ipAddress", AAZStrType, ".ip_address")
             properties.set_prop("ipTags", AAZListType, ".ip_tags")
-            cls._build_schema_public_ip_address_create(properties.set_prop("linkedPublicIPAddress", AAZObjectType, ".linked_public_ip_address"))
+            cls._build_schema_common_public_ip_address_create(properties.set_prop("linkedPublicIPAddress", AAZObjectType, ".linked_public_ip_address"))
             properties.set_prop("migrationPhase", AAZStrType, ".migration_phase")
             properties.set_prop("natGateway", AAZObjectType, ".nat_gateway")
             properties.set_prop("publicIPAddressVersion", AAZStrType, ".public_ip_address_version")
             properties.set_prop("publicIPAllocationMethod", AAZStrType, ".public_ip_allocation_method")
             properties.set_prop("publicIPPrefix", AAZObjectType, ".public_ip_prefix")
-            cls._build_schema_public_ip_address_create(properties.set_prop("servicePublicIPAddress", AAZObjectType, ".service_public_ip_address"))
+            cls._build_schema_common_public_ip_address_create(properties.set_prop("servicePublicIPAddress", AAZObjectType, ".service_public_ip_address"))
 
         ddos_settings = _builder.get(".properties.ddosSettings")
         if ddos_settings is not None:
+            cls._build_schema_common_sub_resource_create(ddos_settings.set_prop("ddosCustomPolicy", AAZObjectType, ".ddos_custom_policy"))
             ddos_settings.set_prop("ddosProtectionPlan", AAZObjectType, ".ddos_protection_plan")
             ddos_settings.set_prop("protectionMode", AAZStrType, ".protection_mode")
 
@@ -755,27 +769,29 @@ class _CreateHelper:
         properties = _builder.get(".properties.natGateway.properties")
         if properties is not None:
             properties.set_prop("idleTimeoutInMinutes", AAZIntType, ".idle_timeout_in_minutes")
+            properties.set_prop("nat64", AAZStrType, ".nat64")
             properties.set_prop("publicIpAddresses", AAZListType, ".public_ip_addresses")
             properties.set_prop("publicIpAddressesV6", AAZListType, ".public_ip_addresses_v6")
             properties.set_prop("publicIpPrefixes", AAZListType, ".public_ip_prefixes")
             properties.set_prop("publicIpPrefixesV6", AAZListType, ".public_ip_prefixes_v6")
-            cls._build_schema_sub_resource_create(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_virtual_network"))
+            cls._build_schema_common_sub_resource_create(properties.set_prop("serviceGateway", AAZObjectType, ".service_gateway"))
+            cls._build_schema_common_sub_resource_create(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_virtual_network"))
 
         public_ip_addresses = _builder.get(".properties.natGateway.properties.publicIpAddresses")
         if public_ip_addresses is not None:
-            cls._build_schema_sub_resource_create(public_ip_addresses.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_create(public_ip_addresses.set_elements(AAZObjectType, "."))
 
         public_ip_addresses_v6 = _builder.get(".properties.natGateway.properties.publicIpAddressesV6")
         if public_ip_addresses_v6 is not None:
-            cls._build_schema_sub_resource_create(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_create(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
 
         public_ip_prefixes = _builder.get(".properties.natGateway.properties.publicIpPrefixes")
         if public_ip_prefixes is not None:
-            cls._build_schema_sub_resource_create(public_ip_prefixes.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_create(public_ip_prefixes.set_elements(AAZObjectType, "."))
 
         public_ip_prefixes_v6 = _builder.get(".properties.natGateway.properties.publicIpPrefixesV6")
         if public_ip_prefixes_v6 is not None:
-            cls._build_schema_sub_resource_create(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_create(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
 
         sku = _builder.get(".properties.natGateway.sku")
         if sku is not None:
@@ -807,45 +823,45 @@ class _CreateHelper:
             zones.set_elements(AAZStrType, ".")
 
     @classmethod
-    def _build_schema_sub_resource_create(cls, _builder):
+    def _build_schema_common_sub_resource_create(cls, _builder):
         if _builder is None:
             return
         _builder.set_prop("id", AAZStrType, ".id")
 
-    _schema_application_security_group_read = None
+    _schema_common_application_security_group_read = None
 
     @classmethod
-    def _build_schema_application_security_group_read(cls, _schema):
-        if cls._schema_application_security_group_read is not None:
-            _schema.etag = cls._schema_application_security_group_read.etag
-            _schema.id = cls._schema_application_security_group_read.id
-            _schema.location = cls._schema_application_security_group_read.location
-            _schema.name = cls._schema_application_security_group_read.name
-            _schema.properties = cls._schema_application_security_group_read.properties
-            _schema.tags = cls._schema_application_security_group_read.tags
-            _schema.type = cls._schema_application_security_group_read.type
+    def _build_schema_common_application_security_group_read(cls, _schema):
+        if cls._schema_common_application_security_group_read is not None:
+            _schema.etag = cls._schema_common_application_security_group_read.etag
+            _schema.id = cls._schema_common_application_security_group_read.id
+            _schema.location = cls._schema_common_application_security_group_read.location
+            _schema.name = cls._schema_common_application_security_group_read.name
+            _schema.properties = cls._schema_common_application_security_group_read.properties
+            _schema.tags = cls._schema_common_application_security_group_read.tags
+            _schema.type = cls._schema_common_application_security_group_read.type
             return
 
-        cls._schema_application_security_group_read = _schema_application_security_group_read = AAZObjectType()
+        cls._schema_common_application_security_group_read = _schema_common_application_security_group_read = AAZObjectType()
 
-        application_security_group_read = _schema_application_security_group_read
-        application_security_group_read.etag = AAZStrType(
+        common_application_security_group_read = _schema_common_application_security_group_read
+        common_application_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.id = AAZStrType()
-        application_security_group_read.location = AAZStrType()
-        application_security_group_read.name = AAZStrType(
+        common_application_security_group_read.id = AAZStrType()
+        common_application_security_group_read.location = AAZStrType()
+        common_application_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.properties = AAZObjectType(
+        common_application_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        application_security_group_read.tags = AAZDictType()
-        application_security_group_read.type = AAZStrType(
+        common_application_security_group_read.tags = AAZDictType()
+        common_application_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_application_security_group_read.properties
+        properties = _schema_common_application_security_group_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -855,69 +871,72 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        tags = _schema_application_security_group_read.tags
+        tags = _schema_common_application_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_application_security_group_read.etag
-        _schema.id = cls._schema_application_security_group_read.id
-        _schema.location = cls._schema_application_security_group_read.location
-        _schema.name = cls._schema_application_security_group_read.name
-        _schema.properties = cls._schema_application_security_group_read.properties
-        _schema.tags = cls._schema_application_security_group_read.tags
-        _schema.type = cls._schema_application_security_group_read.type
+        _schema.etag = cls._schema_common_application_security_group_read.etag
+        _schema.id = cls._schema_common_application_security_group_read.id
+        _schema.location = cls._schema_common_application_security_group_read.location
+        _schema.name = cls._schema_common_application_security_group_read.name
+        _schema.properties = cls._schema_common_application_security_group_read.properties
+        _schema.tags = cls._schema_common_application_security_group_read.tags
+        _schema.type = cls._schema_common_application_security_group_read.type
 
-    _schema_extended_location_read = None
-
-    @classmethod
-    def _build_schema_extended_location_read(cls, _schema):
-        if cls._schema_extended_location_read is not None:
-            _schema.name = cls._schema_extended_location_read.name
-            _schema.type = cls._schema_extended_location_read.type
-            return
-
-        cls._schema_extended_location_read = _schema_extended_location_read = AAZObjectType()
-
-        extended_location_read = _schema_extended_location_read
-        extended_location_read.name = AAZStrType()
-        extended_location_read.type = AAZStrType()
-
-        _schema.name = cls._schema_extended_location_read.name
-        _schema.type = cls._schema_extended_location_read.type
-
-    _schema_frontend_ip_configuration_read = None
+    _schema_common_extended_location_read = None
 
     @classmethod
-    def _build_schema_frontend_ip_configuration_read(cls, _schema):
-        if cls._schema_frontend_ip_configuration_read is not None:
-            _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-            _schema.id = cls._schema_frontend_ip_configuration_read.id
-            _schema.name = cls._schema_frontend_ip_configuration_read.name
-            _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-            _schema.type = cls._schema_frontend_ip_configuration_read.type
-            _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+    def _build_schema_common_extended_location_read(cls, _schema):
+        if cls._schema_common_extended_location_read is not None:
+            _schema.name = cls._schema_common_extended_location_read.name
+            _schema.type = cls._schema_common_extended_location_read.type
             return
 
-        cls._schema_frontend_ip_configuration_read = _schema_frontend_ip_configuration_read = AAZObjectType()
+        cls._schema_common_extended_location_read = _schema_common_extended_location_read = AAZObjectType()
 
-        frontend_ip_configuration_read = _schema_frontend_ip_configuration_read
-        frontend_ip_configuration_read.etag = AAZStrType(
+        common_extended_location_read = _schema_common_extended_location_read
+        common_extended_location_read.name = AAZStrType()
+        common_extended_location_read.type = AAZStrType()
+
+        _schema.name = cls._schema_common_extended_location_read.name
+        _schema.type = cls._schema_common_extended_location_read.type
+
+    _schema_common_frontend_ip_configuration_read = None
+
+    @classmethod
+    def _build_schema_common_frontend_ip_configuration_read(cls, _schema):
+        if cls._schema_common_frontend_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+            _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+            _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+            _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+            _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+            _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
+            return
+
+        cls._schema_common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read = AAZObjectType()
+
+        common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read
+        common_frontend_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.id = AAZStrType()
-        frontend_ip_configuration_read.name = AAZStrType()
-        frontend_ip_configuration_read.properties = AAZObjectType(
+        common_frontend_ip_configuration_read.id = AAZStrType()
+        common_frontend_ip_configuration_read.name = AAZStrType()
+        common_frontend_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        frontend_ip_configuration_read.type = AAZStrType(
+        common_frontend_ip_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.zones = AAZListType()
+        common_frontend_ip_configuration_read.zones = AAZListType()
 
-        properties = _schema_frontend_ip_configuration_read.properties
+        properties = _schema_common_frontend_ip_configuration_read.properties
+        properties.ddos_settings = AAZObjectType(
+            serialized_name="ddosSettings",
+        )
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.inbound_nat_pools = AAZListType(
             serialized_name="inboundNatPools",
             flags={"read_only": True},
@@ -950,66 +969,72 @@ class _CreateHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        inbound_nat_pools = _schema_frontend_ip_configuration_read.properties.inbound_nat_pools
+        ddos_settings = _schema_common_frontend_ip_configuration_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
+
+        inbound_nat_pools = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_pools
         inbound_nat_pools.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_pools.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_pools.Element)
 
-        inbound_nat_rules = _schema_frontend_ip_configuration_read.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancing_rules = _schema_frontend_ip_configuration_read.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_frontend_ip_configuration_read.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_frontend_ip_configuration_read.properties.outbound_rules
+        outbound_rules = _schema_common_frontend_ip_configuration_read.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        zones = _schema_frontend_ip_configuration_read.zones
+        zones = _schema_common_frontend_ip_configuration_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-        _schema.id = cls._schema_frontend_ip_configuration_read.id
-        _schema.name = cls._schema_frontend_ip_configuration_read.name
-        _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-        _schema.type = cls._schema_frontend_ip_configuration_read.type
-        _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+        _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+        _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+        _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+        _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+        _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+        _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
 
-    _schema_ip_configuration_read = None
+    _schema_common_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_ip_configuration_read(cls, _schema):
-        if cls._schema_ip_configuration_read is not None:
-            _schema.etag = cls._schema_ip_configuration_read.etag
-            _schema.id = cls._schema_ip_configuration_read.id
-            _schema.name = cls._schema_ip_configuration_read.name
-            _schema.properties = cls._schema_ip_configuration_read.properties
+    def _build_schema_common_ip_configuration_read(cls, _schema):
+        if cls._schema_common_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_ip_configuration_read.etag
+            _schema.id = cls._schema_common_ip_configuration_read.id
+            _schema.name = cls._schema_common_ip_configuration_read.name
+            _schema.properties = cls._schema_common_ip_configuration_read.properties
             return
 
-        cls._schema_ip_configuration_read = _schema_ip_configuration_read = AAZObjectType(
+        cls._schema_common_ip_configuration_read = _schema_common_ip_configuration_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        ip_configuration_read = _schema_ip_configuration_read
-        ip_configuration_read.etag = AAZStrType(
+        common_ip_configuration_read = _schema_common_ip_configuration_read
+        common_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        ip_configuration_read.id = AAZStrType()
-        ip_configuration_read.name = AAZStrType()
-        ip_configuration_read.properties = AAZObjectType(
+        common_ip_configuration_read.id = AAZStrType()
+        common_ip_configuration_read.name = AAZStrType()
+        common_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_ip_configuration_read.properties
+        properties = _schema_common_ip_configuration_read.properties
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
         )
@@ -1023,41 +1048,43 @@ class _CreateHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        _schema.etag = cls._schema_ip_configuration_read.etag
-        _schema.id = cls._schema_ip_configuration_read.id
-        _schema.name = cls._schema_ip_configuration_read.name
-        _schema.properties = cls._schema_ip_configuration_read.properties
+        _schema.etag = cls._schema_common_ip_configuration_read.etag
+        _schema.id = cls._schema_common_ip_configuration_read.id
+        _schema.name = cls._schema_common_ip_configuration_read.name
+        _schema.properties = cls._schema_common_ip_configuration_read.properties
 
-    _schema_network_interface_ip_configuration_read = None
+    _schema_common_network_interface_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_ip_configuration_read(cls, _schema):
-        if cls._schema_network_interface_ip_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-            _schema.id = cls._schema_network_interface_ip_configuration_read.id
-            _schema.name = cls._schema_network_interface_ip_configuration_read.name
-            _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-            _schema.type = cls._schema_network_interface_ip_configuration_read.type
+    def _build_schema_common_network_interface_ip_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
             return
 
-        cls._schema_network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read = AAZObjectType()
 
-        network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read
-        network_interface_ip_configuration_read.etag = AAZStrType(
+        common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read
+        common_network_interface_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_ip_configuration_read.id = AAZStrType()
-        network_interface_ip_configuration_read.name = AAZStrType()
-        network_interface_ip_configuration_read.properties = AAZObjectType(
+        common_network_interface_ip_configuration_read.id = AAZStrType()
+        common_network_interface_ip_configuration_read.name = AAZStrType()
+        common_network_interface_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_ip_configuration_read.type = AAZStrType()
+        common_network_interface_ip_configuration_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_network_interface_ip_configuration_read.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties
         properties.application_gateway_backend_address_pools = AAZListType(
             serialized_name="applicationGatewayBackendAddressPools",
         )
@@ -1067,7 +1094,7 @@ class _CreateHelper:
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.load_balancer_backend_address_pools = AAZListType(
             serialized_name="loadBalancerBackendAddressPools",
         )
@@ -1099,17 +1126,17 @@ class _CreateHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
         properties.virtual_network_taps = AAZListType(
             serialized_name="virtualNetworkTaps",
         )
 
-        application_gateway_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
+        application_gateway_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
         application_gateway_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1122,7 +1149,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
         properties.backend_addresses = AAZListType(
             serialized_name="backendAddresses",
         )
@@ -1135,27 +1162,27 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        backend_addresses = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
+        backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
         backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
         _element.fqdn = AAZStrType()
         _element.ip_address = AAZStrType(
             serialized_name="ipAddress",
         )
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        application_security_groups = _schema_network_interface_ip_configuration_read.properties.application_security_groups
+        application_security_groups = _schema_common_network_interface_ip_configuration_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        load_balancer_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
+        load_balancer_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
         load_balancer_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1168,7 +1195,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
         properties.backend_ip_configurations = AAZListType(
             serialized_name="backendIPConfigurations",
             flags={"read_only": True},
@@ -1192,7 +1219,7 @@ class _CreateHelper:
             serialized_name="outboundRule",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.outbound_rule)
+        cls._build_schema_common_sub_resource_read(properties.outbound_rule)
         properties.outbound_rules = AAZListType(
             serialized_name="outboundRules",
             flags={"read_only": True},
@@ -1210,26 +1237,26 @@ class _CreateHelper:
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancer_backend_addresses = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
+        load_balancer_backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
         load_balancer_backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
         _element.name = AAZStrType()
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
         properties.admin_state = AAZStrType(
             serialized_name="adminState",
         )
@@ -1243,23 +1270,23 @@ class _CreateHelper:
         properties.load_balancer_frontend_ip_configuration = AAZObjectType(
             serialized_name="loadBalancerFrontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
         properties.network_interface_ip_configuration = AAZObjectType(
             serialized_name="networkInterfaceIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.network_interface_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.network_interface_ip_configuration)
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        inbound_nat_rules_port_mapping = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
+        inbound_nat_rules_port_mapping = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
         inbound_nat_rules_port_mapping.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
         _element.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -1270,27 +1297,27 @@ class _CreateHelper:
             serialized_name="inboundNatRuleName",
         )
 
-        load_balancing_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
+        outbound_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        tunnel_interfaces = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
+        tunnel_interfaces = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
         tunnel_interfaces.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
         _element.identifier = AAZIntType()
         _element.port = AAZIntType()
         _element.protocol = AAZStrType()
         _element.type = AAZStrType()
 
-        load_balancer_inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
+        load_balancer_inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
         load_balancer_inbound_nat_rules.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1303,16 +1330,16 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
         properties.backend_address_pool = AAZObjectType(
             serialized_name="backendAddressPool",
         )
-        cls._build_schema_sub_resource_read(properties.backend_address_pool)
+        cls._build_schema_common_sub_resource_read(properties.backend_address_pool)
         properties.backend_ip_configuration = AAZObjectType(
             serialized_name="backendIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.backend_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.backend_ip_configuration)
         properties.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -1325,7 +1352,7 @@ class _CreateHelper:
         properties.frontend_ip_configuration = AAZObjectType(
             serialized_name="frontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.frontend_ip_configuration)
         properties.frontend_port = AAZIntType(
             serialized_name="frontendPort",
         )
@@ -1344,7 +1371,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        private_link_connection_properties = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties
+        private_link_connection_properties = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties
         private_link_connection_properties.fqdns = AAZListType(
             flags={"read_only": True},
         )
@@ -1357,47 +1384,47 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        fqdns = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
+        fqdns = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
         fqdns.Element = AAZStrType()
 
-        virtual_network_taps = _schema_network_interface_ip_configuration_read.properties.virtual_network_taps
+        virtual_network_taps = _schema_common_network_interface_ip_configuration_read.properties.virtual_network_taps
         virtual_network_taps.Element = AAZObjectType()
-        cls._build_schema_virtual_network_tap_read(virtual_network_taps.Element)
+        cls._build_schema_common_virtual_network_tap_read(virtual_network_taps.Element)
 
-        _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-        _schema.id = cls._schema_network_interface_ip_configuration_read.id
-        _schema.name = cls._schema_network_interface_ip_configuration_read.name
-        _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-        _schema.type = cls._schema_network_interface_ip_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
 
-    _schema_network_interface_tap_configuration_read = None
+    _schema_common_network_interface_tap_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_tap_configuration_read(cls, _schema):
-        if cls._schema_network_interface_tap_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-            _schema.id = cls._schema_network_interface_tap_configuration_read.id
-            _schema.name = cls._schema_network_interface_tap_configuration_read.name
-            _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-            _schema.type = cls._schema_network_interface_tap_configuration_read.type
+    def _build_schema_common_network_interface_tap_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_tap_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
             return
 
-        cls._schema_network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read = AAZObjectType()
 
-        network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read
-        network_interface_tap_configuration_read.etag = AAZStrType(
+        common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read
+        common_network_interface_tap_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_tap_configuration_read.id = AAZStrType()
-        network_interface_tap_configuration_read.name = AAZStrType()
-        network_interface_tap_configuration_read.properties = AAZObjectType(
+        common_network_interface_tap_configuration_read.id = AAZStrType()
+        common_network_interface_tap_configuration_read.name = AAZStrType()
+        common_network_interface_tap_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_tap_configuration_read.type = AAZStrType(
+        common_network_interface_tap_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_tap_configuration_read.properties
+        properties = _schema_common_network_interface_tap_configuration_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -1405,53 +1432,53 @@ class _CreateHelper:
         properties.virtual_network_tap = AAZObjectType(
             serialized_name="virtualNetworkTap",
         )
-        cls._build_schema_virtual_network_tap_read(properties.virtual_network_tap)
+        cls._build_schema_common_virtual_network_tap_read(properties.virtual_network_tap)
 
-        _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-        _schema.id = cls._schema_network_interface_tap_configuration_read.id
-        _schema.name = cls._schema_network_interface_tap_configuration_read.name
-        _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-        _schema.type = cls._schema_network_interface_tap_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
 
-    _schema_network_interface_read = None
+    _schema_common_network_interface_read = None
 
     @classmethod
-    def _build_schema_network_interface_read(cls, _schema):
-        if cls._schema_network_interface_read is not None:
-            _schema.etag = cls._schema_network_interface_read.etag
-            _schema.extended_location = cls._schema_network_interface_read.extended_location
-            _schema.id = cls._schema_network_interface_read.id
-            _schema.location = cls._schema_network_interface_read.location
-            _schema.name = cls._schema_network_interface_read.name
-            _schema.properties = cls._schema_network_interface_read.properties
-            _schema.tags = cls._schema_network_interface_read.tags
-            _schema.type = cls._schema_network_interface_read.type
+    def _build_schema_common_network_interface_read(cls, _schema):
+        if cls._schema_common_network_interface_read is not None:
+            _schema.etag = cls._schema_common_network_interface_read.etag
+            _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+            _schema.id = cls._schema_common_network_interface_read.id
+            _schema.location = cls._schema_common_network_interface_read.location
+            _schema.name = cls._schema_common_network_interface_read.name
+            _schema.properties = cls._schema_common_network_interface_read.properties
+            _schema.tags = cls._schema_common_network_interface_read.tags
+            _schema.type = cls._schema_common_network_interface_read.type
             return
 
-        cls._schema_network_interface_read = _schema_network_interface_read = AAZObjectType()
+        cls._schema_common_network_interface_read = _schema_common_network_interface_read = AAZObjectType()
 
-        network_interface_read = _schema_network_interface_read
-        network_interface_read.etag = AAZStrType(
+        common_network_interface_read = _schema_common_network_interface_read
+        common_network_interface_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.extended_location = AAZObjectType(
+        common_network_interface_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(network_interface_read.extended_location)
-        network_interface_read.id = AAZStrType()
-        network_interface_read.location = AAZStrType()
-        network_interface_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_network_interface_read.extended_location)
+        common_network_interface_read.id = AAZStrType()
+        common_network_interface_read.location = AAZStrType()
+        common_network_interface_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.properties = AAZObjectType(
+        common_network_interface_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_read.tags = AAZDictType()
-        network_interface_read.type = AAZStrType(
+        common_network_interface_read.tags = AAZDictType()
+        common_network_interface_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties
+        properties = _schema_common_network_interface_read.properties
         properties.auxiliary_mode = AAZStrType(
             serialized_name="auxiliaryMode",
         )
@@ -1472,7 +1499,7 @@ class _CreateHelper:
             serialized_name="dscpConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.dscp_configuration)
+        cls._build_schema_common_sub_resource_read(properties.dscp_configuration)
         properties.enable_accelerated_networking = AAZBoolType(
             serialized_name="enableAcceleratedNetworking",
         )
@@ -1496,7 +1523,7 @@ class _CreateHelper:
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.nic_type = AAZStrType(
             serialized_name="nicType",
         )
@@ -1507,7 +1534,7 @@ class _CreateHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_link_service = AAZObjectType(
             serialized_name="privateLinkService",
         )
@@ -1527,7 +1554,7 @@ class _CreateHelper:
             serialized_name="virtualMachine",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.virtual_machine)
+        cls._build_schema_common_sub_resource_read(properties.virtual_machine)
         properties.vnet_encryption_supported = AAZBoolType(
             serialized_name="vnetEncryptionSupported",
             flags={"read_only": True},
@@ -1536,7 +1563,7 @@ class _CreateHelper:
             serialized_name="workloadType",
         )
 
-        dns_settings = _schema_network_interface_read.properties.dns_settings
+        dns_settings = _schema_common_network_interface_read.properties.dns_settings
         dns_settings.applied_dns_servers = AAZListType(
             serialized_name="appliedDnsServers",
             flags={"read_only": True},
@@ -1556,27 +1583,27 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        applied_dns_servers = _schema_network_interface_read.properties.dns_settings.applied_dns_servers
+        applied_dns_servers = _schema_common_network_interface_read.properties.dns_settings.applied_dns_servers
         applied_dns_servers.Element = AAZStrType()
 
-        dns_servers = _schema_network_interface_read.properties.dns_settings.dns_servers
+        dns_servers = _schema_common_network_interface_read.properties.dns_settings.dns_servers
         dns_servers.Element = AAZStrType()
 
-        hosted_workloads = _schema_network_interface_read.properties.hosted_workloads
+        hosted_workloads = _schema_common_network_interface_read.properties.hosted_workloads
         hosted_workloads.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(ip_configurations.Element)
 
-        private_link_service = _schema_network_interface_read.properties.private_link_service
+        private_link_service = _schema_common_network_interface_read.properties.private_link_service
         private_link_service.etag = AAZStrType(
             flags={"read_only": True},
         )
         private_link_service.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_link_service.extended_location)
+        cls._build_schema_common_extended_location_read(private_link_service.extended_location)
         private_link_service.id = AAZStrType()
         private_link_service.location = AAZStrType()
         private_link_service.name = AAZStrType(
@@ -1590,7 +1617,10 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties
+        properties.access_mode = AAZStrType(
+            serialized_name="accessMode",
+        )
         properties.alias = AAZStrType(
             flags={"read_only": True},
         )
@@ -1624,19 +1654,19 @@ class _CreateHelper:
         )
         properties.visibility = AAZObjectType()
 
-        auto_approval = _schema_network_interface_read.properties.private_link_service.properties.auto_approval
+        auto_approval = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval
         auto_approval.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
         subscriptions.Element = AAZStrType()
 
-        fqdns = _schema_network_interface_read.properties.private_link_service.properties.fqdns
+        fqdns = _schema_common_network_interface_read.properties.private_link_service.properties.fqdns
         fqdns.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1649,7 +1679,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
         properties.primary = AAZBoolType()
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
@@ -1665,20 +1695,20 @@ class _CreateHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        load_balancer_frontend_ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
+        load_balancer_frontend_ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
         load_balancer_frontend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
+        cls._build_schema_common_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
 
-        network_interfaces = _schema_network_interface_read.properties.private_link_service.properties.network_interfaces
+        network_interfaces = _schema_common_network_interface_read.properties.private_link_service.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_endpoint_connections = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
+        private_endpoint_connections = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
         private_endpoint_connections.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1691,7 +1721,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
         properties.link_identifier = AAZStrType(
             serialized_name="linkIdentifier",
             flags={"read_only": True},
@@ -1700,7 +1730,7 @@ class _CreateHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_endpoint_location = AAZStrType(
             serialized_name="privateEndpointLocation",
             flags={"read_only": True},
@@ -1708,71 +1738,71 @@ class _CreateHelper:
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
 
-        visibility = _schema_network_interface_read.properties.private_link_service.properties.visibility
+        visibility = _schema_common_network_interface_read.properties.private_link_service.properties.visibility
         visibility.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
         subscriptions.Element = AAZStrType()
 
-        tags = _schema_network_interface_read.properties.private_link_service.tags
+        tags = _schema_common_network_interface_read.properties.private_link_service.tags
         tags.Element = AAZStrType()
 
-        tap_configurations = _schema_network_interface_read.properties.tap_configurations
+        tap_configurations = _schema_common_network_interface_read.properties.tap_configurations
         tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(tap_configurations.Element)
 
-        tags = _schema_network_interface_read.tags
+        tags = _schema_common_network_interface_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_interface_read.etag
-        _schema.extended_location = cls._schema_network_interface_read.extended_location
-        _schema.id = cls._schema_network_interface_read.id
-        _schema.location = cls._schema_network_interface_read.location
-        _schema.name = cls._schema_network_interface_read.name
-        _schema.properties = cls._schema_network_interface_read.properties
-        _schema.tags = cls._schema_network_interface_read.tags
-        _schema.type = cls._schema_network_interface_read.type
+        _schema.etag = cls._schema_common_network_interface_read.etag
+        _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+        _schema.id = cls._schema_common_network_interface_read.id
+        _schema.location = cls._schema_common_network_interface_read.location
+        _schema.name = cls._schema_common_network_interface_read.name
+        _schema.properties = cls._schema_common_network_interface_read.properties
+        _schema.tags = cls._schema_common_network_interface_read.tags
+        _schema.type = cls._schema_common_network_interface_read.type
 
-    _schema_network_security_group_read = None
+    _schema_common_network_security_group_read = None
 
     @classmethod
-    def _build_schema_network_security_group_read(cls, _schema):
-        if cls._schema_network_security_group_read is not None:
-            _schema.etag = cls._schema_network_security_group_read.etag
-            _schema.id = cls._schema_network_security_group_read.id
-            _schema.location = cls._schema_network_security_group_read.location
-            _schema.name = cls._schema_network_security_group_read.name
-            _schema.properties = cls._schema_network_security_group_read.properties
-            _schema.tags = cls._schema_network_security_group_read.tags
-            _schema.type = cls._schema_network_security_group_read.type
+    def _build_schema_common_network_security_group_read(cls, _schema):
+        if cls._schema_common_network_security_group_read is not None:
+            _schema.etag = cls._schema_common_network_security_group_read.etag
+            _schema.id = cls._schema_common_network_security_group_read.id
+            _schema.location = cls._schema_common_network_security_group_read.location
+            _schema.name = cls._schema_common_network_security_group_read.name
+            _schema.properties = cls._schema_common_network_security_group_read.properties
+            _schema.tags = cls._schema_common_network_security_group_read.tags
+            _schema.type = cls._schema_common_network_security_group_read.type
             return
 
-        cls._schema_network_security_group_read = _schema_network_security_group_read = AAZObjectType()
+        cls._schema_common_network_security_group_read = _schema_common_network_security_group_read = AAZObjectType()
 
-        network_security_group_read = _schema_network_security_group_read
-        network_security_group_read.etag = AAZStrType(
+        common_network_security_group_read = _schema_common_network_security_group_read
+        common_network_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.id = AAZStrType()
-        network_security_group_read.location = AAZStrType()
-        network_security_group_read.name = AAZStrType(
+        common_network_security_group_read.id = AAZStrType()
+        common_network_security_group_read.location = AAZStrType()
+        common_network_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.properties = AAZObjectType(
+        common_network_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_security_group_read.tags = AAZDictType()
-        network_security_group_read.type = AAZStrType(
+        common_network_security_group_read.tags = AAZDictType()
+        common_network_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties
+        properties = _schema_common_network_security_group_read.properties
         properties.default_security_rules = AAZListType(
             serialized_name="defaultSecurityRules",
             flags={"read_only": True},
@@ -1803,14 +1833,14 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        default_security_rules = _schema_network_security_group_read.properties.default_security_rules
+        default_security_rules = _schema_common_network_security_group_read.properties.default_security_rules
         default_security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(default_security_rules.Element)
+        cls._build_schema_common_security_rule_read(default_security_rules.Element)
 
-        flow_logs = _schema_network_security_group_read.properties.flow_logs
+        flow_logs = _schema_common_network_security_group_read.properties.flow_logs
         flow_logs.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1828,7 +1858,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        identity = _schema_network_security_group_read.properties.flow_logs.Element.identity
+        identity = _schema_common_network_security_group_read.properties.flow_logs.Element.identity
         identity.principal_id = AAZStrType(
             serialized_name="principalId",
             flags={"read_only": True},
@@ -1842,10 +1872,10 @@ class _CreateHelper:
             serialized_name="userAssignedIdentities",
         )
 
-        user_assigned_identities = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
+        user_assigned_identities = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
         user_assigned_identities.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
         _element.client_id = AAZStrType(
             serialized_name="clientId",
             flags={"read_only": True},
@@ -1855,7 +1885,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties.flow_logs.Element.properties
+        properties = _schema_common_network_security_group_read.properties.flow_logs.Element.properties
         properties.enabled = AAZBoolType()
         properties.enabled_filtering_criteria = AAZStrType(
             serialized_name="enabledFilteringCriteria",
@@ -1867,6 +1897,9 @@ class _CreateHelper:
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
+        )
+        properties.record_types = AAZStrType(
+            serialized_name="recordTypes",
         )
         properties.retention_policy = AAZObjectType(
             serialized_name="retentionPolicy",
@@ -1884,12 +1917,12 @@ class _CreateHelper:
             flags={"required": True},
         )
 
-        flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
+        flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
         flow_analytics_configuration.network_watcher_flow_analytics_configuration = AAZObjectType(
             serialized_name="networkWatcherFlowAnalyticsConfiguration",
         )
 
-        network_watcher_flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
+        network_watcher_flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
         network_watcher_flow_analytics_configuration.enabled = AAZBoolType()
         network_watcher_flow_analytics_configuration.traffic_analytics_interval = AAZIntType(
             serialized_name="trafficAnalyticsInterval",
@@ -1904,83 +1937,86 @@ class _CreateHelper:
             serialized_name="workspaceResourceId",
         )
 
-        format = _schema_network_security_group_read.properties.flow_logs.Element.properties.format
+        format = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.format
         format.type = AAZStrType()
         format.version = AAZIntType()
 
-        retention_policy = _schema_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
+        retention_policy = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
         retention_policy.days = AAZIntType()
         retention_policy.enabled = AAZBoolType()
 
-        tags = _schema_network_security_group_read.properties.flow_logs.Element.tags
+        tags = _schema_common_network_security_group_read.properties.flow_logs.Element.tags
         tags.Element = AAZStrType()
 
-        network_interfaces = _schema_network_security_group_read.properties.network_interfaces
+        network_interfaces = _schema_common_network_security_group_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        security_rules = _schema_network_security_group_read.properties.security_rules
+        security_rules = _schema_common_network_security_group_read.properties.security_rules
         security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(security_rules.Element)
+        cls._build_schema_common_security_rule_read(security_rules.Element)
 
-        subnets = _schema_network_security_group_read.properties.subnets
+        subnets = _schema_common_network_security_group_read.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_network_security_group_read.tags
+        tags = _schema_common_network_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_security_group_read.etag
-        _schema.id = cls._schema_network_security_group_read.id
-        _schema.location = cls._schema_network_security_group_read.location
-        _schema.name = cls._schema_network_security_group_read.name
-        _schema.properties = cls._schema_network_security_group_read.properties
-        _schema.tags = cls._schema_network_security_group_read.tags
-        _schema.type = cls._schema_network_security_group_read.type
+        _schema.etag = cls._schema_common_network_security_group_read.etag
+        _schema.id = cls._schema_common_network_security_group_read.id
+        _schema.location = cls._schema_common_network_security_group_read.location
+        _schema.name = cls._schema_common_network_security_group_read.name
+        _schema.properties = cls._schema_common_network_security_group_read.properties
+        _schema.tags = cls._schema_common_network_security_group_read.tags
+        _schema.type = cls._schema_common_network_security_group_read.type
 
-    _schema_private_endpoint_read = None
+    _schema_common_private_endpoint_read = None
 
     @classmethod
-    def _build_schema_private_endpoint_read(cls, _schema):
-        if cls._schema_private_endpoint_read is not None:
-            _schema.etag = cls._schema_private_endpoint_read.etag
-            _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-            _schema.id = cls._schema_private_endpoint_read.id
-            _schema.location = cls._schema_private_endpoint_read.location
-            _schema.name = cls._schema_private_endpoint_read.name
-            _schema.properties = cls._schema_private_endpoint_read.properties
-            _schema.tags = cls._schema_private_endpoint_read.tags
-            _schema.type = cls._schema_private_endpoint_read.type
+    def _build_schema_common_private_endpoint_read(cls, _schema):
+        if cls._schema_common_private_endpoint_read is not None:
+            _schema.etag = cls._schema_common_private_endpoint_read.etag
+            _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+            _schema.id = cls._schema_common_private_endpoint_read.id
+            _schema.location = cls._schema_common_private_endpoint_read.location
+            _schema.name = cls._schema_common_private_endpoint_read.name
+            _schema.properties = cls._schema_common_private_endpoint_read.properties
+            _schema.tags = cls._schema_common_private_endpoint_read.tags
+            _schema.type = cls._schema_common_private_endpoint_read.type
             return
 
-        cls._schema_private_endpoint_read = _schema_private_endpoint_read = AAZObjectType(
+        cls._schema_common_private_endpoint_read = _schema_common_private_endpoint_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        private_endpoint_read = _schema_private_endpoint_read
-        private_endpoint_read.etag = AAZStrType(
+        common_private_endpoint_read = _schema_common_private_endpoint_read
+        common_private_endpoint_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.extended_location = AAZObjectType(
+        common_private_endpoint_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_endpoint_read.extended_location)
-        private_endpoint_read.id = AAZStrType()
-        private_endpoint_read.location = AAZStrType()
-        private_endpoint_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_private_endpoint_read.extended_location)
+        common_private_endpoint_read.id = AAZStrType()
+        common_private_endpoint_read.location = AAZStrType()
+        common_private_endpoint_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.properties = AAZObjectType(
+        common_private_endpoint_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_endpoint_read.tags = AAZDictType()
-        private_endpoint_read.type = AAZStrType(
+        common_private_endpoint_read.tags = AAZDictType()
+        common_private_endpoint_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties
+        properties = _schema_common_private_endpoint_read.properties
         properties.application_security_groups = AAZListType(
             serialized_name="applicationSecurityGroups",
+        )
+        properties.billing_sku = AAZStrType(
+            serialized_name="billingSku",
         )
         properties.custom_dns_configs = AAZListType(
             serialized_name="customDnsConfigs",
@@ -1990,6 +2026,9 @@ class _CreateHelper:
         )
         properties.ip_configurations = AAZListType(
             serialized_name="ipConfigurations",
+        )
+        properties.ip_version_type = AAZStrType(
+            serialized_name="ipVersionType",
         )
         properties.manual_private_link_service_connections = AAZListType(
             serialized_name="manualPrivateLinkServiceConnections",
@@ -2006,28 +2045,28 @@ class _CreateHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        application_security_groups = _schema_private_endpoint_read.properties.application_security_groups
+        application_security_groups = _schema_common_private_endpoint_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        custom_dns_configs = _schema_private_endpoint_read.properties.custom_dns_configs
+        custom_dns_configs = _schema_common_private_endpoint_read.properties.custom_dns_configs
         custom_dns_configs.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.custom_dns_configs.Element
+        _element = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element
         _element.fqdn = AAZStrType()
         _element.ip_addresses = AAZListType(
             serialized_name="ipAddresses",
         )
 
-        ip_addresses = _schema_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
+        ip_addresses = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
         ip_addresses.Element = AAZStrType()
 
-        ip_configurations = _schema_private_endpoint_read.properties.ip_configurations
+        ip_configurations = _schema_common_private_endpoint_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.ip_configurations.Element
+        _element = _schema_common_private_endpoint_read.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2039,7 +2078,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties.ip_configurations.Element.properties
+        properties = _schema_common_private_endpoint_read.properties.ip_configurations.Element.properties
         properties.group_id = AAZStrType(
             serialized_name="groupId",
         )
@@ -2050,88 +2089,88 @@ class _CreateHelper:
             serialized_name="privateIPAddress",
         )
 
-        manual_private_link_service_connections = _schema_private_endpoint_read.properties.manual_private_link_service_connections
+        manual_private_link_service_connections = _schema_common_private_endpoint_read.properties.manual_private_link_service_connections
         manual_private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(manual_private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(manual_private_link_service_connections.Element)
 
-        network_interfaces = _schema_private_endpoint_read.properties.network_interfaces
+        network_interfaces = _schema_common_private_endpoint_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_link_service_connections = _schema_private_endpoint_read.properties.private_link_service_connections
+        private_link_service_connections = _schema_common_private_endpoint_read.properties.private_link_service_connections
         private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(private_link_service_connections.Element)
 
-        tags = _schema_private_endpoint_read.tags
+        tags = _schema_common_private_endpoint_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_endpoint_read.etag
-        _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-        _schema.id = cls._schema_private_endpoint_read.id
-        _schema.location = cls._schema_private_endpoint_read.location
-        _schema.name = cls._schema_private_endpoint_read.name
-        _schema.properties = cls._schema_private_endpoint_read.properties
-        _schema.tags = cls._schema_private_endpoint_read.tags
-        _schema.type = cls._schema_private_endpoint_read.type
+        _schema.etag = cls._schema_common_private_endpoint_read.etag
+        _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+        _schema.id = cls._schema_common_private_endpoint_read.id
+        _schema.location = cls._schema_common_private_endpoint_read.location
+        _schema.name = cls._schema_common_private_endpoint_read.name
+        _schema.properties = cls._schema_common_private_endpoint_read.properties
+        _schema.tags = cls._schema_common_private_endpoint_read.tags
+        _schema.type = cls._schema_common_private_endpoint_read.type
 
-    _schema_private_link_service_connection_state_read = None
+    _schema_common_private_link_service_connection_state_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_state_read(cls, _schema):
-        if cls._schema_private_link_service_connection_state_read is not None:
-            _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-            _schema.description = cls._schema_private_link_service_connection_state_read.description
-            _schema.status = cls._schema_private_link_service_connection_state_read.status
+    def _build_schema_common_private_link_service_connection_state_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_state_read is not None:
+            _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+            _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+            _schema.status = cls._schema_common_private_link_service_connection_state_read.status
             return
 
-        cls._schema_private_link_service_connection_state_read = _schema_private_link_service_connection_state_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read = AAZObjectType()
 
-        private_link_service_connection_state_read = _schema_private_link_service_connection_state_read
-        private_link_service_connection_state_read.actions_required = AAZStrType(
+        common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read
+        common_private_link_service_connection_state_read.actions_required = AAZStrType(
             serialized_name="actionsRequired",
         )
-        private_link_service_connection_state_read.description = AAZStrType()
-        private_link_service_connection_state_read.status = AAZStrType()
+        common_private_link_service_connection_state_read.description = AAZStrType()
+        common_private_link_service_connection_state_read.status = AAZStrType()
 
-        _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-        _schema.description = cls._schema_private_link_service_connection_state_read.description
-        _schema.status = cls._schema_private_link_service_connection_state_read.status
+        _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+        _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+        _schema.status = cls._schema_common_private_link_service_connection_state_read.status
 
-    _schema_private_link_service_connection_read = None
+    _schema_common_private_link_service_connection_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_read(cls, _schema):
-        if cls._schema_private_link_service_connection_read is not None:
-            _schema.etag = cls._schema_private_link_service_connection_read.etag
-            _schema.id = cls._schema_private_link_service_connection_read.id
-            _schema.name = cls._schema_private_link_service_connection_read.name
-            _schema.properties = cls._schema_private_link_service_connection_read.properties
-            _schema.type = cls._schema_private_link_service_connection_read.type
+    def _build_schema_common_private_link_service_connection_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_read is not None:
+            _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+            _schema.id = cls._schema_common_private_link_service_connection_read.id
+            _schema.name = cls._schema_common_private_link_service_connection_read.name
+            _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+            _schema.type = cls._schema_common_private_link_service_connection_read.type
             return
 
-        cls._schema_private_link_service_connection_read = _schema_private_link_service_connection_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_read = _schema_common_private_link_service_connection_read = AAZObjectType()
 
-        private_link_service_connection_read = _schema_private_link_service_connection_read
-        private_link_service_connection_read.etag = AAZStrType(
+        common_private_link_service_connection_read = _schema_common_private_link_service_connection_read
+        common_private_link_service_connection_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_link_service_connection_read.id = AAZStrType()
-        private_link_service_connection_read.name = AAZStrType()
-        private_link_service_connection_read.properties = AAZObjectType(
+        common_private_link_service_connection_read.id = AAZStrType()
+        common_private_link_service_connection_read.name = AAZStrType()
+        common_private_link_service_connection_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_link_service_connection_read.type = AAZStrType(
+        common_private_link_service_connection_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_link_service_connection_read.properties
+        properties = _schema_common_private_link_service_connection_read.properties
         properties.group_ids = AAZListType(
             serialized_name="groupIds",
         )
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.private_link_service_id = AAZStrType(
             serialized_name="privateLinkServiceId",
         )
@@ -2143,58 +2182,58 @@ class _CreateHelper:
             serialized_name="requestMessage",
         )
 
-        group_ids = _schema_private_link_service_connection_read.properties.group_ids
+        group_ids = _schema_common_private_link_service_connection_read.properties.group_ids
         group_ids.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_link_service_connection_read.etag
-        _schema.id = cls._schema_private_link_service_connection_read.id
-        _schema.name = cls._schema_private_link_service_connection_read.name
-        _schema.properties = cls._schema_private_link_service_connection_read.properties
-        _schema.type = cls._schema_private_link_service_connection_read.type
+        _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+        _schema.id = cls._schema_common_private_link_service_connection_read.id
+        _schema.name = cls._schema_common_private_link_service_connection_read.name
+        _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+        _schema.type = cls._schema_common_private_link_service_connection_read.type
 
-    _schema_public_ip_address_read = None
+    _schema_common_public_ip_address_read = None
 
     @classmethod
-    def _build_schema_public_ip_address_read(cls, _schema):
-        if cls._schema_public_ip_address_read is not None:
-            _schema.etag = cls._schema_public_ip_address_read.etag
-            _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-            _schema.id = cls._schema_public_ip_address_read.id
-            _schema.location = cls._schema_public_ip_address_read.location
-            _schema.name = cls._schema_public_ip_address_read.name
-            _schema.properties = cls._schema_public_ip_address_read.properties
-            _schema.sku = cls._schema_public_ip_address_read.sku
-            _schema.tags = cls._schema_public_ip_address_read.tags
-            _schema.type = cls._schema_public_ip_address_read.type
-            _schema.zones = cls._schema_public_ip_address_read.zones
+    def _build_schema_common_public_ip_address_read(cls, _schema):
+        if cls._schema_common_public_ip_address_read is not None:
+            _schema.etag = cls._schema_common_public_ip_address_read.etag
+            _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+            _schema.id = cls._schema_common_public_ip_address_read.id
+            _schema.location = cls._schema_common_public_ip_address_read.location
+            _schema.name = cls._schema_common_public_ip_address_read.name
+            _schema.properties = cls._schema_common_public_ip_address_read.properties
+            _schema.sku = cls._schema_common_public_ip_address_read.sku
+            _schema.tags = cls._schema_common_public_ip_address_read.tags
+            _schema.type = cls._schema_common_public_ip_address_read.type
+            _schema.zones = cls._schema_common_public_ip_address_read.zones
             return
 
-        cls._schema_public_ip_address_read = _schema_public_ip_address_read = AAZObjectType()
+        cls._schema_common_public_ip_address_read = _schema_common_public_ip_address_read = AAZObjectType()
 
-        public_ip_address_read = _schema_public_ip_address_read
-        public_ip_address_read.etag = AAZStrType(
+        common_public_ip_address_read = _schema_common_public_ip_address_read
+        common_public_ip_address_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.extended_location = AAZObjectType(
+        common_public_ip_address_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(public_ip_address_read.extended_location)
-        public_ip_address_read.id = AAZStrType()
-        public_ip_address_read.location = AAZStrType()
-        public_ip_address_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_public_ip_address_read.extended_location)
+        common_public_ip_address_read.id = AAZStrType()
+        common_public_ip_address_read.location = AAZStrType()
+        common_public_ip_address_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.properties = AAZObjectType(
+        common_public_ip_address_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        public_ip_address_read.sku = AAZObjectType()
-        public_ip_address_read.tags = AAZDictType()
-        public_ip_address_read.type = AAZStrType(
+        common_public_ip_address_read.sku = AAZObjectType()
+        common_public_ip_address_read.tags = AAZDictType()
+        common_public_ip_address_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.zones = AAZListType()
+        common_public_ip_address_read.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties
+        properties = _schema_common_public_ip_address_read.properties
         properties.ddos_settings = AAZObjectType(
             serialized_name="ddosSettings",
         )
@@ -2214,14 +2253,14 @@ class _CreateHelper:
             serialized_name="ipConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_ip_configuration_read(properties.ip_configuration)
+        cls._build_schema_common_ip_configuration_read(properties.ip_configuration)
         properties.ip_tags = AAZListType(
             serialized_name="ipTags",
         )
         properties.linked_public_ip_address = AAZObjectType(
             serialized_name="linkedPublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.linked_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.linked_public_ip_address)
         properties.migration_phase = AAZStrType(
             serialized_name="migrationPhase",
         )
@@ -2241,7 +2280,7 @@ class _CreateHelper:
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.resource_guid = AAZStrType(
             serialized_name="resourceGuid",
             flags={"read_only": True},
@@ -2249,18 +2288,22 @@ class _CreateHelper:
         properties.service_public_ip_address = AAZObjectType(
             serialized_name="servicePublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.service_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.service_public_ip_address)
 
-        ddos_settings = _schema_public_ip_address_read.properties.ddos_settings
+        ddos_settings = _schema_common_public_ip_address_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
         ddos_settings.ddos_protection_plan = AAZObjectType(
             serialized_name="ddosProtectionPlan",
         )
-        cls._build_schema_sub_resource_read(ddos_settings.ddos_protection_plan)
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_protection_plan)
         ddos_settings.protection_mode = AAZStrType(
             serialized_name="protectionMode",
         )
 
-        dns_settings = _schema_public_ip_address_read.properties.dns_settings
+        dns_settings = _schema_common_public_ip_address_read.properties.dns_settings
         dns_settings.domain_name_label = AAZStrType(
             serialized_name="domainNameLabel",
         )
@@ -2272,16 +2315,16 @@ class _CreateHelper:
             serialized_name="reverseFqdn",
         )
 
-        ip_tags = _schema_public_ip_address_read.properties.ip_tags
+        ip_tags = _schema_common_public_ip_address_read.properties.ip_tags
         ip_tags.Element = AAZObjectType()
 
-        _element = _schema_public_ip_address_read.properties.ip_tags.Element
+        _element = _schema_common_public_ip_address_read.properties.ip_tags.Element
         _element.ip_tag_type = AAZStrType(
             serialized_name="ipTagType",
         )
         _element.tag = AAZStrType()
 
-        nat_gateway = _schema_public_ip_address_read.properties.nat_gateway
+        nat_gateway = _schema_common_public_ip_address_read.properties.nat_gateway
         nat_gateway.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2300,10 +2343,11 @@ class _CreateHelper:
         )
         nat_gateway.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties.nat_gateway.properties
+        properties = _schema_common_public_ip_address_read.properties.nat_gateway.properties
         properties.idle_timeout_in_minutes = AAZIntType(
             serialized_name="idleTimeoutInMinutes",
         )
+        properties.nat64 = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -2324,90 +2368,96 @@ class _CreateHelper:
             serialized_name="resourceGuid",
             flags={"read_only": True},
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.source_virtual_network = AAZObjectType(
             serialized_name="sourceVirtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.source_virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.source_virtual_network)
         properties.subnets = AAZListType(
             flags={"read_only": True},
         )
 
-        public_ip_addresses = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
+        public_ip_addresses = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
         public_ip_addresses.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
+        public_ip_addresses_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
+        public_ip_prefixes = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
-        subnets = _schema_public_ip_address_read.properties.nat_gateway.properties.subnets
+        subnets = _schema_common_public_ip_address_read.properties.nat_gateway.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(subnets.Element)
+        cls._build_schema_common_sub_resource_read(subnets.Element)
 
-        sku = _schema_public_ip_address_read.properties.nat_gateway.sku
+        sku = _schema_common_public_ip_address_read.properties.nat_gateway.sku
         sku.name = AAZStrType()
 
-        tags = _schema_public_ip_address_read.properties.nat_gateway.tags
+        tags = _schema_common_public_ip_address_read.properties.nat_gateway.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.properties.nat_gateway.zones
+        zones = _schema_common_public_ip_address_read.properties.nat_gateway.zones
         zones.Element = AAZStrType()
 
-        sku = _schema_public_ip_address_read.sku
+        sku = _schema_common_public_ip_address_read.sku
         sku.name = AAZStrType()
         sku.tier = AAZStrType()
 
-        tags = _schema_public_ip_address_read.tags
+        tags = _schema_common_public_ip_address_read.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.zones
+        zones = _schema_common_public_ip_address_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_public_ip_address_read.etag
-        _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-        _schema.id = cls._schema_public_ip_address_read.id
-        _schema.location = cls._schema_public_ip_address_read.location
-        _schema.name = cls._schema_public_ip_address_read.name
-        _schema.properties = cls._schema_public_ip_address_read.properties
-        _schema.sku = cls._schema_public_ip_address_read.sku
-        _schema.tags = cls._schema_public_ip_address_read.tags
-        _schema.type = cls._schema_public_ip_address_read.type
-        _schema.zones = cls._schema_public_ip_address_read.zones
+        _schema.etag = cls._schema_common_public_ip_address_read.etag
+        _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+        _schema.id = cls._schema_common_public_ip_address_read.id
+        _schema.location = cls._schema_common_public_ip_address_read.location
+        _schema.name = cls._schema_common_public_ip_address_read.name
+        _schema.properties = cls._schema_common_public_ip_address_read.properties
+        _schema.sku = cls._schema_common_public_ip_address_read.sku
+        _schema.tags = cls._schema_common_public_ip_address_read.tags
+        _schema.type = cls._schema_common_public_ip_address_read.type
+        _schema.zones = cls._schema_common_public_ip_address_read.zones
 
-    _schema_security_rule_read = None
+    _schema_common_security_rule_read = None
 
     @classmethod
-    def _build_schema_security_rule_read(cls, _schema):
-        if cls._schema_security_rule_read is not None:
-            _schema.etag = cls._schema_security_rule_read.etag
-            _schema.id = cls._schema_security_rule_read.id
-            _schema.name = cls._schema_security_rule_read.name
-            _schema.properties = cls._schema_security_rule_read.properties
-            _schema.type = cls._schema_security_rule_read.type
+    def _build_schema_common_security_rule_read(cls, _schema):
+        if cls._schema_common_security_rule_read is not None:
+            _schema.etag = cls._schema_common_security_rule_read.etag
+            _schema.id = cls._schema_common_security_rule_read.id
+            _schema.name = cls._schema_common_security_rule_read.name
+            _schema.properties = cls._schema_common_security_rule_read.properties
+            _schema.type = cls._schema_common_security_rule_read.type
             return
 
-        cls._schema_security_rule_read = _schema_security_rule_read = AAZObjectType()
+        cls._schema_common_security_rule_read = _schema_common_security_rule_read = AAZObjectType()
 
-        security_rule_read = _schema_security_rule_read
-        security_rule_read.etag = AAZStrType(
+        common_security_rule_read = _schema_common_security_rule_read
+        common_security_rule_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        security_rule_read.id = AAZStrType()
-        security_rule_read.name = AAZStrType()
-        security_rule_read.properties = AAZObjectType(
+        common_security_rule_read.id = AAZStrType()
+        common_security_rule_read.name = AAZStrType()
+        common_security_rule_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        security_rule_read.type = AAZStrType()
+        common_security_rule_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_security_rule_read.properties
+        properties = _schema_common_security_rule_read.properties
         properties.access = AAZStrType(
             flags={"required": True},
         )
@@ -2456,75 +2506,77 @@ class _CreateHelper:
             serialized_name="sourcePortRanges",
         )
 
-        destination_address_prefixes = _schema_security_rule_read.properties.destination_address_prefixes
+        destination_address_prefixes = _schema_common_security_rule_read.properties.destination_address_prefixes
         destination_address_prefixes.Element = AAZStrType()
 
-        destination_application_security_groups = _schema_security_rule_read.properties.destination_application_security_groups
+        destination_application_security_groups = _schema_common_security_rule_read.properties.destination_application_security_groups
         destination_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(destination_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(destination_application_security_groups.Element)
 
-        destination_port_ranges = _schema_security_rule_read.properties.destination_port_ranges
+        destination_port_ranges = _schema_common_security_rule_read.properties.destination_port_ranges
         destination_port_ranges.Element = AAZStrType()
 
-        source_address_prefixes = _schema_security_rule_read.properties.source_address_prefixes
+        source_address_prefixes = _schema_common_security_rule_read.properties.source_address_prefixes
         source_address_prefixes.Element = AAZStrType()
 
-        source_application_security_groups = _schema_security_rule_read.properties.source_application_security_groups
+        source_application_security_groups = _schema_common_security_rule_read.properties.source_application_security_groups
         source_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(source_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(source_application_security_groups.Element)
 
-        source_port_ranges = _schema_security_rule_read.properties.source_port_ranges
+        source_port_ranges = _schema_common_security_rule_read.properties.source_port_ranges
         source_port_ranges.Element = AAZStrType()
 
-        _schema.etag = cls._schema_security_rule_read.etag
-        _schema.id = cls._schema_security_rule_read.id
-        _schema.name = cls._schema_security_rule_read.name
-        _schema.properties = cls._schema_security_rule_read.properties
-        _schema.type = cls._schema_security_rule_read.type
+        _schema.etag = cls._schema_common_security_rule_read.etag
+        _schema.id = cls._schema_common_security_rule_read.id
+        _schema.name = cls._schema_common_security_rule_read.name
+        _schema.properties = cls._schema_common_security_rule_read.properties
+        _schema.type = cls._schema_common_security_rule_read.type
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType(
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
-    _schema_subnet_read = None
+    _schema_common_subnet_read = None
 
     @classmethod
-    def _build_schema_subnet_read(cls, _schema):
-        if cls._schema_subnet_read is not None:
-            _schema.etag = cls._schema_subnet_read.etag
-            _schema.id = cls._schema_subnet_read.id
-            _schema.name = cls._schema_subnet_read.name
-            _schema.properties = cls._schema_subnet_read.properties
-            _schema.type = cls._schema_subnet_read.type
+    def _build_schema_common_subnet_read(cls, _schema):
+        if cls._schema_common_subnet_read is not None:
+            _schema.etag = cls._schema_common_subnet_read.etag
+            _schema.id = cls._schema_common_subnet_read.id
+            _schema.name = cls._schema_common_subnet_read.name
+            _schema.properties = cls._schema_common_subnet_read.properties
+            _schema.type = cls._schema_common_subnet_read.type
             return
 
-        cls._schema_subnet_read = _schema_subnet_read = AAZObjectType()
+        cls._schema_common_subnet_read = _schema_common_subnet_read = AAZObjectType()
 
-        subnet_read = _schema_subnet_read
-        subnet_read.etag = AAZStrType(
+        common_subnet_read = _schema_common_subnet_read
+        common_subnet_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        subnet_read.id = AAZStrType()
-        subnet_read.name = AAZStrType()
-        subnet_read.properties = AAZObjectType(
+        common_subnet_read.id = AAZStrType()
+        common_subnet_read.name = AAZStrType()
+        common_subnet_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        subnet_read.type = AAZStrType()
+        common_subnet_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties
+        properties = _schema_common_subnet_read.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
@@ -2555,11 +2607,11 @@ class _CreateHelper:
         properties.nat_gateway = AAZObjectType(
             serialized_name="natGateway",
         )
-        cls._build_schema_sub_resource_read(properties.nat_gateway)
+        cls._build_schema_common_sub_resource_read(properties.nat_gateway)
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.private_endpoint_network_policies = AAZStrType(
             serialized_name="privateEndpointNetworkPolicies",
         )
@@ -2594,17 +2646,21 @@ class _CreateHelper:
         properties.service_endpoints = AAZListType(
             serialized_name="serviceEndpoints",
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.sharing_scope = AAZStrType(
             serialized_name="sharingScope",
         )
 
-        address_prefixes = _schema_subnet_read.properties.address_prefixes
+        address_prefixes = _schema_common_subnet_read.properties.address_prefixes
         address_prefixes.Element = AAZStrType()
 
-        application_gateway_ip_configurations = _schema_subnet_read.properties.application_gateway_ip_configurations
+        application_gateway_ip_configurations = _schema_common_subnet_read.properties.application_gateway_ip_configurations
         application_gateway_ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.application_gateway_ip_configurations.Element
+        _element = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2617,18 +2673,18 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.application_gateway_ip_configurations.Element.properties
+        properties = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
 
-        delegations = _schema_subnet_read.properties.delegations
+        delegations = _schema_common_subnet_read.properties.delegations
         delegations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.delegations.Element
+        _element = _schema_common_subnet_read.properties.delegations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2639,7 +2695,7 @@ class _CreateHelper:
         )
         _element.type = AAZStrType()
 
-        properties = _schema_subnet_read.properties.delegations.Element.properties
+        properties = _schema_common_subnet_read.properties.delegations.Element.properties
         properties.actions = AAZListType(
             flags={"read_only": True},
         )
@@ -2651,17 +2707,17 @@ class _CreateHelper:
             serialized_name="serviceName",
         )
 
-        actions = _schema_subnet_read.properties.delegations.Element.properties.actions
+        actions = _schema_common_subnet_read.properties.delegations.Element.properties.actions
         actions.Element = AAZStrType()
 
-        ip_allocations = _schema_subnet_read.properties.ip_allocations
+        ip_allocations = _schema_common_subnet_read.properties.ip_allocations
         ip_allocations.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(ip_allocations.Element)
+        cls._build_schema_common_sub_resource_read(ip_allocations.Element)
 
-        ip_configuration_profiles = _schema_subnet_read.properties.ip_configuration_profiles
+        ip_configuration_profiles = _schema_common_subnet_read.properties.ip_configuration_profiles
         ip_configuration_profiles.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ip_configuration_profiles.Element
+        _element = _schema_common_subnet_read.properties.ip_configuration_profiles.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2674,22 +2730,22 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.ip_configuration_profiles.Element.properties
+        properties = _schema_common_subnet_read.properties.ip_configuration_profiles.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        ip_configurations = _schema_subnet_read.properties.ip_configurations
+        ip_configurations = _schema_common_subnet_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_ip_configuration_read(ip_configurations.Element)
 
-        ipam_pool_prefix_allocations = _schema_subnet_read.properties.ipam_pool_prefix_allocations
+        ipam_pool_prefix_allocations = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations
         ipam_pool_prefix_allocations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element
+        _element = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element
         _element.allocated_address_prefixes = AAZListType(
             serialized_name="allocatedAddressPrefixes",
             flags={"read_only": True},
@@ -2701,20 +2757,20 @@ class _CreateHelper:
             flags={"client_flatten": True},
         )
 
-        allocated_address_prefixes = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
+        allocated_address_prefixes = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
         allocated_address_prefixes.Element = AAZStrType()
 
-        pool = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
+        pool = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
         pool.id = AAZStrType()
 
-        private_endpoints = _schema_subnet_read.properties.private_endpoints
+        private_endpoints = _schema_common_subnet_read.properties.private_endpoints
         private_endpoints.Element = AAZObjectType()
-        cls._build_schema_private_endpoint_read(private_endpoints.Element)
+        cls._build_schema_common_private_endpoint_read(private_endpoints.Element)
 
-        resource_navigation_links = _schema_subnet_read.properties.resource_navigation_links
+        resource_navigation_links = _schema_common_subnet_read.properties.resource_navigation_links
         resource_navigation_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.resource_navigation_links.Element
+        _element = _schema_common_subnet_read.properties.resource_navigation_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2729,7 +2785,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.resource_navigation_links.Element.properties
+        properties = _schema_common_subnet_read.properties.resource_navigation_links.Element.properties
         properties.link = AAZStrType()
         properties.linked_resource_type = AAZStrType(
             serialized_name="linkedResourceType",
@@ -2739,7 +2795,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        route_table = _schema_subnet_read.properties.route_table
+        route_table = _schema_common_subnet_read.properties.route_table
         route_table.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2756,9 +2812,12 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.route_table.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties
         properties.disable_bgp_route_propagation = AAZBoolType(
             serialized_name="disableBgpRoutePropagation",
+        )
+        properties.disable_peering_route = AAZStrType(
+            serialized_name="disablePeeringRoute",
         )
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2773,10 +2832,10 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        routes = _schema_subnet_read.properties.route_table.properties.routes
+        routes = _schema_common_subnet_read.properties.route_table.properties.routes
         routes.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.route_table.properties.routes.Element
+        _element = _schema_common_subnet_read.properties.route_table.properties.routes.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2785,15 +2844,20 @@ class _CreateHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.route_table.properties.routes.Element.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
         properties.has_bgp_override = AAZBoolType(
             serialized_name="hasBgpOverride",
             flags={"read_only": True},
+        )
+        properties.next_hop = AAZObjectType(
+            serialized_name="nextHop",
         )
         properties.next_hop_ip_address = AAZStrType(
             serialized_name="nextHopIpAddress",
@@ -2807,17 +2871,26 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        subnets = _schema_subnet_read.properties.route_table.properties.subnets
-        subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        next_hop = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop
+        next_hop.next_hop_ip_addresses = AAZListType(
+            serialized_name="nextHopIpAddresses",
+            flags={"required": True},
+        )
 
-        tags = _schema_subnet_read.properties.route_table.tags
+        next_hop_ip_addresses = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop.next_hop_ip_addresses
+        next_hop_ip_addresses.Element = AAZStrType()
+
+        subnets = _schema_common_subnet_read.properties.route_table.properties.subnets
+        subnets.Element = AAZObjectType()
+        cls._build_schema_common_subnet_read(subnets.Element)
+
+        tags = _schema_common_subnet_read.properties.route_table.tags
         tags.Element = AAZStrType()
 
-        service_association_links = _schema_subnet_read.properties.service_association_links
+        service_association_links = _schema_common_subnet_read.properties.service_association_links
         service_association_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_association_links.Element
+        _element = _schema_common_subnet_read.properties.service_association_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2830,7 +2903,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_association_links.Element.properties
+        properties = _schema_common_subnet_read.properties.service_association_links.Element.properties
         properties.allow_delete = AAZBoolType(
             serialized_name="allowDelete",
         )
@@ -2844,13 +2917,13 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        locations = _schema_subnet_read.properties.service_association_links.Element.properties.locations
+        locations = _schema_common_subnet_read.properties.service_association_links.Element.properties.locations
         locations.Element = AAZStrType()
 
-        service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies
+        service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies
         service_endpoint_policies.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2870,7 +2943,7 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties
         properties.contextual_service_endpoint_policies = AAZListType(
             serialized_name="contextualServiceEndpointPolicies",
         )
@@ -2892,13 +2965,13 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        contextual_service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
+        contextual_service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
         contextual_service_endpoint_policies.Element = AAZStrType()
 
-        service_endpoint_policy_definitions = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
+        service_endpoint_policy_definitions = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
         service_endpoint_policy_definitions.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2907,9 +2980,11 @@ class _CreateHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
         properties.description = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2920,82 +2995,82 @@ class _CreateHelper:
             serialized_name="serviceResources",
         )
 
-        service_resources = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
+        service_resources = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
         service_resources.Element = AAZStrType()
 
-        subnets = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
+        subnets = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_subnet_read.properties.service_endpoint_policies.Element.tags
+        tags = _schema_common_subnet_read.properties.service_endpoint_policies.Element.tags
         tags.Element = AAZStrType()
 
-        service_endpoints = _schema_subnet_read.properties.service_endpoints
+        service_endpoints = _schema_common_subnet_read.properties.service_endpoints
         service_endpoints.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoints.Element
+        _element = _schema_common_subnet_read.properties.service_endpoints.Element
         _element.locations = AAZListType()
         _element.network_identifier = AAZObjectType(
             serialized_name="networkIdentifier",
         )
-        cls._build_schema_sub_resource_read(_element.network_identifier)
+        cls._build_schema_common_sub_resource_read(_element.network_identifier)
         _element.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         _element.service = AAZStrType()
 
-        locations = _schema_subnet_read.properties.service_endpoints.Element.locations
+        locations = _schema_common_subnet_read.properties.service_endpoints.Element.locations
         locations.Element = AAZStrType()
 
-        _schema.etag = cls._schema_subnet_read.etag
-        _schema.id = cls._schema_subnet_read.id
-        _schema.name = cls._schema_subnet_read.name
-        _schema.properties = cls._schema_subnet_read.properties
-        _schema.type = cls._schema_subnet_read.type
+        _schema.etag = cls._schema_common_subnet_read.etag
+        _schema.id = cls._schema_common_subnet_read.id
+        _schema.name = cls._schema_common_subnet_read.name
+        _schema.properties = cls._schema_common_subnet_read.properties
+        _schema.type = cls._schema_common_subnet_read.type
 
-    _schema_virtual_network_tap_read = None
+    _schema_common_virtual_network_tap_read = None
 
     @classmethod
-    def _build_schema_virtual_network_tap_read(cls, _schema):
-        if cls._schema_virtual_network_tap_read is not None:
-            _schema.etag = cls._schema_virtual_network_tap_read.etag
-            _schema.id = cls._schema_virtual_network_tap_read.id
-            _schema.location = cls._schema_virtual_network_tap_read.location
-            _schema.name = cls._schema_virtual_network_tap_read.name
-            _schema.properties = cls._schema_virtual_network_tap_read.properties
-            _schema.tags = cls._schema_virtual_network_tap_read.tags
-            _schema.type = cls._schema_virtual_network_tap_read.type
+    def _build_schema_common_virtual_network_tap_read(cls, _schema):
+        if cls._schema_common_virtual_network_tap_read is not None:
+            _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+            _schema.id = cls._schema_common_virtual_network_tap_read.id
+            _schema.location = cls._schema_common_virtual_network_tap_read.location
+            _schema.name = cls._schema_common_virtual_network_tap_read.name
+            _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+            _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+            _schema.type = cls._schema_common_virtual_network_tap_read.type
             return
 
-        cls._schema_virtual_network_tap_read = _schema_virtual_network_tap_read = AAZObjectType()
+        cls._schema_common_virtual_network_tap_read = _schema_common_virtual_network_tap_read = AAZObjectType()
 
-        virtual_network_tap_read = _schema_virtual_network_tap_read
-        virtual_network_tap_read.etag = AAZStrType(
+        common_virtual_network_tap_read = _schema_common_virtual_network_tap_read
+        common_virtual_network_tap_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.id = AAZStrType()
-        virtual_network_tap_read.location = AAZStrType()
-        virtual_network_tap_read.name = AAZStrType(
+        common_virtual_network_tap_read.id = AAZStrType()
+        common_virtual_network_tap_read.location = AAZStrType()
+        common_virtual_network_tap_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.properties = AAZObjectType(
+        common_virtual_network_tap_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        virtual_network_tap_read.tags = AAZDictType()
-        virtual_network_tap_read.type = AAZStrType(
+        common_virtual_network_tap_read.tags = AAZDictType()
+        common_virtual_network_tap_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_virtual_network_tap_read.properties
+        properties = _schema_common_virtual_network_tap_read.properties
         properties.destination_load_balancer_front_end_ip_configuration = AAZObjectType(
             serialized_name="destinationLoadBalancerFrontEndIPConfiguration",
         )
-        cls._build_schema_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
+        cls._build_schema_common_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
         properties.destination_network_interface_ip_configuration = AAZObjectType(
             serialized_name="destinationNetworkInterfaceIPConfiguration",
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
         properties.destination_port = AAZIntType(
             serialized_name="destinationPort",
         )
@@ -3012,20 +3087,20 @@ class _CreateHelper:
             flags={"read_only": True},
         )
 
-        network_interface_tap_configurations = _schema_virtual_network_tap_read.properties.network_interface_tap_configurations
+        network_interface_tap_configurations = _schema_common_virtual_network_tap_read.properties.network_interface_tap_configurations
         network_interface_tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
 
-        tags = _schema_virtual_network_tap_read.tags
+        tags = _schema_common_virtual_network_tap_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_virtual_network_tap_read.etag
-        _schema.id = cls._schema_virtual_network_tap_read.id
-        _schema.location = cls._schema_virtual_network_tap_read.location
-        _schema.name = cls._schema_virtual_network_tap_read.name
-        _schema.properties = cls._schema_virtual_network_tap_read.properties
-        _schema.tags = cls._schema_virtual_network_tap_read.tags
-        _schema.type = cls._schema_virtual_network_tap_read.type
+        _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+        _schema.id = cls._schema_common_virtual_network_tap_read.id
+        _schema.location = cls._schema_common_virtual_network_tap_read.location
+        _schema.name = cls._schema_common_virtual_network_tap_read.name
+        _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+        _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+        _schema.type = cls._schema_common_virtual_network_tap_read.type
 
 
 __all__ = ["Create"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_delete.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_delete.py
@@ -22,9 +22,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2025-07-01"],
         ]
     }
 
@@ -58,7 +58,7 @@ class Delete(AAZCommand):
 
     def _execute_operations(self):
         self.pre_operations()
-        yield self.PublicIPAddressesDelete(ctx=self.ctx)()
+        yield self.PublicIpAddressOperationGroupDelete(ctx=self.ctx)()
         self.post_operations()
 
     @register_callback
@@ -69,7 +69,7 @@ class Delete(AAZCommand):
     def post_operations(self):
         pass
 
-    class PublicIPAddressesDelete(AAZHttpOperation):
+    class PublicIpAddressOperationGroupDelete(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -142,7 +142,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_list.py
@@ -28,10 +28,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.network/publicipaddresses", "2024-07-01"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.network/publicipaddresses", "2025-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses", "2025-07-01"],
         ]
     }
 
@@ -57,12 +57,12 @@ class List(AAZCommand):
 
     def _execute_operations(self):
         self.pre_operations()
-        condition_0 = has_value(self.ctx.args.resource_group) and has_value(self.ctx.subscription_id)
-        condition_1 = has_value(self.ctx.subscription_id) and has_value(self.ctx.args.resource_group) is not True
+        condition_0 = has_value(self.ctx.subscription_id) and has_value(self.ctx.args.resource_group) is not True
+        condition_1 = has_value(self.ctx.args.resource_group) and has_value(self.ctx.subscription_id)
         if condition_0:
-            self.PublicIPAddressesList(ctx=self.ctx)()
+            self.PublicIpAddressOperationGroupListAll(ctx=self.ctx)()
         if condition_1:
-            self.PublicIPAddressesListAll(ctx=self.ctx)()
+            self.PublicIpAddressOperationGroupList(ctx=self.ctx)()
         self.post_operations()
 
     @register_callback
@@ -78,7 +78,93 @@ class List(AAZCommand):
         next_link = self.deserialize_output(self.ctx.vars.instance.next_link)
         return result, next_link
 
-    class PublicIPAddressesList(AAZHttpOperation):
+    class PublicIpAddressOperationGroupListAll(AAZHttpOperation):
+        CLIENT_TYPE = "MgmtClient"
+
+        def __call__(self, *args, **kwargs):
+            request = self.make_request()
+            session = self.client.send_request(request=request, stream=False, **kwargs)
+            if session.http_response.status_code in [200]:
+                return self.on_200(session)
+
+            return self.on_error(session.http_response)
+
+        @property
+        def url(self):
+            return self.client.format_url(
+                "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses",
+                **self.url_parameters
+            )
+
+        @property
+        def method(self):
+            return "GET"
+
+        @property
+        def error_format(self):
+            return "ODataV4Format"
+
+        @property
+        def url_parameters(self):
+            parameters = {
+                **self.serialize_url_param(
+                    "subscriptionId", self.ctx.subscription_id,
+                    required=True,
+                ),
+            }
+            return parameters
+
+        @property
+        def query_parameters(self):
+            parameters = {
+                **self.serialize_query_param(
+                    "api-version", "2025-07-01",
+                    required=True,
+                ),
+            }
+            return parameters
+
+        @property
+        def header_parameters(self):
+            parameters = {
+                **self.serialize_header_param(
+                    "Accept", "application/json",
+                ),
+            }
+            return parameters
+
+        def on_200(self, session):
+            data = self.deserialize_http_content(session)
+            self.ctx.set_var(
+                "instance",
+                data,
+                schema_builder=self._build_schema_on_200
+            )
+
+        _schema_on_200 = None
+
+        @classmethod
+        def _build_schema_on_200(cls):
+            if cls._schema_on_200 is not None:
+                return cls._schema_on_200
+
+            cls._schema_on_200 = AAZObjectType()
+
+            _schema_on_200 = cls._schema_on_200
+            _schema_on_200.next_link = AAZStrType(
+                serialized_name="nextLink",
+            )
+            _schema_on_200.value = AAZListType(
+                flags={"required": True},
+            )
+
+            value = cls._schema_on_200.value
+            value.Element = AAZObjectType()
+            _ListHelper._build_schema_common_public_ip_address_read(value.Element)
+
+            return cls._schema_on_200
+
+    class PublicIpAddressOperationGroupList(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -122,7 +208,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -158,95 +244,13 @@ class List(AAZCommand):
             _schema_on_200.next_link = AAZStrType(
                 serialized_name="nextLink",
             )
-            _schema_on_200.value = AAZListType()
+            _schema_on_200.value = AAZListType(
+                flags={"required": True},
+            )
 
             value = cls._schema_on_200.value
             value.Element = AAZObjectType()
-            _ListHelper._build_schema_public_ip_address_read(value.Element)
-
-            return cls._schema_on_200
-
-    class PublicIPAddressesListAll(AAZHttpOperation):
-        CLIENT_TYPE = "MgmtClient"
-
-        def __call__(self, *args, **kwargs):
-            request = self.make_request()
-            session = self.client.send_request(request=request, stream=False, **kwargs)
-            if session.http_response.status_code in [200]:
-                return self.on_200(session)
-
-            return self.on_error(session.http_response)
-
-        @property
-        def url(self):
-            return self.client.format_url(
-                "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses",
-                **self.url_parameters
-            )
-
-        @property
-        def method(self):
-            return "GET"
-
-        @property
-        def error_format(self):
-            return "ODataV4Format"
-
-        @property
-        def url_parameters(self):
-            parameters = {
-                **self.serialize_url_param(
-                    "subscriptionId", self.ctx.subscription_id,
-                    required=True,
-                ),
-            }
-            return parameters
-
-        @property
-        def query_parameters(self):
-            parameters = {
-                **self.serialize_query_param(
-                    "api-version", "2024-07-01",
-                    required=True,
-                ),
-            }
-            return parameters
-
-        @property
-        def header_parameters(self):
-            parameters = {
-                **self.serialize_header_param(
-                    "Accept", "application/json",
-                ),
-            }
-            return parameters
-
-        def on_200(self, session):
-            data = self.deserialize_http_content(session)
-            self.ctx.set_var(
-                "instance",
-                data,
-                schema_builder=self._build_schema_on_200
-            )
-
-        _schema_on_200 = None
-
-        @classmethod
-        def _build_schema_on_200(cls):
-            if cls._schema_on_200 is not None:
-                return cls._schema_on_200
-
-            cls._schema_on_200 = AAZObjectType()
-
-            _schema_on_200 = cls._schema_on_200
-            _schema_on_200.next_link = AAZStrType(
-                serialized_name="nextLink",
-            )
-            _schema_on_200.value = AAZListType()
-
-            value = cls._schema_on_200.value
-            value.Element = AAZObjectType()
-            _ListHelper._build_schema_public_ip_address_read(value.Element)
+            _ListHelper._build_schema_common_public_ip_address_read(value.Element)
 
             return cls._schema_on_200
 
@@ -254,40 +258,40 @@ class List(AAZCommand):
 class _ListHelper:
     """Helper class for List"""
 
-    _schema_application_security_group_read = None
+    _schema_common_application_security_group_read = None
 
     @classmethod
-    def _build_schema_application_security_group_read(cls, _schema):
-        if cls._schema_application_security_group_read is not None:
-            _schema.etag = cls._schema_application_security_group_read.etag
-            _schema.id = cls._schema_application_security_group_read.id
-            _schema.location = cls._schema_application_security_group_read.location
-            _schema.name = cls._schema_application_security_group_read.name
-            _schema.properties = cls._schema_application_security_group_read.properties
-            _schema.tags = cls._schema_application_security_group_read.tags
-            _schema.type = cls._schema_application_security_group_read.type
+    def _build_schema_common_application_security_group_read(cls, _schema):
+        if cls._schema_common_application_security_group_read is not None:
+            _schema.etag = cls._schema_common_application_security_group_read.etag
+            _schema.id = cls._schema_common_application_security_group_read.id
+            _schema.location = cls._schema_common_application_security_group_read.location
+            _schema.name = cls._schema_common_application_security_group_read.name
+            _schema.properties = cls._schema_common_application_security_group_read.properties
+            _schema.tags = cls._schema_common_application_security_group_read.tags
+            _schema.type = cls._schema_common_application_security_group_read.type
             return
 
-        cls._schema_application_security_group_read = _schema_application_security_group_read = AAZObjectType()
+        cls._schema_common_application_security_group_read = _schema_common_application_security_group_read = AAZObjectType()
 
-        application_security_group_read = _schema_application_security_group_read
-        application_security_group_read.etag = AAZStrType(
+        common_application_security_group_read = _schema_common_application_security_group_read
+        common_application_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.id = AAZStrType()
-        application_security_group_read.location = AAZStrType()
-        application_security_group_read.name = AAZStrType(
+        common_application_security_group_read.id = AAZStrType()
+        common_application_security_group_read.location = AAZStrType()
+        common_application_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.properties = AAZObjectType(
+        common_application_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        application_security_group_read.tags = AAZDictType()
-        application_security_group_read.type = AAZStrType(
+        common_application_security_group_read.tags = AAZDictType()
+        common_application_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_application_security_group_read.properties
+        properties = _schema_common_application_security_group_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -297,69 +301,72 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        tags = _schema_application_security_group_read.tags
+        tags = _schema_common_application_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_application_security_group_read.etag
-        _schema.id = cls._schema_application_security_group_read.id
-        _schema.location = cls._schema_application_security_group_read.location
-        _schema.name = cls._schema_application_security_group_read.name
-        _schema.properties = cls._schema_application_security_group_read.properties
-        _schema.tags = cls._schema_application_security_group_read.tags
-        _schema.type = cls._schema_application_security_group_read.type
+        _schema.etag = cls._schema_common_application_security_group_read.etag
+        _schema.id = cls._schema_common_application_security_group_read.id
+        _schema.location = cls._schema_common_application_security_group_read.location
+        _schema.name = cls._schema_common_application_security_group_read.name
+        _schema.properties = cls._schema_common_application_security_group_read.properties
+        _schema.tags = cls._schema_common_application_security_group_read.tags
+        _schema.type = cls._schema_common_application_security_group_read.type
 
-    _schema_extended_location_read = None
-
-    @classmethod
-    def _build_schema_extended_location_read(cls, _schema):
-        if cls._schema_extended_location_read is not None:
-            _schema.name = cls._schema_extended_location_read.name
-            _schema.type = cls._schema_extended_location_read.type
-            return
-
-        cls._schema_extended_location_read = _schema_extended_location_read = AAZObjectType()
-
-        extended_location_read = _schema_extended_location_read
-        extended_location_read.name = AAZStrType()
-        extended_location_read.type = AAZStrType()
-
-        _schema.name = cls._schema_extended_location_read.name
-        _schema.type = cls._schema_extended_location_read.type
-
-    _schema_frontend_ip_configuration_read = None
+    _schema_common_extended_location_read = None
 
     @classmethod
-    def _build_schema_frontend_ip_configuration_read(cls, _schema):
-        if cls._schema_frontend_ip_configuration_read is not None:
-            _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-            _schema.id = cls._schema_frontend_ip_configuration_read.id
-            _schema.name = cls._schema_frontend_ip_configuration_read.name
-            _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-            _schema.type = cls._schema_frontend_ip_configuration_read.type
-            _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+    def _build_schema_common_extended_location_read(cls, _schema):
+        if cls._schema_common_extended_location_read is not None:
+            _schema.name = cls._schema_common_extended_location_read.name
+            _schema.type = cls._schema_common_extended_location_read.type
             return
 
-        cls._schema_frontend_ip_configuration_read = _schema_frontend_ip_configuration_read = AAZObjectType()
+        cls._schema_common_extended_location_read = _schema_common_extended_location_read = AAZObjectType()
 
-        frontend_ip_configuration_read = _schema_frontend_ip_configuration_read
-        frontend_ip_configuration_read.etag = AAZStrType(
+        common_extended_location_read = _schema_common_extended_location_read
+        common_extended_location_read.name = AAZStrType()
+        common_extended_location_read.type = AAZStrType()
+
+        _schema.name = cls._schema_common_extended_location_read.name
+        _schema.type = cls._schema_common_extended_location_read.type
+
+    _schema_common_frontend_ip_configuration_read = None
+
+    @classmethod
+    def _build_schema_common_frontend_ip_configuration_read(cls, _schema):
+        if cls._schema_common_frontend_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+            _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+            _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+            _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+            _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+            _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
+            return
+
+        cls._schema_common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read = AAZObjectType()
+
+        common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read
+        common_frontend_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.id = AAZStrType()
-        frontend_ip_configuration_read.name = AAZStrType()
-        frontend_ip_configuration_read.properties = AAZObjectType(
+        common_frontend_ip_configuration_read.id = AAZStrType()
+        common_frontend_ip_configuration_read.name = AAZStrType()
+        common_frontend_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        frontend_ip_configuration_read.type = AAZStrType(
+        common_frontend_ip_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.zones = AAZListType()
+        common_frontend_ip_configuration_read.zones = AAZListType()
 
-        properties = _schema_frontend_ip_configuration_read.properties
+        properties = _schema_common_frontend_ip_configuration_read.properties
+        properties.ddos_settings = AAZObjectType(
+            serialized_name="ddosSettings",
+        )
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.inbound_nat_pools = AAZListType(
             serialized_name="inboundNatPools",
             flags={"read_only": True},
@@ -392,66 +399,72 @@ class _ListHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        inbound_nat_pools = _schema_frontend_ip_configuration_read.properties.inbound_nat_pools
+        ddos_settings = _schema_common_frontend_ip_configuration_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
+
+        inbound_nat_pools = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_pools
         inbound_nat_pools.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_pools.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_pools.Element)
 
-        inbound_nat_rules = _schema_frontend_ip_configuration_read.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancing_rules = _schema_frontend_ip_configuration_read.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_frontend_ip_configuration_read.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_frontend_ip_configuration_read.properties.outbound_rules
+        outbound_rules = _schema_common_frontend_ip_configuration_read.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        zones = _schema_frontend_ip_configuration_read.zones
+        zones = _schema_common_frontend_ip_configuration_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-        _schema.id = cls._schema_frontend_ip_configuration_read.id
-        _schema.name = cls._schema_frontend_ip_configuration_read.name
-        _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-        _schema.type = cls._schema_frontend_ip_configuration_read.type
-        _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+        _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+        _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+        _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+        _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+        _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+        _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
 
-    _schema_ip_configuration_read = None
+    _schema_common_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_ip_configuration_read(cls, _schema):
-        if cls._schema_ip_configuration_read is not None:
-            _schema.etag = cls._schema_ip_configuration_read.etag
-            _schema.id = cls._schema_ip_configuration_read.id
-            _schema.name = cls._schema_ip_configuration_read.name
-            _schema.properties = cls._schema_ip_configuration_read.properties
+    def _build_schema_common_ip_configuration_read(cls, _schema):
+        if cls._schema_common_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_ip_configuration_read.etag
+            _schema.id = cls._schema_common_ip_configuration_read.id
+            _schema.name = cls._schema_common_ip_configuration_read.name
+            _schema.properties = cls._schema_common_ip_configuration_read.properties
             return
 
-        cls._schema_ip_configuration_read = _schema_ip_configuration_read = AAZObjectType(
+        cls._schema_common_ip_configuration_read = _schema_common_ip_configuration_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        ip_configuration_read = _schema_ip_configuration_read
-        ip_configuration_read.etag = AAZStrType(
+        common_ip_configuration_read = _schema_common_ip_configuration_read
+        common_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        ip_configuration_read.id = AAZStrType()
-        ip_configuration_read.name = AAZStrType()
-        ip_configuration_read.properties = AAZObjectType(
+        common_ip_configuration_read.id = AAZStrType()
+        common_ip_configuration_read.name = AAZStrType()
+        common_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_ip_configuration_read.properties
+        properties = _schema_common_ip_configuration_read.properties
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
         )
@@ -465,41 +478,43 @@ class _ListHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        _schema.etag = cls._schema_ip_configuration_read.etag
-        _schema.id = cls._schema_ip_configuration_read.id
-        _schema.name = cls._schema_ip_configuration_read.name
-        _schema.properties = cls._schema_ip_configuration_read.properties
+        _schema.etag = cls._schema_common_ip_configuration_read.etag
+        _schema.id = cls._schema_common_ip_configuration_read.id
+        _schema.name = cls._schema_common_ip_configuration_read.name
+        _schema.properties = cls._schema_common_ip_configuration_read.properties
 
-    _schema_network_interface_ip_configuration_read = None
+    _schema_common_network_interface_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_ip_configuration_read(cls, _schema):
-        if cls._schema_network_interface_ip_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-            _schema.id = cls._schema_network_interface_ip_configuration_read.id
-            _schema.name = cls._schema_network_interface_ip_configuration_read.name
-            _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-            _schema.type = cls._schema_network_interface_ip_configuration_read.type
+    def _build_schema_common_network_interface_ip_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
             return
 
-        cls._schema_network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read = AAZObjectType()
 
-        network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read
-        network_interface_ip_configuration_read.etag = AAZStrType(
+        common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read
+        common_network_interface_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_ip_configuration_read.id = AAZStrType()
-        network_interface_ip_configuration_read.name = AAZStrType()
-        network_interface_ip_configuration_read.properties = AAZObjectType(
+        common_network_interface_ip_configuration_read.id = AAZStrType()
+        common_network_interface_ip_configuration_read.name = AAZStrType()
+        common_network_interface_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_ip_configuration_read.type = AAZStrType()
+        common_network_interface_ip_configuration_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_network_interface_ip_configuration_read.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties
         properties.application_gateway_backend_address_pools = AAZListType(
             serialized_name="applicationGatewayBackendAddressPools",
         )
@@ -509,7 +524,7 @@ class _ListHelper:
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.load_balancer_backend_address_pools = AAZListType(
             serialized_name="loadBalancerBackendAddressPools",
         )
@@ -541,17 +556,17 @@ class _ListHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
         properties.virtual_network_taps = AAZListType(
             serialized_name="virtualNetworkTaps",
         )
 
-        application_gateway_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
+        application_gateway_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
         application_gateway_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -564,7 +579,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
         properties.backend_addresses = AAZListType(
             serialized_name="backendAddresses",
         )
@@ -577,27 +592,27 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        backend_addresses = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
+        backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
         backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
         _element.fqdn = AAZStrType()
         _element.ip_address = AAZStrType(
             serialized_name="ipAddress",
         )
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        application_security_groups = _schema_network_interface_ip_configuration_read.properties.application_security_groups
+        application_security_groups = _schema_common_network_interface_ip_configuration_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        load_balancer_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
+        load_balancer_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
         load_balancer_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -610,7 +625,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
         properties.backend_ip_configurations = AAZListType(
             serialized_name="backendIPConfigurations",
             flags={"read_only": True},
@@ -634,7 +649,7 @@ class _ListHelper:
             serialized_name="outboundRule",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.outbound_rule)
+        cls._build_schema_common_sub_resource_read(properties.outbound_rule)
         properties.outbound_rules = AAZListType(
             serialized_name="outboundRules",
             flags={"read_only": True},
@@ -652,26 +667,26 @@ class _ListHelper:
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancer_backend_addresses = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
+        load_balancer_backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
         load_balancer_backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
         _element.name = AAZStrType()
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
         properties.admin_state = AAZStrType(
             serialized_name="adminState",
         )
@@ -685,23 +700,23 @@ class _ListHelper:
         properties.load_balancer_frontend_ip_configuration = AAZObjectType(
             serialized_name="loadBalancerFrontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
         properties.network_interface_ip_configuration = AAZObjectType(
             serialized_name="networkInterfaceIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.network_interface_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.network_interface_ip_configuration)
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        inbound_nat_rules_port_mapping = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
+        inbound_nat_rules_port_mapping = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
         inbound_nat_rules_port_mapping.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
         _element.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -712,27 +727,27 @@ class _ListHelper:
             serialized_name="inboundNatRuleName",
         )
 
-        load_balancing_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
+        outbound_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        tunnel_interfaces = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
+        tunnel_interfaces = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
         tunnel_interfaces.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
         _element.identifier = AAZIntType()
         _element.port = AAZIntType()
         _element.protocol = AAZStrType()
         _element.type = AAZStrType()
 
-        load_balancer_inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
+        load_balancer_inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
         load_balancer_inbound_nat_rules.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -745,16 +760,16 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
         properties.backend_address_pool = AAZObjectType(
             serialized_name="backendAddressPool",
         )
-        cls._build_schema_sub_resource_read(properties.backend_address_pool)
+        cls._build_schema_common_sub_resource_read(properties.backend_address_pool)
         properties.backend_ip_configuration = AAZObjectType(
             serialized_name="backendIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.backend_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.backend_ip_configuration)
         properties.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -767,7 +782,7 @@ class _ListHelper:
         properties.frontend_ip_configuration = AAZObjectType(
             serialized_name="frontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.frontend_ip_configuration)
         properties.frontend_port = AAZIntType(
             serialized_name="frontendPort",
         )
@@ -786,7 +801,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        private_link_connection_properties = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties
+        private_link_connection_properties = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties
         private_link_connection_properties.fqdns = AAZListType(
             flags={"read_only": True},
         )
@@ -799,47 +814,47 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        fqdns = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
+        fqdns = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
         fqdns.Element = AAZStrType()
 
-        virtual_network_taps = _schema_network_interface_ip_configuration_read.properties.virtual_network_taps
+        virtual_network_taps = _schema_common_network_interface_ip_configuration_read.properties.virtual_network_taps
         virtual_network_taps.Element = AAZObjectType()
-        cls._build_schema_virtual_network_tap_read(virtual_network_taps.Element)
+        cls._build_schema_common_virtual_network_tap_read(virtual_network_taps.Element)
 
-        _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-        _schema.id = cls._schema_network_interface_ip_configuration_read.id
-        _schema.name = cls._schema_network_interface_ip_configuration_read.name
-        _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-        _schema.type = cls._schema_network_interface_ip_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
 
-    _schema_network_interface_tap_configuration_read = None
+    _schema_common_network_interface_tap_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_tap_configuration_read(cls, _schema):
-        if cls._schema_network_interface_tap_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-            _schema.id = cls._schema_network_interface_tap_configuration_read.id
-            _schema.name = cls._schema_network_interface_tap_configuration_read.name
-            _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-            _schema.type = cls._schema_network_interface_tap_configuration_read.type
+    def _build_schema_common_network_interface_tap_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_tap_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
             return
 
-        cls._schema_network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read = AAZObjectType()
 
-        network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read
-        network_interface_tap_configuration_read.etag = AAZStrType(
+        common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read
+        common_network_interface_tap_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_tap_configuration_read.id = AAZStrType()
-        network_interface_tap_configuration_read.name = AAZStrType()
-        network_interface_tap_configuration_read.properties = AAZObjectType(
+        common_network_interface_tap_configuration_read.id = AAZStrType()
+        common_network_interface_tap_configuration_read.name = AAZStrType()
+        common_network_interface_tap_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_tap_configuration_read.type = AAZStrType(
+        common_network_interface_tap_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_tap_configuration_read.properties
+        properties = _schema_common_network_interface_tap_configuration_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -847,53 +862,53 @@ class _ListHelper:
         properties.virtual_network_tap = AAZObjectType(
             serialized_name="virtualNetworkTap",
         )
-        cls._build_schema_virtual_network_tap_read(properties.virtual_network_tap)
+        cls._build_schema_common_virtual_network_tap_read(properties.virtual_network_tap)
 
-        _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-        _schema.id = cls._schema_network_interface_tap_configuration_read.id
-        _schema.name = cls._schema_network_interface_tap_configuration_read.name
-        _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-        _schema.type = cls._schema_network_interface_tap_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
 
-    _schema_network_interface_read = None
+    _schema_common_network_interface_read = None
 
     @classmethod
-    def _build_schema_network_interface_read(cls, _schema):
-        if cls._schema_network_interface_read is not None:
-            _schema.etag = cls._schema_network_interface_read.etag
-            _schema.extended_location = cls._schema_network_interface_read.extended_location
-            _schema.id = cls._schema_network_interface_read.id
-            _schema.location = cls._schema_network_interface_read.location
-            _schema.name = cls._schema_network_interface_read.name
-            _schema.properties = cls._schema_network_interface_read.properties
-            _schema.tags = cls._schema_network_interface_read.tags
-            _schema.type = cls._schema_network_interface_read.type
+    def _build_schema_common_network_interface_read(cls, _schema):
+        if cls._schema_common_network_interface_read is not None:
+            _schema.etag = cls._schema_common_network_interface_read.etag
+            _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+            _schema.id = cls._schema_common_network_interface_read.id
+            _schema.location = cls._schema_common_network_interface_read.location
+            _schema.name = cls._schema_common_network_interface_read.name
+            _schema.properties = cls._schema_common_network_interface_read.properties
+            _schema.tags = cls._schema_common_network_interface_read.tags
+            _schema.type = cls._schema_common_network_interface_read.type
             return
 
-        cls._schema_network_interface_read = _schema_network_interface_read = AAZObjectType()
+        cls._schema_common_network_interface_read = _schema_common_network_interface_read = AAZObjectType()
 
-        network_interface_read = _schema_network_interface_read
-        network_interface_read.etag = AAZStrType(
+        common_network_interface_read = _schema_common_network_interface_read
+        common_network_interface_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.extended_location = AAZObjectType(
+        common_network_interface_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(network_interface_read.extended_location)
-        network_interface_read.id = AAZStrType()
-        network_interface_read.location = AAZStrType()
-        network_interface_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_network_interface_read.extended_location)
+        common_network_interface_read.id = AAZStrType()
+        common_network_interface_read.location = AAZStrType()
+        common_network_interface_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.properties = AAZObjectType(
+        common_network_interface_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_read.tags = AAZDictType()
-        network_interface_read.type = AAZStrType(
+        common_network_interface_read.tags = AAZDictType()
+        common_network_interface_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties
+        properties = _schema_common_network_interface_read.properties
         properties.auxiliary_mode = AAZStrType(
             serialized_name="auxiliaryMode",
         )
@@ -914,7 +929,7 @@ class _ListHelper:
             serialized_name="dscpConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.dscp_configuration)
+        cls._build_schema_common_sub_resource_read(properties.dscp_configuration)
         properties.enable_accelerated_networking = AAZBoolType(
             serialized_name="enableAcceleratedNetworking",
         )
@@ -938,7 +953,7 @@ class _ListHelper:
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.nic_type = AAZStrType(
             serialized_name="nicType",
         )
@@ -949,7 +964,7 @@ class _ListHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_link_service = AAZObjectType(
             serialized_name="privateLinkService",
         )
@@ -969,7 +984,7 @@ class _ListHelper:
             serialized_name="virtualMachine",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.virtual_machine)
+        cls._build_schema_common_sub_resource_read(properties.virtual_machine)
         properties.vnet_encryption_supported = AAZBoolType(
             serialized_name="vnetEncryptionSupported",
             flags={"read_only": True},
@@ -978,7 +993,7 @@ class _ListHelper:
             serialized_name="workloadType",
         )
 
-        dns_settings = _schema_network_interface_read.properties.dns_settings
+        dns_settings = _schema_common_network_interface_read.properties.dns_settings
         dns_settings.applied_dns_servers = AAZListType(
             serialized_name="appliedDnsServers",
             flags={"read_only": True},
@@ -998,27 +1013,27 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        applied_dns_servers = _schema_network_interface_read.properties.dns_settings.applied_dns_servers
+        applied_dns_servers = _schema_common_network_interface_read.properties.dns_settings.applied_dns_servers
         applied_dns_servers.Element = AAZStrType()
 
-        dns_servers = _schema_network_interface_read.properties.dns_settings.dns_servers
+        dns_servers = _schema_common_network_interface_read.properties.dns_settings.dns_servers
         dns_servers.Element = AAZStrType()
 
-        hosted_workloads = _schema_network_interface_read.properties.hosted_workloads
+        hosted_workloads = _schema_common_network_interface_read.properties.hosted_workloads
         hosted_workloads.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(ip_configurations.Element)
 
-        private_link_service = _schema_network_interface_read.properties.private_link_service
+        private_link_service = _schema_common_network_interface_read.properties.private_link_service
         private_link_service.etag = AAZStrType(
             flags={"read_only": True},
         )
         private_link_service.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_link_service.extended_location)
+        cls._build_schema_common_extended_location_read(private_link_service.extended_location)
         private_link_service.id = AAZStrType()
         private_link_service.location = AAZStrType()
         private_link_service.name = AAZStrType(
@@ -1032,7 +1047,10 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties
+        properties.access_mode = AAZStrType(
+            serialized_name="accessMode",
+        )
         properties.alias = AAZStrType(
             flags={"read_only": True},
         )
@@ -1066,19 +1084,19 @@ class _ListHelper:
         )
         properties.visibility = AAZObjectType()
 
-        auto_approval = _schema_network_interface_read.properties.private_link_service.properties.auto_approval
+        auto_approval = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval
         auto_approval.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
         subscriptions.Element = AAZStrType()
 
-        fqdns = _schema_network_interface_read.properties.private_link_service.properties.fqdns
+        fqdns = _schema_common_network_interface_read.properties.private_link_service.properties.fqdns
         fqdns.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1091,7 +1109,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
         properties.primary = AAZBoolType()
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
@@ -1107,20 +1125,20 @@ class _ListHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        load_balancer_frontend_ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
+        load_balancer_frontend_ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
         load_balancer_frontend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
+        cls._build_schema_common_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
 
-        network_interfaces = _schema_network_interface_read.properties.private_link_service.properties.network_interfaces
+        network_interfaces = _schema_common_network_interface_read.properties.private_link_service.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_endpoint_connections = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
+        private_endpoint_connections = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
         private_endpoint_connections.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1133,7 +1151,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
         properties.link_identifier = AAZStrType(
             serialized_name="linkIdentifier",
             flags={"read_only": True},
@@ -1142,7 +1160,7 @@ class _ListHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_endpoint_location = AAZStrType(
             serialized_name="privateEndpointLocation",
             flags={"read_only": True},
@@ -1150,71 +1168,71 @@ class _ListHelper:
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
 
-        visibility = _schema_network_interface_read.properties.private_link_service.properties.visibility
+        visibility = _schema_common_network_interface_read.properties.private_link_service.properties.visibility
         visibility.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
         subscriptions.Element = AAZStrType()
 
-        tags = _schema_network_interface_read.properties.private_link_service.tags
+        tags = _schema_common_network_interface_read.properties.private_link_service.tags
         tags.Element = AAZStrType()
 
-        tap_configurations = _schema_network_interface_read.properties.tap_configurations
+        tap_configurations = _schema_common_network_interface_read.properties.tap_configurations
         tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(tap_configurations.Element)
 
-        tags = _schema_network_interface_read.tags
+        tags = _schema_common_network_interface_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_interface_read.etag
-        _schema.extended_location = cls._schema_network_interface_read.extended_location
-        _schema.id = cls._schema_network_interface_read.id
-        _schema.location = cls._schema_network_interface_read.location
-        _schema.name = cls._schema_network_interface_read.name
-        _schema.properties = cls._schema_network_interface_read.properties
-        _schema.tags = cls._schema_network_interface_read.tags
-        _schema.type = cls._schema_network_interface_read.type
+        _schema.etag = cls._schema_common_network_interface_read.etag
+        _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+        _schema.id = cls._schema_common_network_interface_read.id
+        _schema.location = cls._schema_common_network_interface_read.location
+        _schema.name = cls._schema_common_network_interface_read.name
+        _schema.properties = cls._schema_common_network_interface_read.properties
+        _schema.tags = cls._schema_common_network_interface_read.tags
+        _schema.type = cls._schema_common_network_interface_read.type
 
-    _schema_network_security_group_read = None
+    _schema_common_network_security_group_read = None
 
     @classmethod
-    def _build_schema_network_security_group_read(cls, _schema):
-        if cls._schema_network_security_group_read is not None:
-            _schema.etag = cls._schema_network_security_group_read.etag
-            _schema.id = cls._schema_network_security_group_read.id
-            _schema.location = cls._schema_network_security_group_read.location
-            _schema.name = cls._schema_network_security_group_read.name
-            _schema.properties = cls._schema_network_security_group_read.properties
-            _schema.tags = cls._schema_network_security_group_read.tags
-            _schema.type = cls._schema_network_security_group_read.type
+    def _build_schema_common_network_security_group_read(cls, _schema):
+        if cls._schema_common_network_security_group_read is not None:
+            _schema.etag = cls._schema_common_network_security_group_read.etag
+            _schema.id = cls._schema_common_network_security_group_read.id
+            _schema.location = cls._schema_common_network_security_group_read.location
+            _schema.name = cls._schema_common_network_security_group_read.name
+            _schema.properties = cls._schema_common_network_security_group_read.properties
+            _schema.tags = cls._schema_common_network_security_group_read.tags
+            _schema.type = cls._schema_common_network_security_group_read.type
             return
 
-        cls._schema_network_security_group_read = _schema_network_security_group_read = AAZObjectType()
+        cls._schema_common_network_security_group_read = _schema_common_network_security_group_read = AAZObjectType()
 
-        network_security_group_read = _schema_network_security_group_read
-        network_security_group_read.etag = AAZStrType(
+        common_network_security_group_read = _schema_common_network_security_group_read
+        common_network_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.id = AAZStrType()
-        network_security_group_read.location = AAZStrType()
-        network_security_group_read.name = AAZStrType(
+        common_network_security_group_read.id = AAZStrType()
+        common_network_security_group_read.location = AAZStrType()
+        common_network_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.properties = AAZObjectType(
+        common_network_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_security_group_read.tags = AAZDictType()
-        network_security_group_read.type = AAZStrType(
+        common_network_security_group_read.tags = AAZDictType()
+        common_network_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties
+        properties = _schema_common_network_security_group_read.properties
         properties.default_security_rules = AAZListType(
             serialized_name="defaultSecurityRules",
             flags={"read_only": True},
@@ -1245,14 +1263,14 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        default_security_rules = _schema_network_security_group_read.properties.default_security_rules
+        default_security_rules = _schema_common_network_security_group_read.properties.default_security_rules
         default_security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(default_security_rules.Element)
+        cls._build_schema_common_security_rule_read(default_security_rules.Element)
 
-        flow_logs = _schema_network_security_group_read.properties.flow_logs
+        flow_logs = _schema_common_network_security_group_read.properties.flow_logs
         flow_logs.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1270,7 +1288,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        identity = _schema_network_security_group_read.properties.flow_logs.Element.identity
+        identity = _schema_common_network_security_group_read.properties.flow_logs.Element.identity
         identity.principal_id = AAZStrType(
             serialized_name="principalId",
             flags={"read_only": True},
@@ -1284,10 +1302,10 @@ class _ListHelper:
             serialized_name="userAssignedIdentities",
         )
 
-        user_assigned_identities = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
+        user_assigned_identities = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
         user_assigned_identities.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
         _element.client_id = AAZStrType(
             serialized_name="clientId",
             flags={"read_only": True},
@@ -1297,7 +1315,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties.flow_logs.Element.properties
+        properties = _schema_common_network_security_group_read.properties.flow_logs.Element.properties
         properties.enabled = AAZBoolType()
         properties.enabled_filtering_criteria = AAZStrType(
             serialized_name="enabledFilteringCriteria",
@@ -1309,6 +1327,9 @@ class _ListHelper:
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
+        )
+        properties.record_types = AAZStrType(
+            serialized_name="recordTypes",
         )
         properties.retention_policy = AAZObjectType(
             serialized_name="retentionPolicy",
@@ -1326,12 +1347,12 @@ class _ListHelper:
             flags={"required": True},
         )
 
-        flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
+        flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
         flow_analytics_configuration.network_watcher_flow_analytics_configuration = AAZObjectType(
             serialized_name="networkWatcherFlowAnalyticsConfiguration",
         )
 
-        network_watcher_flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
+        network_watcher_flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
         network_watcher_flow_analytics_configuration.enabled = AAZBoolType()
         network_watcher_flow_analytics_configuration.traffic_analytics_interval = AAZIntType(
             serialized_name="trafficAnalyticsInterval",
@@ -1346,83 +1367,86 @@ class _ListHelper:
             serialized_name="workspaceResourceId",
         )
 
-        format = _schema_network_security_group_read.properties.flow_logs.Element.properties.format
+        format = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.format
         format.type = AAZStrType()
         format.version = AAZIntType()
 
-        retention_policy = _schema_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
+        retention_policy = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
         retention_policy.days = AAZIntType()
         retention_policy.enabled = AAZBoolType()
 
-        tags = _schema_network_security_group_read.properties.flow_logs.Element.tags
+        tags = _schema_common_network_security_group_read.properties.flow_logs.Element.tags
         tags.Element = AAZStrType()
 
-        network_interfaces = _schema_network_security_group_read.properties.network_interfaces
+        network_interfaces = _schema_common_network_security_group_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        security_rules = _schema_network_security_group_read.properties.security_rules
+        security_rules = _schema_common_network_security_group_read.properties.security_rules
         security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(security_rules.Element)
+        cls._build_schema_common_security_rule_read(security_rules.Element)
 
-        subnets = _schema_network_security_group_read.properties.subnets
+        subnets = _schema_common_network_security_group_read.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_network_security_group_read.tags
+        tags = _schema_common_network_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_security_group_read.etag
-        _schema.id = cls._schema_network_security_group_read.id
-        _schema.location = cls._schema_network_security_group_read.location
-        _schema.name = cls._schema_network_security_group_read.name
-        _schema.properties = cls._schema_network_security_group_read.properties
-        _schema.tags = cls._schema_network_security_group_read.tags
-        _schema.type = cls._schema_network_security_group_read.type
+        _schema.etag = cls._schema_common_network_security_group_read.etag
+        _schema.id = cls._schema_common_network_security_group_read.id
+        _schema.location = cls._schema_common_network_security_group_read.location
+        _schema.name = cls._schema_common_network_security_group_read.name
+        _schema.properties = cls._schema_common_network_security_group_read.properties
+        _schema.tags = cls._schema_common_network_security_group_read.tags
+        _schema.type = cls._schema_common_network_security_group_read.type
 
-    _schema_private_endpoint_read = None
+    _schema_common_private_endpoint_read = None
 
     @classmethod
-    def _build_schema_private_endpoint_read(cls, _schema):
-        if cls._schema_private_endpoint_read is not None:
-            _schema.etag = cls._schema_private_endpoint_read.etag
-            _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-            _schema.id = cls._schema_private_endpoint_read.id
-            _schema.location = cls._schema_private_endpoint_read.location
-            _schema.name = cls._schema_private_endpoint_read.name
-            _schema.properties = cls._schema_private_endpoint_read.properties
-            _schema.tags = cls._schema_private_endpoint_read.tags
-            _schema.type = cls._schema_private_endpoint_read.type
+    def _build_schema_common_private_endpoint_read(cls, _schema):
+        if cls._schema_common_private_endpoint_read is not None:
+            _schema.etag = cls._schema_common_private_endpoint_read.etag
+            _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+            _schema.id = cls._schema_common_private_endpoint_read.id
+            _schema.location = cls._schema_common_private_endpoint_read.location
+            _schema.name = cls._schema_common_private_endpoint_read.name
+            _schema.properties = cls._schema_common_private_endpoint_read.properties
+            _schema.tags = cls._schema_common_private_endpoint_read.tags
+            _schema.type = cls._schema_common_private_endpoint_read.type
             return
 
-        cls._schema_private_endpoint_read = _schema_private_endpoint_read = AAZObjectType(
+        cls._schema_common_private_endpoint_read = _schema_common_private_endpoint_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        private_endpoint_read = _schema_private_endpoint_read
-        private_endpoint_read.etag = AAZStrType(
+        common_private_endpoint_read = _schema_common_private_endpoint_read
+        common_private_endpoint_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.extended_location = AAZObjectType(
+        common_private_endpoint_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_endpoint_read.extended_location)
-        private_endpoint_read.id = AAZStrType()
-        private_endpoint_read.location = AAZStrType()
-        private_endpoint_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_private_endpoint_read.extended_location)
+        common_private_endpoint_read.id = AAZStrType()
+        common_private_endpoint_read.location = AAZStrType()
+        common_private_endpoint_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.properties = AAZObjectType(
+        common_private_endpoint_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_endpoint_read.tags = AAZDictType()
-        private_endpoint_read.type = AAZStrType(
+        common_private_endpoint_read.tags = AAZDictType()
+        common_private_endpoint_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties
+        properties = _schema_common_private_endpoint_read.properties
         properties.application_security_groups = AAZListType(
             serialized_name="applicationSecurityGroups",
+        )
+        properties.billing_sku = AAZStrType(
+            serialized_name="billingSku",
         )
         properties.custom_dns_configs = AAZListType(
             serialized_name="customDnsConfigs",
@@ -1432,6 +1456,9 @@ class _ListHelper:
         )
         properties.ip_configurations = AAZListType(
             serialized_name="ipConfigurations",
+        )
+        properties.ip_version_type = AAZStrType(
+            serialized_name="ipVersionType",
         )
         properties.manual_private_link_service_connections = AAZListType(
             serialized_name="manualPrivateLinkServiceConnections",
@@ -1448,28 +1475,28 @@ class _ListHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        application_security_groups = _schema_private_endpoint_read.properties.application_security_groups
+        application_security_groups = _schema_common_private_endpoint_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        custom_dns_configs = _schema_private_endpoint_read.properties.custom_dns_configs
+        custom_dns_configs = _schema_common_private_endpoint_read.properties.custom_dns_configs
         custom_dns_configs.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.custom_dns_configs.Element
+        _element = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element
         _element.fqdn = AAZStrType()
         _element.ip_addresses = AAZListType(
             serialized_name="ipAddresses",
         )
 
-        ip_addresses = _schema_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
+        ip_addresses = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
         ip_addresses.Element = AAZStrType()
 
-        ip_configurations = _schema_private_endpoint_read.properties.ip_configurations
+        ip_configurations = _schema_common_private_endpoint_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.ip_configurations.Element
+        _element = _schema_common_private_endpoint_read.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1481,7 +1508,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties.ip_configurations.Element.properties
+        properties = _schema_common_private_endpoint_read.properties.ip_configurations.Element.properties
         properties.group_id = AAZStrType(
             serialized_name="groupId",
         )
@@ -1492,88 +1519,88 @@ class _ListHelper:
             serialized_name="privateIPAddress",
         )
 
-        manual_private_link_service_connections = _schema_private_endpoint_read.properties.manual_private_link_service_connections
+        manual_private_link_service_connections = _schema_common_private_endpoint_read.properties.manual_private_link_service_connections
         manual_private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(manual_private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(manual_private_link_service_connections.Element)
 
-        network_interfaces = _schema_private_endpoint_read.properties.network_interfaces
+        network_interfaces = _schema_common_private_endpoint_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_link_service_connections = _schema_private_endpoint_read.properties.private_link_service_connections
+        private_link_service_connections = _schema_common_private_endpoint_read.properties.private_link_service_connections
         private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(private_link_service_connections.Element)
 
-        tags = _schema_private_endpoint_read.tags
+        tags = _schema_common_private_endpoint_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_endpoint_read.etag
-        _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-        _schema.id = cls._schema_private_endpoint_read.id
-        _schema.location = cls._schema_private_endpoint_read.location
-        _schema.name = cls._schema_private_endpoint_read.name
-        _schema.properties = cls._schema_private_endpoint_read.properties
-        _schema.tags = cls._schema_private_endpoint_read.tags
-        _schema.type = cls._schema_private_endpoint_read.type
+        _schema.etag = cls._schema_common_private_endpoint_read.etag
+        _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+        _schema.id = cls._schema_common_private_endpoint_read.id
+        _schema.location = cls._schema_common_private_endpoint_read.location
+        _schema.name = cls._schema_common_private_endpoint_read.name
+        _schema.properties = cls._schema_common_private_endpoint_read.properties
+        _schema.tags = cls._schema_common_private_endpoint_read.tags
+        _schema.type = cls._schema_common_private_endpoint_read.type
 
-    _schema_private_link_service_connection_state_read = None
+    _schema_common_private_link_service_connection_state_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_state_read(cls, _schema):
-        if cls._schema_private_link_service_connection_state_read is not None:
-            _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-            _schema.description = cls._schema_private_link_service_connection_state_read.description
-            _schema.status = cls._schema_private_link_service_connection_state_read.status
+    def _build_schema_common_private_link_service_connection_state_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_state_read is not None:
+            _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+            _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+            _schema.status = cls._schema_common_private_link_service_connection_state_read.status
             return
 
-        cls._schema_private_link_service_connection_state_read = _schema_private_link_service_connection_state_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read = AAZObjectType()
 
-        private_link_service_connection_state_read = _schema_private_link_service_connection_state_read
-        private_link_service_connection_state_read.actions_required = AAZStrType(
+        common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read
+        common_private_link_service_connection_state_read.actions_required = AAZStrType(
             serialized_name="actionsRequired",
         )
-        private_link_service_connection_state_read.description = AAZStrType()
-        private_link_service_connection_state_read.status = AAZStrType()
+        common_private_link_service_connection_state_read.description = AAZStrType()
+        common_private_link_service_connection_state_read.status = AAZStrType()
 
-        _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-        _schema.description = cls._schema_private_link_service_connection_state_read.description
-        _schema.status = cls._schema_private_link_service_connection_state_read.status
+        _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+        _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+        _schema.status = cls._schema_common_private_link_service_connection_state_read.status
 
-    _schema_private_link_service_connection_read = None
+    _schema_common_private_link_service_connection_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_read(cls, _schema):
-        if cls._schema_private_link_service_connection_read is not None:
-            _schema.etag = cls._schema_private_link_service_connection_read.etag
-            _schema.id = cls._schema_private_link_service_connection_read.id
-            _schema.name = cls._schema_private_link_service_connection_read.name
-            _schema.properties = cls._schema_private_link_service_connection_read.properties
-            _schema.type = cls._schema_private_link_service_connection_read.type
+    def _build_schema_common_private_link_service_connection_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_read is not None:
+            _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+            _schema.id = cls._schema_common_private_link_service_connection_read.id
+            _schema.name = cls._schema_common_private_link_service_connection_read.name
+            _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+            _schema.type = cls._schema_common_private_link_service_connection_read.type
             return
 
-        cls._schema_private_link_service_connection_read = _schema_private_link_service_connection_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_read = _schema_common_private_link_service_connection_read = AAZObjectType()
 
-        private_link_service_connection_read = _schema_private_link_service_connection_read
-        private_link_service_connection_read.etag = AAZStrType(
+        common_private_link_service_connection_read = _schema_common_private_link_service_connection_read
+        common_private_link_service_connection_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_link_service_connection_read.id = AAZStrType()
-        private_link_service_connection_read.name = AAZStrType()
-        private_link_service_connection_read.properties = AAZObjectType(
+        common_private_link_service_connection_read.id = AAZStrType()
+        common_private_link_service_connection_read.name = AAZStrType()
+        common_private_link_service_connection_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_link_service_connection_read.type = AAZStrType(
+        common_private_link_service_connection_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_link_service_connection_read.properties
+        properties = _schema_common_private_link_service_connection_read.properties
         properties.group_ids = AAZListType(
             serialized_name="groupIds",
         )
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.private_link_service_id = AAZStrType(
             serialized_name="privateLinkServiceId",
         )
@@ -1585,58 +1612,58 @@ class _ListHelper:
             serialized_name="requestMessage",
         )
 
-        group_ids = _schema_private_link_service_connection_read.properties.group_ids
+        group_ids = _schema_common_private_link_service_connection_read.properties.group_ids
         group_ids.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_link_service_connection_read.etag
-        _schema.id = cls._schema_private_link_service_connection_read.id
-        _schema.name = cls._schema_private_link_service_connection_read.name
-        _schema.properties = cls._schema_private_link_service_connection_read.properties
-        _schema.type = cls._schema_private_link_service_connection_read.type
+        _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+        _schema.id = cls._schema_common_private_link_service_connection_read.id
+        _schema.name = cls._schema_common_private_link_service_connection_read.name
+        _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+        _schema.type = cls._schema_common_private_link_service_connection_read.type
 
-    _schema_public_ip_address_read = None
+    _schema_common_public_ip_address_read = None
 
     @classmethod
-    def _build_schema_public_ip_address_read(cls, _schema):
-        if cls._schema_public_ip_address_read is not None:
-            _schema.etag = cls._schema_public_ip_address_read.etag
-            _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-            _schema.id = cls._schema_public_ip_address_read.id
-            _schema.location = cls._schema_public_ip_address_read.location
-            _schema.name = cls._schema_public_ip_address_read.name
-            _schema.properties = cls._schema_public_ip_address_read.properties
-            _schema.sku = cls._schema_public_ip_address_read.sku
-            _schema.tags = cls._schema_public_ip_address_read.tags
-            _schema.type = cls._schema_public_ip_address_read.type
-            _schema.zones = cls._schema_public_ip_address_read.zones
+    def _build_schema_common_public_ip_address_read(cls, _schema):
+        if cls._schema_common_public_ip_address_read is not None:
+            _schema.etag = cls._schema_common_public_ip_address_read.etag
+            _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+            _schema.id = cls._schema_common_public_ip_address_read.id
+            _schema.location = cls._schema_common_public_ip_address_read.location
+            _schema.name = cls._schema_common_public_ip_address_read.name
+            _schema.properties = cls._schema_common_public_ip_address_read.properties
+            _schema.sku = cls._schema_common_public_ip_address_read.sku
+            _schema.tags = cls._schema_common_public_ip_address_read.tags
+            _schema.type = cls._schema_common_public_ip_address_read.type
+            _schema.zones = cls._schema_common_public_ip_address_read.zones
             return
 
-        cls._schema_public_ip_address_read = _schema_public_ip_address_read = AAZObjectType()
+        cls._schema_common_public_ip_address_read = _schema_common_public_ip_address_read = AAZObjectType()
 
-        public_ip_address_read = _schema_public_ip_address_read
-        public_ip_address_read.etag = AAZStrType(
+        common_public_ip_address_read = _schema_common_public_ip_address_read
+        common_public_ip_address_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.extended_location = AAZObjectType(
+        common_public_ip_address_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(public_ip_address_read.extended_location)
-        public_ip_address_read.id = AAZStrType()
-        public_ip_address_read.location = AAZStrType()
-        public_ip_address_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_public_ip_address_read.extended_location)
+        common_public_ip_address_read.id = AAZStrType()
+        common_public_ip_address_read.location = AAZStrType()
+        common_public_ip_address_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.properties = AAZObjectType(
+        common_public_ip_address_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        public_ip_address_read.sku = AAZObjectType()
-        public_ip_address_read.tags = AAZDictType()
-        public_ip_address_read.type = AAZStrType(
+        common_public_ip_address_read.sku = AAZObjectType()
+        common_public_ip_address_read.tags = AAZDictType()
+        common_public_ip_address_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.zones = AAZListType()
+        common_public_ip_address_read.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties
+        properties = _schema_common_public_ip_address_read.properties
         properties.ddos_settings = AAZObjectType(
             serialized_name="ddosSettings",
         )
@@ -1656,14 +1683,14 @@ class _ListHelper:
             serialized_name="ipConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_ip_configuration_read(properties.ip_configuration)
+        cls._build_schema_common_ip_configuration_read(properties.ip_configuration)
         properties.ip_tags = AAZListType(
             serialized_name="ipTags",
         )
         properties.linked_public_ip_address = AAZObjectType(
             serialized_name="linkedPublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.linked_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.linked_public_ip_address)
         properties.migration_phase = AAZStrType(
             serialized_name="migrationPhase",
         )
@@ -1683,7 +1710,7 @@ class _ListHelper:
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.resource_guid = AAZStrType(
             serialized_name="resourceGuid",
             flags={"read_only": True},
@@ -1691,18 +1718,22 @@ class _ListHelper:
         properties.service_public_ip_address = AAZObjectType(
             serialized_name="servicePublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.service_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.service_public_ip_address)
 
-        ddos_settings = _schema_public_ip_address_read.properties.ddos_settings
+        ddos_settings = _schema_common_public_ip_address_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
         ddos_settings.ddos_protection_plan = AAZObjectType(
             serialized_name="ddosProtectionPlan",
         )
-        cls._build_schema_sub_resource_read(ddos_settings.ddos_protection_plan)
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_protection_plan)
         ddos_settings.protection_mode = AAZStrType(
             serialized_name="protectionMode",
         )
 
-        dns_settings = _schema_public_ip_address_read.properties.dns_settings
+        dns_settings = _schema_common_public_ip_address_read.properties.dns_settings
         dns_settings.domain_name_label = AAZStrType(
             serialized_name="domainNameLabel",
         )
@@ -1714,16 +1745,16 @@ class _ListHelper:
             serialized_name="reverseFqdn",
         )
 
-        ip_tags = _schema_public_ip_address_read.properties.ip_tags
+        ip_tags = _schema_common_public_ip_address_read.properties.ip_tags
         ip_tags.Element = AAZObjectType()
 
-        _element = _schema_public_ip_address_read.properties.ip_tags.Element
+        _element = _schema_common_public_ip_address_read.properties.ip_tags.Element
         _element.ip_tag_type = AAZStrType(
             serialized_name="ipTagType",
         )
         _element.tag = AAZStrType()
 
-        nat_gateway = _schema_public_ip_address_read.properties.nat_gateway
+        nat_gateway = _schema_common_public_ip_address_read.properties.nat_gateway
         nat_gateway.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1742,10 +1773,11 @@ class _ListHelper:
         )
         nat_gateway.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties.nat_gateway.properties
+        properties = _schema_common_public_ip_address_read.properties.nat_gateway.properties
         properties.idle_timeout_in_minutes = AAZIntType(
             serialized_name="idleTimeoutInMinutes",
         )
+        properties.nat64 = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -1766,90 +1798,96 @@ class _ListHelper:
             serialized_name="resourceGuid",
             flags={"read_only": True},
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.source_virtual_network = AAZObjectType(
             serialized_name="sourceVirtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.source_virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.source_virtual_network)
         properties.subnets = AAZListType(
             flags={"read_only": True},
         )
 
-        public_ip_addresses = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
+        public_ip_addresses = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
         public_ip_addresses.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
+        public_ip_addresses_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
+        public_ip_prefixes = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
-        subnets = _schema_public_ip_address_read.properties.nat_gateway.properties.subnets
+        subnets = _schema_common_public_ip_address_read.properties.nat_gateway.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(subnets.Element)
+        cls._build_schema_common_sub_resource_read(subnets.Element)
 
-        sku = _schema_public_ip_address_read.properties.nat_gateway.sku
+        sku = _schema_common_public_ip_address_read.properties.nat_gateway.sku
         sku.name = AAZStrType()
 
-        tags = _schema_public_ip_address_read.properties.nat_gateway.tags
+        tags = _schema_common_public_ip_address_read.properties.nat_gateway.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.properties.nat_gateway.zones
+        zones = _schema_common_public_ip_address_read.properties.nat_gateway.zones
         zones.Element = AAZStrType()
 
-        sku = _schema_public_ip_address_read.sku
+        sku = _schema_common_public_ip_address_read.sku
         sku.name = AAZStrType()
         sku.tier = AAZStrType()
 
-        tags = _schema_public_ip_address_read.tags
+        tags = _schema_common_public_ip_address_read.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.zones
+        zones = _schema_common_public_ip_address_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_public_ip_address_read.etag
-        _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-        _schema.id = cls._schema_public_ip_address_read.id
-        _schema.location = cls._schema_public_ip_address_read.location
-        _schema.name = cls._schema_public_ip_address_read.name
-        _schema.properties = cls._schema_public_ip_address_read.properties
-        _schema.sku = cls._schema_public_ip_address_read.sku
-        _schema.tags = cls._schema_public_ip_address_read.tags
-        _schema.type = cls._schema_public_ip_address_read.type
-        _schema.zones = cls._schema_public_ip_address_read.zones
+        _schema.etag = cls._schema_common_public_ip_address_read.etag
+        _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+        _schema.id = cls._schema_common_public_ip_address_read.id
+        _schema.location = cls._schema_common_public_ip_address_read.location
+        _schema.name = cls._schema_common_public_ip_address_read.name
+        _schema.properties = cls._schema_common_public_ip_address_read.properties
+        _schema.sku = cls._schema_common_public_ip_address_read.sku
+        _schema.tags = cls._schema_common_public_ip_address_read.tags
+        _schema.type = cls._schema_common_public_ip_address_read.type
+        _schema.zones = cls._schema_common_public_ip_address_read.zones
 
-    _schema_security_rule_read = None
+    _schema_common_security_rule_read = None
 
     @classmethod
-    def _build_schema_security_rule_read(cls, _schema):
-        if cls._schema_security_rule_read is not None:
-            _schema.etag = cls._schema_security_rule_read.etag
-            _schema.id = cls._schema_security_rule_read.id
-            _schema.name = cls._schema_security_rule_read.name
-            _schema.properties = cls._schema_security_rule_read.properties
-            _schema.type = cls._schema_security_rule_read.type
+    def _build_schema_common_security_rule_read(cls, _schema):
+        if cls._schema_common_security_rule_read is not None:
+            _schema.etag = cls._schema_common_security_rule_read.etag
+            _schema.id = cls._schema_common_security_rule_read.id
+            _schema.name = cls._schema_common_security_rule_read.name
+            _schema.properties = cls._schema_common_security_rule_read.properties
+            _schema.type = cls._schema_common_security_rule_read.type
             return
 
-        cls._schema_security_rule_read = _schema_security_rule_read = AAZObjectType()
+        cls._schema_common_security_rule_read = _schema_common_security_rule_read = AAZObjectType()
 
-        security_rule_read = _schema_security_rule_read
-        security_rule_read.etag = AAZStrType(
+        common_security_rule_read = _schema_common_security_rule_read
+        common_security_rule_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        security_rule_read.id = AAZStrType()
-        security_rule_read.name = AAZStrType()
-        security_rule_read.properties = AAZObjectType(
+        common_security_rule_read.id = AAZStrType()
+        common_security_rule_read.name = AAZStrType()
+        common_security_rule_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        security_rule_read.type = AAZStrType()
+        common_security_rule_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_security_rule_read.properties
+        properties = _schema_common_security_rule_read.properties
         properties.access = AAZStrType(
             flags={"required": True},
         )
@@ -1898,75 +1936,77 @@ class _ListHelper:
             serialized_name="sourcePortRanges",
         )
 
-        destination_address_prefixes = _schema_security_rule_read.properties.destination_address_prefixes
+        destination_address_prefixes = _schema_common_security_rule_read.properties.destination_address_prefixes
         destination_address_prefixes.Element = AAZStrType()
 
-        destination_application_security_groups = _schema_security_rule_read.properties.destination_application_security_groups
+        destination_application_security_groups = _schema_common_security_rule_read.properties.destination_application_security_groups
         destination_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(destination_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(destination_application_security_groups.Element)
 
-        destination_port_ranges = _schema_security_rule_read.properties.destination_port_ranges
+        destination_port_ranges = _schema_common_security_rule_read.properties.destination_port_ranges
         destination_port_ranges.Element = AAZStrType()
 
-        source_address_prefixes = _schema_security_rule_read.properties.source_address_prefixes
+        source_address_prefixes = _schema_common_security_rule_read.properties.source_address_prefixes
         source_address_prefixes.Element = AAZStrType()
 
-        source_application_security_groups = _schema_security_rule_read.properties.source_application_security_groups
+        source_application_security_groups = _schema_common_security_rule_read.properties.source_application_security_groups
         source_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(source_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(source_application_security_groups.Element)
 
-        source_port_ranges = _schema_security_rule_read.properties.source_port_ranges
+        source_port_ranges = _schema_common_security_rule_read.properties.source_port_ranges
         source_port_ranges.Element = AAZStrType()
 
-        _schema.etag = cls._schema_security_rule_read.etag
-        _schema.id = cls._schema_security_rule_read.id
-        _schema.name = cls._schema_security_rule_read.name
-        _schema.properties = cls._schema_security_rule_read.properties
-        _schema.type = cls._schema_security_rule_read.type
+        _schema.etag = cls._schema_common_security_rule_read.etag
+        _schema.id = cls._schema_common_security_rule_read.id
+        _schema.name = cls._schema_common_security_rule_read.name
+        _schema.properties = cls._schema_common_security_rule_read.properties
+        _schema.type = cls._schema_common_security_rule_read.type
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType(
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
-    _schema_subnet_read = None
+    _schema_common_subnet_read = None
 
     @classmethod
-    def _build_schema_subnet_read(cls, _schema):
-        if cls._schema_subnet_read is not None:
-            _schema.etag = cls._schema_subnet_read.etag
-            _schema.id = cls._schema_subnet_read.id
-            _schema.name = cls._schema_subnet_read.name
-            _schema.properties = cls._schema_subnet_read.properties
-            _schema.type = cls._schema_subnet_read.type
+    def _build_schema_common_subnet_read(cls, _schema):
+        if cls._schema_common_subnet_read is not None:
+            _schema.etag = cls._schema_common_subnet_read.etag
+            _schema.id = cls._schema_common_subnet_read.id
+            _schema.name = cls._schema_common_subnet_read.name
+            _schema.properties = cls._schema_common_subnet_read.properties
+            _schema.type = cls._schema_common_subnet_read.type
             return
 
-        cls._schema_subnet_read = _schema_subnet_read = AAZObjectType()
+        cls._schema_common_subnet_read = _schema_common_subnet_read = AAZObjectType()
 
-        subnet_read = _schema_subnet_read
-        subnet_read.etag = AAZStrType(
+        common_subnet_read = _schema_common_subnet_read
+        common_subnet_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        subnet_read.id = AAZStrType()
-        subnet_read.name = AAZStrType()
-        subnet_read.properties = AAZObjectType(
+        common_subnet_read.id = AAZStrType()
+        common_subnet_read.name = AAZStrType()
+        common_subnet_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        subnet_read.type = AAZStrType()
+        common_subnet_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties
+        properties = _schema_common_subnet_read.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
@@ -1997,11 +2037,11 @@ class _ListHelper:
         properties.nat_gateway = AAZObjectType(
             serialized_name="natGateway",
         )
-        cls._build_schema_sub_resource_read(properties.nat_gateway)
+        cls._build_schema_common_sub_resource_read(properties.nat_gateway)
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.private_endpoint_network_policies = AAZStrType(
             serialized_name="privateEndpointNetworkPolicies",
         )
@@ -2036,17 +2076,21 @@ class _ListHelper:
         properties.service_endpoints = AAZListType(
             serialized_name="serviceEndpoints",
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.sharing_scope = AAZStrType(
             serialized_name="sharingScope",
         )
 
-        address_prefixes = _schema_subnet_read.properties.address_prefixes
+        address_prefixes = _schema_common_subnet_read.properties.address_prefixes
         address_prefixes.Element = AAZStrType()
 
-        application_gateway_ip_configurations = _schema_subnet_read.properties.application_gateway_ip_configurations
+        application_gateway_ip_configurations = _schema_common_subnet_read.properties.application_gateway_ip_configurations
         application_gateway_ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.application_gateway_ip_configurations.Element
+        _element = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2059,18 +2103,18 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.application_gateway_ip_configurations.Element.properties
+        properties = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
 
-        delegations = _schema_subnet_read.properties.delegations
+        delegations = _schema_common_subnet_read.properties.delegations
         delegations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.delegations.Element
+        _element = _schema_common_subnet_read.properties.delegations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2081,7 +2125,7 @@ class _ListHelper:
         )
         _element.type = AAZStrType()
 
-        properties = _schema_subnet_read.properties.delegations.Element.properties
+        properties = _schema_common_subnet_read.properties.delegations.Element.properties
         properties.actions = AAZListType(
             flags={"read_only": True},
         )
@@ -2093,17 +2137,17 @@ class _ListHelper:
             serialized_name="serviceName",
         )
 
-        actions = _schema_subnet_read.properties.delegations.Element.properties.actions
+        actions = _schema_common_subnet_read.properties.delegations.Element.properties.actions
         actions.Element = AAZStrType()
 
-        ip_allocations = _schema_subnet_read.properties.ip_allocations
+        ip_allocations = _schema_common_subnet_read.properties.ip_allocations
         ip_allocations.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(ip_allocations.Element)
+        cls._build_schema_common_sub_resource_read(ip_allocations.Element)
 
-        ip_configuration_profiles = _schema_subnet_read.properties.ip_configuration_profiles
+        ip_configuration_profiles = _schema_common_subnet_read.properties.ip_configuration_profiles
         ip_configuration_profiles.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ip_configuration_profiles.Element
+        _element = _schema_common_subnet_read.properties.ip_configuration_profiles.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2116,22 +2160,22 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.ip_configuration_profiles.Element.properties
+        properties = _schema_common_subnet_read.properties.ip_configuration_profiles.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        ip_configurations = _schema_subnet_read.properties.ip_configurations
+        ip_configurations = _schema_common_subnet_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_ip_configuration_read(ip_configurations.Element)
 
-        ipam_pool_prefix_allocations = _schema_subnet_read.properties.ipam_pool_prefix_allocations
+        ipam_pool_prefix_allocations = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations
         ipam_pool_prefix_allocations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element
+        _element = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element
         _element.allocated_address_prefixes = AAZListType(
             serialized_name="allocatedAddressPrefixes",
             flags={"read_only": True},
@@ -2143,20 +2187,20 @@ class _ListHelper:
             flags={"client_flatten": True},
         )
 
-        allocated_address_prefixes = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
+        allocated_address_prefixes = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
         allocated_address_prefixes.Element = AAZStrType()
 
-        pool = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
+        pool = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
         pool.id = AAZStrType()
 
-        private_endpoints = _schema_subnet_read.properties.private_endpoints
+        private_endpoints = _schema_common_subnet_read.properties.private_endpoints
         private_endpoints.Element = AAZObjectType()
-        cls._build_schema_private_endpoint_read(private_endpoints.Element)
+        cls._build_schema_common_private_endpoint_read(private_endpoints.Element)
 
-        resource_navigation_links = _schema_subnet_read.properties.resource_navigation_links
+        resource_navigation_links = _schema_common_subnet_read.properties.resource_navigation_links
         resource_navigation_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.resource_navigation_links.Element
+        _element = _schema_common_subnet_read.properties.resource_navigation_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2171,7 +2215,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.resource_navigation_links.Element.properties
+        properties = _schema_common_subnet_read.properties.resource_navigation_links.Element.properties
         properties.link = AAZStrType()
         properties.linked_resource_type = AAZStrType(
             serialized_name="linkedResourceType",
@@ -2181,7 +2225,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        route_table = _schema_subnet_read.properties.route_table
+        route_table = _schema_common_subnet_read.properties.route_table
         route_table.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2198,9 +2242,12 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.route_table.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties
         properties.disable_bgp_route_propagation = AAZBoolType(
             serialized_name="disableBgpRoutePropagation",
+        )
+        properties.disable_peering_route = AAZStrType(
+            serialized_name="disablePeeringRoute",
         )
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2215,10 +2262,10 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        routes = _schema_subnet_read.properties.route_table.properties.routes
+        routes = _schema_common_subnet_read.properties.route_table.properties.routes
         routes.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.route_table.properties.routes.Element
+        _element = _schema_common_subnet_read.properties.route_table.properties.routes.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2227,15 +2274,20 @@ class _ListHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.route_table.properties.routes.Element.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
         properties.has_bgp_override = AAZBoolType(
             serialized_name="hasBgpOverride",
             flags={"read_only": True},
+        )
+        properties.next_hop = AAZObjectType(
+            serialized_name="nextHop",
         )
         properties.next_hop_ip_address = AAZStrType(
             serialized_name="nextHopIpAddress",
@@ -2249,17 +2301,26 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        subnets = _schema_subnet_read.properties.route_table.properties.subnets
-        subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        next_hop = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop
+        next_hop.next_hop_ip_addresses = AAZListType(
+            serialized_name="nextHopIpAddresses",
+            flags={"required": True},
+        )
 
-        tags = _schema_subnet_read.properties.route_table.tags
+        next_hop_ip_addresses = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop.next_hop_ip_addresses
+        next_hop_ip_addresses.Element = AAZStrType()
+
+        subnets = _schema_common_subnet_read.properties.route_table.properties.subnets
+        subnets.Element = AAZObjectType()
+        cls._build_schema_common_subnet_read(subnets.Element)
+
+        tags = _schema_common_subnet_read.properties.route_table.tags
         tags.Element = AAZStrType()
 
-        service_association_links = _schema_subnet_read.properties.service_association_links
+        service_association_links = _schema_common_subnet_read.properties.service_association_links
         service_association_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_association_links.Element
+        _element = _schema_common_subnet_read.properties.service_association_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2272,7 +2333,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_association_links.Element.properties
+        properties = _schema_common_subnet_read.properties.service_association_links.Element.properties
         properties.allow_delete = AAZBoolType(
             serialized_name="allowDelete",
         )
@@ -2286,13 +2347,13 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        locations = _schema_subnet_read.properties.service_association_links.Element.properties.locations
+        locations = _schema_common_subnet_read.properties.service_association_links.Element.properties.locations
         locations.Element = AAZStrType()
 
-        service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies
+        service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies
         service_endpoint_policies.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2312,7 +2373,7 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties
         properties.contextual_service_endpoint_policies = AAZListType(
             serialized_name="contextualServiceEndpointPolicies",
         )
@@ -2334,13 +2395,13 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        contextual_service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
+        contextual_service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
         contextual_service_endpoint_policies.Element = AAZStrType()
 
-        service_endpoint_policy_definitions = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
+        service_endpoint_policy_definitions = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
         service_endpoint_policy_definitions.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2349,9 +2410,11 @@ class _ListHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
         properties.description = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2362,82 +2425,82 @@ class _ListHelper:
             serialized_name="serviceResources",
         )
 
-        service_resources = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
+        service_resources = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
         service_resources.Element = AAZStrType()
 
-        subnets = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
+        subnets = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_subnet_read.properties.service_endpoint_policies.Element.tags
+        tags = _schema_common_subnet_read.properties.service_endpoint_policies.Element.tags
         tags.Element = AAZStrType()
 
-        service_endpoints = _schema_subnet_read.properties.service_endpoints
+        service_endpoints = _schema_common_subnet_read.properties.service_endpoints
         service_endpoints.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoints.Element
+        _element = _schema_common_subnet_read.properties.service_endpoints.Element
         _element.locations = AAZListType()
         _element.network_identifier = AAZObjectType(
             serialized_name="networkIdentifier",
         )
-        cls._build_schema_sub_resource_read(_element.network_identifier)
+        cls._build_schema_common_sub_resource_read(_element.network_identifier)
         _element.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         _element.service = AAZStrType()
 
-        locations = _schema_subnet_read.properties.service_endpoints.Element.locations
+        locations = _schema_common_subnet_read.properties.service_endpoints.Element.locations
         locations.Element = AAZStrType()
 
-        _schema.etag = cls._schema_subnet_read.etag
-        _schema.id = cls._schema_subnet_read.id
-        _schema.name = cls._schema_subnet_read.name
-        _schema.properties = cls._schema_subnet_read.properties
-        _schema.type = cls._schema_subnet_read.type
+        _schema.etag = cls._schema_common_subnet_read.etag
+        _schema.id = cls._schema_common_subnet_read.id
+        _schema.name = cls._schema_common_subnet_read.name
+        _schema.properties = cls._schema_common_subnet_read.properties
+        _schema.type = cls._schema_common_subnet_read.type
 
-    _schema_virtual_network_tap_read = None
+    _schema_common_virtual_network_tap_read = None
 
     @classmethod
-    def _build_schema_virtual_network_tap_read(cls, _schema):
-        if cls._schema_virtual_network_tap_read is not None:
-            _schema.etag = cls._schema_virtual_network_tap_read.etag
-            _schema.id = cls._schema_virtual_network_tap_read.id
-            _schema.location = cls._schema_virtual_network_tap_read.location
-            _schema.name = cls._schema_virtual_network_tap_read.name
-            _schema.properties = cls._schema_virtual_network_tap_read.properties
-            _schema.tags = cls._schema_virtual_network_tap_read.tags
-            _schema.type = cls._schema_virtual_network_tap_read.type
+    def _build_schema_common_virtual_network_tap_read(cls, _schema):
+        if cls._schema_common_virtual_network_tap_read is not None:
+            _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+            _schema.id = cls._schema_common_virtual_network_tap_read.id
+            _schema.location = cls._schema_common_virtual_network_tap_read.location
+            _schema.name = cls._schema_common_virtual_network_tap_read.name
+            _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+            _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+            _schema.type = cls._schema_common_virtual_network_tap_read.type
             return
 
-        cls._schema_virtual_network_tap_read = _schema_virtual_network_tap_read = AAZObjectType()
+        cls._schema_common_virtual_network_tap_read = _schema_common_virtual_network_tap_read = AAZObjectType()
 
-        virtual_network_tap_read = _schema_virtual_network_tap_read
-        virtual_network_tap_read.etag = AAZStrType(
+        common_virtual_network_tap_read = _schema_common_virtual_network_tap_read
+        common_virtual_network_tap_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.id = AAZStrType()
-        virtual_network_tap_read.location = AAZStrType()
-        virtual_network_tap_read.name = AAZStrType(
+        common_virtual_network_tap_read.id = AAZStrType()
+        common_virtual_network_tap_read.location = AAZStrType()
+        common_virtual_network_tap_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.properties = AAZObjectType(
+        common_virtual_network_tap_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        virtual_network_tap_read.tags = AAZDictType()
-        virtual_network_tap_read.type = AAZStrType(
+        common_virtual_network_tap_read.tags = AAZDictType()
+        common_virtual_network_tap_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_virtual_network_tap_read.properties
+        properties = _schema_common_virtual_network_tap_read.properties
         properties.destination_load_balancer_front_end_ip_configuration = AAZObjectType(
             serialized_name="destinationLoadBalancerFrontEndIPConfiguration",
         )
-        cls._build_schema_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
+        cls._build_schema_common_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
         properties.destination_network_interface_ip_configuration = AAZObjectType(
             serialized_name="destinationNetworkInterfaceIPConfiguration",
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
         properties.destination_port = AAZIntType(
             serialized_name="destinationPort",
         )
@@ -2454,20 +2517,20 @@ class _ListHelper:
             flags={"read_only": True},
         )
 
-        network_interface_tap_configurations = _schema_virtual_network_tap_read.properties.network_interface_tap_configurations
+        network_interface_tap_configurations = _schema_common_virtual_network_tap_read.properties.network_interface_tap_configurations
         network_interface_tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
 
-        tags = _schema_virtual_network_tap_read.tags
+        tags = _schema_common_virtual_network_tap_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_virtual_network_tap_read.etag
-        _schema.id = cls._schema_virtual_network_tap_read.id
-        _schema.location = cls._schema_virtual_network_tap_read.location
-        _schema.name = cls._schema_virtual_network_tap_read.name
-        _schema.properties = cls._schema_virtual_network_tap_read.properties
-        _schema.tags = cls._schema_virtual_network_tap_read.tags
-        _schema.type = cls._schema_virtual_network_tap_read.type
+        _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+        _schema.id = cls._schema_common_virtual_network_tap_read.id
+        _schema.location = cls._schema_common_virtual_network_tap_read.location
+        _schema.name = cls._schema_common_virtual_network_tap_read.name
+        _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+        _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+        _schema.type = cls._schema_common_virtual_network_tap_read.type
 
 
 __all__ = ["List"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_show.py
@@ -25,9 +25,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2025-07-01"],
         ]
     }
 
@@ -56,15 +56,11 @@ class Show(AAZCommand):
         _args_schema.resource_group = AAZResourceGroupNameArg(
             required=True,
         )
-        _args_schema.expand = AAZStrArg(
-            options=["--expand"],
-            help="Expands referenced resources.",
-        )
         return cls._args_schema
 
     def _execute_operations(self):
         self.pre_operations()
-        self.PublicIPAddressesGet(ctx=self.ctx)()
+        self.PublicIpAddressOperationGroupGet(ctx=self.ctx)()
         self.post_operations()
 
     @register_callback
@@ -79,7 +75,7 @@ class Show(AAZCommand):
         result = self.deserialize_output(self.ctx.vars.instance, client_flatten=True)
         return result
 
-    class PublicIPAddressesGet(AAZHttpOperation):
+    class PublicIpAddressOperationGroupGet(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -127,10 +123,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "$expand", self.ctx.args.expand,
-                ),
-                **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -161,7 +154,7 @@ class Show(AAZCommand):
                 return cls._schema_on_200
 
             cls._schema_on_200 = AAZObjectType()
-            _ShowHelper._build_schema_public_ip_address_read(cls._schema_on_200)
+            _ShowHelper._build_schema_common_public_ip_address_read(cls._schema_on_200)
 
             return cls._schema_on_200
 
@@ -169,40 +162,40 @@ class Show(AAZCommand):
 class _ShowHelper:
     """Helper class for Show"""
 
-    _schema_application_security_group_read = None
+    _schema_common_application_security_group_read = None
 
     @classmethod
-    def _build_schema_application_security_group_read(cls, _schema):
-        if cls._schema_application_security_group_read is not None:
-            _schema.etag = cls._schema_application_security_group_read.etag
-            _schema.id = cls._schema_application_security_group_read.id
-            _schema.location = cls._schema_application_security_group_read.location
-            _schema.name = cls._schema_application_security_group_read.name
-            _schema.properties = cls._schema_application_security_group_read.properties
-            _schema.tags = cls._schema_application_security_group_read.tags
-            _schema.type = cls._schema_application_security_group_read.type
+    def _build_schema_common_application_security_group_read(cls, _schema):
+        if cls._schema_common_application_security_group_read is not None:
+            _schema.etag = cls._schema_common_application_security_group_read.etag
+            _schema.id = cls._schema_common_application_security_group_read.id
+            _schema.location = cls._schema_common_application_security_group_read.location
+            _schema.name = cls._schema_common_application_security_group_read.name
+            _schema.properties = cls._schema_common_application_security_group_read.properties
+            _schema.tags = cls._schema_common_application_security_group_read.tags
+            _schema.type = cls._schema_common_application_security_group_read.type
             return
 
-        cls._schema_application_security_group_read = _schema_application_security_group_read = AAZObjectType()
+        cls._schema_common_application_security_group_read = _schema_common_application_security_group_read = AAZObjectType()
 
-        application_security_group_read = _schema_application_security_group_read
-        application_security_group_read.etag = AAZStrType(
+        common_application_security_group_read = _schema_common_application_security_group_read
+        common_application_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.id = AAZStrType()
-        application_security_group_read.location = AAZStrType()
-        application_security_group_read.name = AAZStrType(
+        common_application_security_group_read.id = AAZStrType()
+        common_application_security_group_read.location = AAZStrType()
+        common_application_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.properties = AAZObjectType(
+        common_application_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        application_security_group_read.tags = AAZDictType()
-        application_security_group_read.type = AAZStrType(
+        common_application_security_group_read.tags = AAZDictType()
+        common_application_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_application_security_group_read.properties
+        properties = _schema_common_application_security_group_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -212,69 +205,72 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        tags = _schema_application_security_group_read.tags
+        tags = _schema_common_application_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_application_security_group_read.etag
-        _schema.id = cls._schema_application_security_group_read.id
-        _schema.location = cls._schema_application_security_group_read.location
-        _schema.name = cls._schema_application_security_group_read.name
-        _schema.properties = cls._schema_application_security_group_read.properties
-        _schema.tags = cls._schema_application_security_group_read.tags
-        _schema.type = cls._schema_application_security_group_read.type
+        _schema.etag = cls._schema_common_application_security_group_read.etag
+        _schema.id = cls._schema_common_application_security_group_read.id
+        _schema.location = cls._schema_common_application_security_group_read.location
+        _schema.name = cls._schema_common_application_security_group_read.name
+        _schema.properties = cls._schema_common_application_security_group_read.properties
+        _schema.tags = cls._schema_common_application_security_group_read.tags
+        _schema.type = cls._schema_common_application_security_group_read.type
 
-    _schema_extended_location_read = None
-
-    @classmethod
-    def _build_schema_extended_location_read(cls, _schema):
-        if cls._schema_extended_location_read is not None:
-            _schema.name = cls._schema_extended_location_read.name
-            _schema.type = cls._schema_extended_location_read.type
-            return
-
-        cls._schema_extended_location_read = _schema_extended_location_read = AAZObjectType()
-
-        extended_location_read = _schema_extended_location_read
-        extended_location_read.name = AAZStrType()
-        extended_location_read.type = AAZStrType()
-
-        _schema.name = cls._schema_extended_location_read.name
-        _schema.type = cls._schema_extended_location_read.type
-
-    _schema_frontend_ip_configuration_read = None
+    _schema_common_extended_location_read = None
 
     @classmethod
-    def _build_schema_frontend_ip_configuration_read(cls, _schema):
-        if cls._schema_frontend_ip_configuration_read is not None:
-            _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-            _schema.id = cls._schema_frontend_ip_configuration_read.id
-            _schema.name = cls._schema_frontend_ip_configuration_read.name
-            _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-            _schema.type = cls._schema_frontend_ip_configuration_read.type
-            _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+    def _build_schema_common_extended_location_read(cls, _schema):
+        if cls._schema_common_extended_location_read is not None:
+            _schema.name = cls._schema_common_extended_location_read.name
+            _schema.type = cls._schema_common_extended_location_read.type
             return
 
-        cls._schema_frontend_ip_configuration_read = _schema_frontend_ip_configuration_read = AAZObjectType()
+        cls._schema_common_extended_location_read = _schema_common_extended_location_read = AAZObjectType()
 
-        frontend_ip_configuration_read = _schema_frontend_ip_configuration_read
-        frontend_ip_configuration_read.etag = AAZStrType(
+        common_extended_location_read = _schema_common_extended_location_read
+        common_extended_location_read.name = AAZStrType()
+        common_extended_location_read.type = AAZStrType()
+
+        _schema.name = cls._schema_common_extended_location_read.name
+        _schema.type = cls._schema_common_extended_location_read.type
+
+    _schema_common_frontend_ip_configuration_read = None
+
+    @classmethod
+    def _build_schema_common_frontend_ip_configuration_read(cls, _schema):
+        if cls._schema_common_frontend_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+            _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+            _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+            _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+            _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+            _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
+            return
+
+        cls._schema_common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read = AAZObjectType()
+
+        common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read
+        common_frontend_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.id = AAZStrType()
-        frontend_ip_configuration_read.name = AAZStrType()
-        frontend_ip_configuration_read.properties = AAZObjectType(
+        common_frontend_ip_configuration_read.id = AAZStrType()
+        common_frontend_ip_configuration_read.name = AAZStrType()
+        common_frontend_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        frontend_ip_configuration_read.type = AAZStrType(
+        common_frontend_ip_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.zones = AAZListType()
+        common_frontend_ip_configuration_read.zones = AAZListType()
 
-        properties = _schema_frontend_ip_configuration_read.properties
+        properties = _schema_common_frontend_ip_configuration_read.properties
+        properties.ddos_settings = AAZObjectType(
+            serialized_name="ddosSettings",
+        )
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.inbound_nat_pools = AAZListType(
             serialized_name="inboundNatPools",
             flags={"read_only": True},
@@ -307,66 +303,72 @@ class _ShowHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        inbound_nat_pools = _schema_frontend_ip_configuration_read.properties.inbound_nat_pools
+        ddos_settings = _schema_common_frontend_ip_configuration_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
+
+        inbound_nat_pools = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_pools
         inbound_nat_pools.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_pools.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_pools.Element)
 
-        inbound_nat_rules = _schema_frontend_ip_configuration_read.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancing_rules = _schema_frontend_ip_configuration_read.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_frontend_ip_configuration_read.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_frontend_ip_configuration_read.properties.outbound_rules
+        outbound_rules = _schema_common_frontend_ip_configuration_read.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        zones = _schema_frontend_ip_configuration_read.zones
+        zones = _schema_common_frontend_ip_configuration_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-        _schema.id = cls._schema_frontend_ip_configuration_read.id
-        _schema.name = cls._schema_frontend_ip_configuration_read.name
-        _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-        _schema.type = cls._schema_frontend_ip_configuration_read.type
-        _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+        _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+        _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+        _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+        _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+        _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+        _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
 
-    _schema_ip_configuration_read = None
+    _schema_common_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_ip_configuration_read(cls, _schema):
-        if cls._schema_ip_configuration_read is not None:
-            _schema.etag = cls._schema_ip_configuration_read.etag
-            _schema.id = cls._schema_ip_configuration_read.id
-            _schema.name = cls._schema_ip_configuration_read.name
-            _schema.properties = cls._schema_ip_configuration_read.properties
+    def _build_schema_common_ip_configuration_read(cls, _schema):
+        if cls._schema_common_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_ip_configuration_read.etag
+            _schema.id = cls._schema_common_ip_configuration_read.id
+            _schema.name = cls._schema_common_ip_configuration_read.name
+            _schema.properties = cls._schema_common_ip_configuration_read.properties
             return
 
-        cls._schema_ip_configuration_read = _schema_ip_configuration_read = AAZObjectType(
+        cls._schema_common_ip_configuration_read = _schema_common_ip_configuration_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        ip_configuration_read = _schema_ip_configuration_read
-        ip_configuration_read.etag = AAZStrType(
+        common_ip_configuration_read = _schema_common_ip_configuration_read
+        common_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        ip_configuration_read.id = AAZStrType()
-        ip_configuration_read.name = AAZStrType()
-        ip_configuration_read.properties = AAZObjectType(
+        common_ip_configuration_read.id = AAZStrType()
+        common_ip_configuration_read.name = AAZStrType()
+        common_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_ip_configuration_read.properties
+        properties = _schema_common_ip_configuration_read.properties
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
         )
@@ -380,41 +382,43 @@ class _ShowHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        _schema.etag = cls._schema_ip_configuration_read.etag
-        _schema.id = cls._schema_ip_configuration_read.id
-        _schema.name = cls._schema_ip_configuration_read.name
-        _schema.properties = cls._schema_ip_configuration_read.properties
+        _schema.etag = cls._schema_common_ip_configuration_read.etag
+        _schema.id = cls._schema_common_ip_configuration_read.id
+        _schema.name = cls._schema_common_ip_configuration_read.name
+        _schema.properties = cls._schema_common_ip_configuration_read.properties
 
-    _schema_network_interface_ip_configuration_read = None
+    _schema_common_network_interface_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_ip_configuration_read(cls, _schema):
-        if cls._schema_network_interface_ip_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-            _schema.id = cls._schema_network_interface_ip_configuration_read.id
-            _schema.name = cls._schema_network_interface_ip_configuration_read.name
-            _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-            _schema.type = cls._schema_network_interface_ip_configuration_read.type
+    def _build_schema_common_network_interface_ip_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
             return
 
-        cls._schema_network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read = AAZObjectType()
 
-        network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read
-        network_interface_ip_configuration_read.etag = AAZStrType(
+        common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read
+        common_network_interface_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_ip_configuration_read.id = AAZStrType()
-        network_interface_ip_configuration_read.name = AAZStrType()
-        network_interface_ip_configuration_read.properties = AAZObjectType(
+        common_network_interface_ip_configuration_read.id = AAZStrType()
+        common_network_interface_ip_configuration_read.name = AAZStrType()
+        common_network_interface_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_ip_configuration_read.type = AAZStrType()
+        common_network_interface_ip_configuration_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_network_interface_ip_configuration_read.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties
         properties.application_gateway_backend_address_pools = AAZListType(
             serialized_name="applicationGatewayBackendAddressPools",
         )
@@ -424,7 +428,7 @@ class _ShowHelper:
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.load_balancer_backend_address_pools = AAZListType(
             serialized_name="loadBalancerBackendAddressPools",
         )
@@ -456,17 +460,17 @@ class _ShowHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
         properties.virtual_network_taps = AAZListType(
             serialized_name="virtualNetworkTaps",
         )
 
-        application_gateway_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
+        application_gateway_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
         application_gateway_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -479,7 +483,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
         properties.backend_addresses = AAZListType(
             serialized_name="backendAddresses",
         )
@@ -492,27 +496,27 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        backend_addresses = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
+        backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
         backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
         _element.fqdn = AAZStrType()
         _element.ip_address = AAZStrType(
             serialized_name="ipAddress",
         )
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        application_security_groups = _schema_network_interface_ip_configuration_read.properties.application_security_groups
+        application_security_groups = _schema_common_network_interface_ip_configuration_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        load_balancer_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
+        load_balancer_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
         load_balancer_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -525,7 +529,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
         properties.backend_ip_configurations = AAZListType(
             serialized_name="backendIPConfigurations",
             flags={"read_only": True},
@@ -549,7 +553,7 @@ class _ShowHelper:
             serialized_name="outboundRule",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.outbound_rule)
+        cls._build_schema_common_sub_resource_read(properties.outbound_rule)
         properties.outbound_rules = AAZListType(
             serialized_name="outboundRules",
             flags={"read_only": True},
@@ -567,26 +571,26 @@ class _ShowHelper:
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancer_backend_addresses = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
+        load_balancer_backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
         load_balancer_backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
         _element.name = AAZStrType()
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
         properties.admin_state = AAZStrType(
             serialized_name="adminState",
         )
@@ -600,23 +604,23 @@ class _ShowHelper:
         properties.load_balancer_frontend_ip_configuration = AAZObjectType(
             serialized_name="loadBalancerFrontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
         properties.network_interface_ip_configuration = AAZObjectType(
             serialized_name="networkInterfaceIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.network_interface_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.network_interface_ip_configuration)
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        inbound_nat_rules_port_mapping = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
+        inbound_nat_rules_port_mapping = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
         inbound_nat_rules_port_mapping.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
         _element.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -627,27 +631,27 @@ class _ShowHelper:
             serialized_name="inboundNatRuleName",
         )
 
-        load_balancing_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
+        outbound_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        tunnel_interfaces = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
+        tunnel_interfaces = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
         tunnel_interfaces.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
         _element.identifier = AAZIntType()
         _element.port = AAZIntType()
         _element.protocol = AAZStrType()
         _element.type = AAZStrType()
 
-        load_balancer_inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
+        load_balancer_inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
         load_balancer_inbound_nat_rules.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -660,16 +664,16 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
         properties.backend_address_pool = AAZObjectType(
             serialized_name="backendAddressPool",
         )
-        cls._build_schema_sub_resource_read(properties.backend_address_pool)
+        cls._build_schema_common_sub_resource_read(properties.backend_address_pool)
         properties.backend_ip_configuration = AAZObjectType(
             serialized_name="backendIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.backend_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.backend_ip_configuration)
         properties.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -682,7 +686,7 @@ class _ShowHelper:
         properties.frontend_ip_configuration = AAZObjectType(
             serialized_name="frontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.frontend_ip_configuration)
         properties.frontend_port = AAZIntType(
             serialized_name="frontendPort",
         )
@@ -701,7 +705,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        private_link_connection_properties = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties
+        private_link_connection_properties = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties
         private_link_connection_properties.fqdns = AAZListType(
             flags={"read_only": True},
         )
@@ -714,47 +718,47 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        fqdns = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
+        fqdns = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
         fqdns.Element = AAZStrType()
 
-        virtual_network_taps = _schema_network_interface_ip_configuration_read.properties.virtual_network_taps
+        virtual_network_taps = _schema_common_network_interface_ip_configuration_read.properties.virtual_network_taps
         virtual_network_taps.Element = AAZObjectType()
-        cls._build_schema_virtual_network_tap_read(virtual_network_taps.Element)
+        cls._build_schema_common_virtual_network_tap_read(virtual_network_taps.Element)
 
-        _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-        _schema.id = cls._schema_network_interface_ip_configuration_read.id
-        _schema.name = cls._schema_network_interface_ip_configuration_read.name
-        _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-        _schema.type = cls._schema_network_interface_ip_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
 
-    _schema_network_interface_tap_configuration_read = None
+    _schema_common_network_interface_tap_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_tap_configuration_read(cls, _schema):
-        if cls._schema_network_interface_tap_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-            _schema.id = cls._schema_network_interface_tap_configuration_read.id
-            _schema.name = cls._schema_network_interface_tap_configuration_read.name
-            _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-            _schema.type = cls._schema_network_interface_tap_configuration_read.type
+    def _build_schema_common_network_interface_tap_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_tap_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
             return
 
-        cls._schema_network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read = AAZObjectType()
 
-        network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read
-        network_interface_tap_configuration_read.etag = AAZStrType(
+        common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read
+        common_network_interface_tap_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_tap_configuration_read.id = AAZStrType()
-        network_interface_tap_configuration_read.name = AAZStrType()
-        network_interface_tap_configuration_read.properties = AAZObjectType(
+        common_network_interface_tap_configuration_read.id = AAZStrType()
+        common_network_interface_tap_configuration_read.name = AAZStrType()
+        common_network_interface_tap_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_tap_configuration_read.type = AAZStrType(
+        common_network_interface_tap_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_tap_configuration_read.properties
+        properties = _schema_common_network_interface_tap_configuration_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -762,53 +766,53 @@ class _ShowHelper:
         properties.virtual_network_tap = AAZObjectType(
             serialized_name="virtualNetworkTap",
         )
-        cls._build_schema_virtual_network_tap_read(properties.virtual_network_tap)
+        cls._build_schema_common_virtual_network_tap_read(properties.virtual_network_tap)
 
-        _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-        _schema.id = cls._schema_network_interface_tap_configuration_read.id
-        _schema.name = cls._schema_network_interface_tap_configuration_read.name
-        _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-        _schema.type = cls._schema_network_interface_tap_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
 
-    _schema_network_interface_read = None
+    _schema_common_network_interface_read = None
 
     @classmethod
-    def _build_schema_network_interface_read(cls, _schema):
-        if cls._schema_network_interface_read is not None:
-            _schema.etag = cls._schema_network_interface_read.etag
-            _schema.extended_location = cls._schema_network_interface_read.extended_location
-            _schema.id = cls._schema_network_interface_read.id
-            _schema.location = cls._schema_network_interface_read.location
-            _schema.name = cls._schema_network_interface_read.name
-            _schema.properties = cls._schema_network_interface_read.properties
-            _schema.tags = cls._schema_network_interface_read.tags
-            _schema.type = cls._schema_network_interface_read.type
+    def _build_schema_common_network_interface_read(cls, _schema):
+        if cls._schema_common_network_interface_read is not None:
+            _schema.etag = cls._schema_common_network_interface_read.etag
+            _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+            _schema.id = cls._schema_common_network_interface_read.id
+            _schema.location = cls._schema_common_network_interface_read.location
+            _schema.name = cls._schema_common_network_interface_read.name
+            _schema.properties = cls._schema_common_network_interface_read.properties
+            _schema.tags = cls._schema_common_network_interface_read.tags
+            _schema.type = cls._schema_common_network_interface_read.type
             return
 
-        cls._schema_network_interface_read = _schema_network_interface_read = AAZObjectType()
+        cls._schema_common_network_interface_read = _schema_common_network_interface_read = AAZObjectType()
 
-        network_interface_read = _schema_network_interface_read
-        network_interface_read.etag = AAZStrType(
+        common_network_interface_read = _schema_common_network_interface_read
+        common_network_interface_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.extended_location = AAZObjectType(
+        common_network_interface_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(network_interface_read.extended_location)
-        network_interface_read.id = AAZStrType()
-        network_interface_read.location = AAZStrType()
-        network_interface_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_network_interface_read.extended_location)
+        common_network_interface_read.id = AAZStrType()
+        common_network_interface_read.location = AAZStrType()
+        common_network_interface_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.properties = AAZObjectType(
+        common_network_interface_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_read.tags = AAZDictType()
-        network_interface_read.type = AAZStrType(
+        common_network_interface_read.tags = AAZDictType()
+        common_network_interface_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties
+        properties = _schema_common_network_interface_read.properties
         properties.auxiliary_mode = AAZStrType(
             serialized_name="auxiliaryMode",
         )
@@ -829,7 +833,7 @@ class _ShowHelper:
             serialized_name="dscpConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.dscp_configuration)
+        cls._build_schema_common_sub_resource_read(properties.dscp_configuration)
         properties.enable_accelerated_networking = AAZBoolType(
             serialized_name="enableAcceleratedNetworking",
         )
@@ -853,7 +857,7 @@ class _ShowHelper:
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.nic_type = AAZStrType(
             serialized_name="nicType",
         )
@@ -864,7 +868,7 @@ class _ShowHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_link_service = AAZObjectType(
             serialized_name="privateLinkService",
         )
@@ -884,7 +888,7 @@ class _ShowHelper:
             serialized_name="virtualMachine",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.virtual_machine)
+        cls._build_schema_common_sub_resource_read(properties.virtual_machine)
         properties.vnet_encryption_supported = AAZBoolType(
             serialized_name="vnetEncryptionSupported",
             flags={"read_only": True},
@@ -893,7 +897,7 @@ class _ShowHelper:
             serialized_name="workloadType",
         )
 
-        dns_settings = _schema_network_interface_read.properties.dns_settings
+        dns_settings = _schema_common_network_interface_read.properties.dns_settings
         dns_settings.applied_dns_servers = AAZListType(
             serialized_name="appliedDnsServers",
             flags={"read_only": True},
@@ -913,27 +917,27 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        applied_dns_servers = _schema_network_interface_read.properties.dns_settings.applied_dns_servers
+        applied_dns_servers = _schema_common_network_interface_read.properties.dns_settings.applied_dns_servers
         applied_dns_servers.Element = AAZStrType()
 
-        dns_servers = _schema_network_interface_read.properties.dns_settings.dns_servers
+        dns_servers = _schema_common_network_interface_read.properties.dns_settings.dns_servers
         dns_servers.Element = AAZStrType()
 
-        hosted_workloads = _schema_network_interface_read.properties.hosted_workloads
+        hosted_workloads = _schema_common_network_interface_read.properties.hosted_workloads
         hosted_workloads.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(ip_configurations.Element)
 
-        private_link_service = _schema_network_interface_read.properties.private_link_service
+        private_link_service = _schema_common_network_interface_read.properties.private_link_service
         private_link_service.etag = AAZStrType(
             flags={"read_only": True},
         )
         private_link_service.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_link_service.extended_location)
+        cls._build_schema_common_extended_location_read(private_link_service.extended_location)
         private_link_service.id = AAZStrType()
         private_link_service.location = AAZStrType()
         private_link_service.name = AAZStrType(
@@ -947,7 +951,10 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties
+        properties.access_mode = AAZStrType(
+            serialized_name="accessMode",
+        )
         properties.alias = AAZStrType(
             flags={"read_only": True},
         )
@@ -981,19 +988,19 @@ class _ShowHelper:
         )
         properties.visibility = AAZObjectType()
 
-        auto_approval = _schema_network_interface_read.properties.private_link_service.properties.auto_approval
+        auto_approval = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval
         auto_approval.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
         subscriptions.Element = AAZStrType()
 
-        fqdns = _schema_network_interface_read.properties.private_link_service.properties.fqdns
+        fqdns = _schema_common_network_interface_read.properties.private_link_service.properties.fqdns
         fqdns.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1006,7 +1013,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
         properties.primary = AAZBoolType()
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
@@ -1022,20 +1029,20 @@ class _ShowHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        load_balancer_frontend_ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
+        load_balancer_frontend_ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
         load_balancer_frontend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
+        cls._build_schema_common_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
 
-        network_interfaces = _schema_network_interface_read.properties.private_link_service.properties.network_interfaces
+        network_interfaces = _schema_common_network_interface_read.properties.private_link_service.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_endpoint_connections = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
+        private_endpoint_connections = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
         private_endpoint_connections.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1048,7 +1055,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
         properties.link_identifier = AAZStrType(
             serialized_name="linkIdentifier",
             flags={"read_only": True},
@@ -1057,7 +1064,7 @@ class _ShowHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_endpoint_location = AAZStrType(
             serialized_name="privateEndpointLocation",
             flags={"read_only": True},
@@ -1065,71 +1072,71 @@ class _ShowHelper:
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
 
-        visibility = _schema_network_interface_read.properties.private_link_service.properties.visibility
+        visibility = _schema_common_network_interface_read.properties.private_link_service.properties.visibility
         visibility.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
         subscriptions.Element = AAZStrType()
 
-        tags = _schema_network_interface_read.properties.private_link_service.tags
+        tags = _schema_common_network_interface_read.properties.private_link_service.tags
         tags.Element = AAZStrType()
 
-        tap_configurations = _schema_network_interface_read.properties.tap_configurations
+        tap_configurations = _schema_common_network_interface_read.properties.tap_configurations
         tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(tap_configurations.Element)
 
-        tags = _schema_network_interface_read.tags
+        tags = _schema_common_network_interface_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_interface_read.etag
-        _schema.extended_location = cls._schema_network_interface_read.extended_location
-        _schema.id = cls._schema_network_interface_read.id
-        _schema.location = cls._schema_network_interface_read.location
-        _schema.name = cls._schema_network_interface_read.name
-        _schema.properties = cls._schema_network_interface_read.properties
-        _schema.tags = cls._schema_network_interface_read.tags
-        _schema.type = cls._schema_network_interface_read.type
+        _schema.etag = cls._schema_common_network_interface_read.etag
+        _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+        _schema.id = cls._schema_common_network_interface_read.id
+        _schema.location = cls._schema_common_network_interface_read.location
+        _schema.name = cls._schema_common_network_interface_read.name
+        _schema.properties = cls._schema_common_network_interface_read.properties
+        _schema.tags = cls._schema_common_network_interface_read.tags
+        _schema.type = cls._schema_common_network_interface_read.type
 
-    _schema_network_security_group_read = None
+    _schema_common_network_security_group_read = None
 
     @classmethod
-    def _build_schema_network_security_group_read(cls, _schema):
-        if cls._schema_network_security_group_read is not None:
-            _schema.etag = cls._schema_network_security_group_read.etag
-            _schema.id = cls._schema_network_security_group_read.id
-            _schema.location = cls._schema_network_security_group_read.location
-            _schema.name = cls._schema_network_security_group_read.name
-            _schema.properties = cls._schema_network_security_group_read.properties
-            _schema.tags = cls._schema_network_security_group_read.tags
-            _schema.type = cls._schema_network_security_group_read.type
+    def _build_schema_common_network_security_group_read(cls, _schema):
+        if cls._schema_common_network_security_group_read is not None:
+            _schema.etag = cls._schema_common_network_security_group_read.etag
+            _schema.id = cls._schema_common_network_security_group_read.id
+            _schema.location = cls._schema_common_network_security_group_read.location
+            _schema.name = cls._schema_common_network_security_group_read.name
+            _schema.properties = cls._schema_common_network_security_group_read.properties
+            _schema.tags = cls._schema_common_network_security_group_read.tags
+            _schema.type = cls._schema_common_network_security_group_read.type
             return
 
-        cls._schema_network_security_group_read = _schema_network_security_group_read = AAZObjectType()
+        cls._schema_common_network_security_group_read = _schema_common_network_security_group_read = AAZObjectType()
 
-        network_security_group_read = _schema_network_security_group_read
-        network_security_group_read.etag = AAZStrType(
+        common_network_security_group_read = _schema_common_network_security_group_read
+        common_network_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.id = AAZStrType()
-        network_security_group_read.location = AAZStrType()
-        network_security_group_read.name = AAZStrType(
+        common_network_security_group_read.id = AAZStrType()
+        common_network_security_group_read.location = AAZStrType()
+        common_network_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.properties = AAZObjectType(
+        common_network_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_security_group_read.tags = AAZDictType()
-        network_security_group_read.type = AAZStrType(
+        common_network_security_group_read.tags = AAZDictType()
+        common_network_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties
+        properties = _schema_common_network_security_group_read.properties
         properties.default_security_rules = AAZListType(
             serialized_name="defaultSecurityRules",
             flags={"read_only": True},
@@ -1160,14 +1167,14 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        default_security_rules = _schema_network_security_group_read.properties.default_security_rules
+        default_security_rules = _schema_common_network_security_group_read.properties.default_security_rules
         default_security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(default_security_rules.Element)
+        cls._build_schema_common_security_rule_read(default_security_rules.Element)
 
-        flow_logs = _schema_network_security_group_read.properties.flow_logs
+        flow_logs = _schema_common_network_security_group_read.properties.flow_logs
         flow_logs.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1185,7 +1192,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        identity = _schema_network_security_group_read.properties.flow_logs.Element.identity
+        identity = _schema_common_network_security_group_read.properties.flow_logs.Element.identity
         identity.principal_id = AAZStrType(
             serialized_name="principalId",
             flags={"read_only": True},
@@ -1199,10 +1206,10 @@ class _ShowHelper:
             serialized_name="userAssignedIdentities",
         )
 
-        user_assigned_identities = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
+        user_assigned_identities = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
         user_assigned_identities.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
         _element.client_id = AAZStrType(
             serialized_name="clientId",
             flags={"read_only": True},
@@ -1212,7 +1219,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties.flow_logs.Element.properties
+        properties = _schema_common_network_security_group_read.properties.flow_logs.Element.properties
         properties.enabled = AAZBoolType()
         properties.enabled_filtering_criteria = AAZStrType(
             serialized_name="enabledFilteringCriteria",
@@ -1224,6 +1231,9 @@ class _ShowHelper:
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
+        )
+        properties.record_types = AAZStrType(
+            serialized_name="recordTypes",
         )
         properties.retention_policy = AAZObjectType(
             serialized_name="retentionPolicy",
@@ -1241,12 +1251,12 @@ class _ShowHelper:
             flags={"required": True},
         )
 
-        flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
+        flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
         flow_analytics_configuration.network_watcher_flow_analytics_configuration = AAZObjectType(
             serialized_name="networkWatcherFlowAnalyticsConfiguration",
         )
 
-        network_watcher_flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
+        network_watcher_flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
         network_watcher_flow_analytics_configuration.enabled = AAZBoolType()
         network_watcher_flow_analytics_configuration.traffic_analytics_interval = AAZIntType(
             serialized_name="trafficAnalyticsInterval",
@@ -1261,83 +1271,86 @@ class _ShowHelper:
             serialized_name="workspaceResourceId",
         )
 
-        format = _schema_network_security_group_read.properties.flow_logs.Element.properties.format
+        format = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.format
         format.type = AAZStrType()
         format.version = AAZIntType()
 
-        retention_policy = _schema_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
+        retention_policy = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
         retention_policy.days = AAZIntType()
         retention_policy.enabled = AAZBoolType()
 
-        tags = _schema_network_security_group_read.properties.flow_logs.Element.tags
+        tags = _schema_common_network_security_group_read.properties.flow_logs.Element.tags
         tags.Element = AAZStrType()
 
-        network_interfaces = _schema_network_security_group_read.properties.network_interfaces
+        network_interfaces = _schema_common_network_security_group_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        security_rules = _schema_network_security_group_read.properties.security_rules
+        security_rules = _schema_common_network_security_group_read.properties.security_rules
         security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(security_rules.Element)
+        cls._build_schema_common_security_rule_read(security_rules.Element)
 
-        subnets = _schema_network_security_group_read.properties.subnets
+        subnets = _schema_common_network_security_group_read.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_network_security_group_read.tags
+        tags = _schema_common_network_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_security_group_read.etag
-        _schema.id = cls._schema_network_security_group_read.id
-        _schema.location = cls._schema_network_security_group_read.location
-        _schema.name = cls._schema_network_security_group_read.name
-        _schema.properties = cls._schema_network_security_group_read.properties
-        _schema.tags = cls._schema_network_security_group_read.tags
-        _schema.type = cls._schema_network_security_group_read.type
+        _schema.etag = cls._schema_common_network_security_group_read.etag
+        _schema.id = cls._schema_common_network_security_group_read.id
+        _schema.location = cls._schema_common_network_security_group_read.location
+        _schema.name = cls._schema_common_network_security_group_read.name
+        _schema.properties = cls._schema_common_network_security_group_read.properties
+        _schema.tags = cls._schema_common_network_security_group_read.tags
+        _schema.type = cls._schema_common_network_security_group_read.type
 
-    _schema_private_endpoint_read = None
+    _schema_common_private_endpoint_read = None
 
     @classmethod
-    def _build_schema_private_endpoint_read(cls, _schema):
-        if cls._schema_private_endpoint_read is not None:
-            _schema.etag = cls._schema_private_endpoint_read.etag
-            _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-            _schema.id = cls._schema_private_endpoint_read.id
-            _schema.location = cls._schema_private_endpoint_read.location
-            _schema.name = cls._schema_private_endpoint_read.name
-            _schema.properties = cls._schema_private_endpoint_read.properties
-            _schema.tags = cls._schema_private_endpoint_read.tags
-            _schema.type = cls._schema_private_endpoint_read.type
+    def _build_schema_common_private_endpoint_read(cls, _schema):
+        if cls._schema_common_private_endpoint_read is not None:
+            _schema.etag = cls._schema_common_private_endpoint_read.etag
+            _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+            _schema.id = cls._schema_common_private_endpoint_read.id
+            _schema.location = cls._schema_common_private_endpoint_read.location
+            _schema.name = cls._schema_common_private_endpoint_read.name
+            _schema.properties = cls._schema_common_private_endpoint_read.properties
+            _schema.tags = cls._schema_common_private_endpoint_read.tags
+            _schema.type = cls._schema_common_private_endpoint_read.type
             return
 
-        cls._schema_private_endpoint_read = _schema_private_endpoint_read = AAZObjectType(
+        cls._schema_common_private_endpoint_read = _schema_common_private_endpoint_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        private_endpoint_read = _schema_private_endpoint_read
-        private_endpoint_read.etag = AAZStrType(
+        common_private_endpoint_read = _schema_common_private_endpoint_read
+        common_private_endpoint_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.extended_location = AAZObjectType(
+        common_private_endpoint_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_endpoint_read.extended_location)
-        private_endpoint_read.id = AAZStrType()
-        private_endpoint_read.location = AAZStrType()
-        private_endpoint_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_private_endpoint_read.extended_location)
+        common_private_endpoint_read.id = AAZStrType()
+        common_private_endpoint_read.location = AAZStrType()
+        common_private_endpoint_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.properties = AAZObjectType(
+        common_private_endpoint_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_endpoint_read.tags = AAZDictType()
-        private_endpoint_read.type = AAZStrType(
+        common_private_endpoint_read.tags = AAZDictType()
+        common_private_endpoint_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties
+        properties = _schema_common_private_endpoint_read.properties
         properties.application_security_groups = AAZListType(
             serialized_name="applicationSecurityGroups",
+        )
+        properties.billing_sku = AAZStrType(
+            serialized_name="billingSku",
         )
         properties.custom_dns_configs = AAZListType(
             serialized_name="customDnsConfigs",
@@ -1347,6 +1360,9 @@ class _ShowHelper:
         )
         properties.ip_configurations = AAZListType(
             serialized_name="ipConfigurations",
+        )
+        properties.ip_version_type = AAZStrType(
+            serialized_name="ipVersionType",
         )
         properties.manual_private_link_service_connections = AAZListType(
             serialized_name="manualPrivateLinkServiceConnections",
@@ -1363,28 +1379,28 @@ class _ShowHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        application_security_groups = _schema_private_endpoint_read.properties.application_security_groups
+        application_security_groups = _schema_common_private_endpoint_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        custom_dns_configs = _schema_private_endpoint_read.properties.custom_dns_configs
+        custom_dns_configs = _schema_common_private_endpoint_read.properties.custom_dns_configs
         custom_dns_configs.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.custom_dns_configs.Element
+        _element = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element
         _element.fqdn = AAZStrType()
         _element.ip_addresses = AAZListType(
             serialized_name="ipAddresses",
         )
 
-        ip_addresses = _schema_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
+        ip_addresses = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
         ip_addresses.Element = AAZStrType()
 
-        ip_configurations = _schema_private_endpoint_read.properties.ip_configurations
+        ip_configurations = _schema_common_private_endpoint_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.ip_configurations.Element
+        _element = _schema_common_private_endpoint_read.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1396,7 +1412,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties.ip_configurations.Element.properties
+        properties = _schema_common_private_endpoint_read.properties.ip_configurations.Element.properties
         properties.group_id = AAZStrType(
             serialized_name="groupId",
         )
@@ -1407,88 +1423,88 @@ class _ShowHelper:
             serialized_name="privateIPAddress",
         )
 
-        manual_private_link_service_connections = _schema_private_endpoint_read.properties.manual_private_link_service_connections
+        manual_private_link_service_connections = _schema_common_private_endpoint_read.properties.manual_private_link_service_connections
         manual_private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(manual_private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(manual_private_link_service_connections.Element)
 
-        network_interfaces = _schema_private_endpoint_read.properties.network_interfaces
+        network_interfaces = _schema_common_private_endpoint_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_link_service_connections = _schema_private_endpoint_read.properties.private_link_service_connections
+        private_link_service_connections = _schema_common_private_endpoint_read.properties.private_link_service_connections
         private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(private_link_service_connections.Element)
 
-        tags = _schema_private_endpoint_read.tags
+        tags = _schema_common_private_endpoint_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_endpoint_read.etag
-        _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-        _schema.id = cls._schema_private_endpoint_read.id
-        _schema.location = cls._schema_private_endpoint_read.location
-        _schema.name = cls._schema_private_endpoint_read.name
-        _schema.properties = cls._schema_private_endpoint_read.properties
-        _schema.tags = cls._schema_private_endpoint_read.tags
-        _schema.type = cls._schema_private_endpoint_read.type
+        _schema.etag = cls._schema_common_private_endpoint_read.etag
+        _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+        _schema.id = cls._schema_common_private_endpoint_read.id
+        _schema.location = cls._schema_common_private_endpoint_read.location
+        _schema.name = cls._schema_common_private_endpoint_read.name
+        _schema.properties = cls._schema_common_private_endpoint_read.properties
+        _schema.tags = cls._schema_common_private_endpoint_read.tags
+        _schema.type = cls._schema_common_private_endpoint_read.type
 
-    _schema_private_link_service_connection_state_read = None
+    _schema_common_private_link_service_connection_state_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_state_read(cls, _schema):
-        if cls._schema_private_link_service_connection_state_read is not None:
-            _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-            _schema.description = cls._schema_private_link_service_connection_state_read.description
-            _schema.status = cls._schema_private_link_service_connection_state_read.status
+    def _build_schema_common_private_link_service_connection_state_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_state_read is not None:
+            _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+            _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+            _schema.status = cls._schema_common_private_link_service_connection_state_read.status
             return
 
-        cls._schema_private_link_service_connection_state_read = _schema_private_link_service_connection_state_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read = AAZObjectType()
 
-        private_link_service_connection_state_read = _schema_private_link_service_connection_state_read
-        private_link_service_connection_state_read.actions_required = AAZStrType(
+        common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read
+        common_private_link_service_connection_state_read.actions_required = AAZStrType(
             serialized_name="actionsRequired",
         )
-        private_link_service_connection_state_read.description = AAZStrType()
-        private_link_service_connection_state_read.status = AAZStrType()
+        common_private_link_service_connection_state_read.description = AAZStrType()
+        common_private_link_service_connection_state_read.status = AAZStrType()
 
-        _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-        _schema.description = cls._schema_private_link_service_connection_state_read.description
-        _schema.status = cls._schema_private_link_service_connection_state_read.status
+        _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+        _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+        _schema.status = cls._schema_common_private_link_service_connection_state_read.status
 
-    _schema_private_link_service_connection_read = None
+    _schema_common_private_link_service_connection_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_read(cls, _schema):
-        if cls._schema_private_link_service_connection_read is not None:
-            _schema.etag = cls._schema_private_link_service_connection_read.etag
-            _schema.id = cls._schema_private_link_service_connection_read.id
-            _schema.name = cls._schema_private_link_service_connection_read.name
-            _schema.properties = cls._schema_private_link_service_connection_read.properties
-            _schema.type = cls._schema_private_link_service_connection_read.type
+    def _build_schema_common_private_link_service_connection_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_read is not None:
+            _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+            _schema.id = cls._schema_common_private_link_service_connection_read.id
+            _schema.name = cls._schema_common_private_link_service_connection_read.name
+            _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+            _schema.type = cls._schema_common_private_link_service_connection_read.type
             return
 
-        cls._schema_private_link_service_connection_read = _schema_private_link_service_connection_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_read = _schema_common_private_link_service_connection_read = AAZObjectType()
 
-        private_link_service_connection_read = _schema_private_link_service_connection_read
-        private_link_service_connection_read.etag = AAZStrType(
+        common_private_link_service_connection_read = _schema_common_private_link_service_connection_read
+        common_private_link_service_connection_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_link_service_connection_read.id = AAZStrType()
-        private_link_service_connection_read.name = AAZStrType()
-        private_link_service_connection_read.properties = AAZObjectType(
+        common_private_link_service_connection_read.id = AAZStrType()
+        common_private_link_service_connection_read.name = AAZStrType()
+        common_private_link_service_connection_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_link_service_connection_read.type = AAZStrType(
+        common_private_link_service_connection_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_link_service_connection_read.properties
+        properties = _schema_common_private_link_service_connection_read.properties
         properties.group_ids = AAZListType(
             serialized_name="groupIds",
         )
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.private_link_service_id = AAZStrType(
             serialized_name="privateLinkServiceId",
         )
@@ -1500,58 +1516,58 @@ class _ShowHelper:
             serialized_name="requestMessage",
         )
 
-        group_ids = _schema_private_link_service_connection_read.properties.group_ids
+        group_ids = _schema_common_private_link_service_connection_read.properties.group_ids
         group_ids.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_link_service_connection_read.etag
-        _schema.id = cls._schema_private_link_service_connection_read.id
-        _schema.name = cls._schema_private_link_service_connection_read.name
-        _schema.properties = cls._schema_private_link_service_connection_read.properties
-        _schema.type = cls._schema_private_link_service_connection_read.type
+        _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+        _schema.id = cls._schema_common_private_link_service_connection_read.id
+        _schema.name = cls._schema_common_private_link_service_connection_read.name
+        _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+        _schema.type = cls._schema_common_private_link_service_connection_read.type
 
-    _schema_public_ip_address_read = None
+    _schema_common_public_ip_address_read = None
 
     @classmethod
-    def _build_schema_public_ip_address_read(cls, _schema):
-        if cls._schema_public_ip_address_read is not None:
-            _schema.etag = cls._schema_public_ip_address_read.etag
-            _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-            _schema.id = cls._schema_public_ip_address_read.id
-            _schema.location = cls._schema_public_ip_address_read.location
-            _schema.name = cls._schema_public_ip_address_read.name
-            _schema.properties = cls._schema_public_ip_address_read.properties
-            _schema.sku = cls._schema_public_ip_address_read.sku
-            _schema.tags = cls._schema_public_ip_address_read.tags
-            _schema.type = cls._schema_public_ip_address_read.type
-            _schema.zones = cls._schema_public_ip_address_read.zones
+    def _build_schema_common_public_ip_address_read(cls, _schema):
+        if cls._schema_common_public_ip_address_read is not None:
+            _schema.etag = cls._schema_common_public_ip_address_read.etag
+            _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+            _schema.id = cls._schema_common_public_ip_address_read.id
+            _schema.location = cls._schema_common_public_ip_address_read.location
+            _schema.name = cls._schema_common_public_ip_address_read.name
+            _schema.properties = cls._schema_common_public_ip_address_read.properties
+            _schema.sku = cls._schema_common_public_ip_address_read.sku
+            _schema.tags = cls._schema_common_public_ip_address_read.tags
+            _schema.type = cls._schema_common_public_ip_address_read.type
+            _schema.zones = cls._schema_common_public_ip_address_read.zones
             return
 
-        cls._schema_public_ip_address_read = _schema_public_ip_address_read = AAZObjectType()
+        cls._schema_common_public_ip_address_read = _schema_common_public_ip_address_read = AAZObjectType()
 
-        public_ip_address_read = _schema_public_ip_address_read
-        public_ip_address_read.etag = AAZStrType(
+        common_public_ip_address_read = _schema_common_public_ip_address_read
+        common_public_ip_address_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.extended_location = AAZObjectType(
+        common_public_ip_address_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(public_ip_address_read.extended_location)
-        public_ip_address_read.id = AAZStrType()
-        public_ip_address_read.location = AAZStrType()
-        public_ip_address_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_public_ip_address_read.extended_location)
+        common_public_ip_address_read.id = AAZStrType()
+        common_public_ip_address_read.location = AAZStrType()
+        common_public_ip_address_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.properties = AAZObjectType(
+        common_public_ip_address_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        public_ip_address_read.sku = AAZObjectType()
-        public_ip_address_read.tags = AAZDictType()
-        public_ip_address_read.type = AAZStrType(
+        common_public_ip_address_read.sku = AAZObjectType()
+        common_public_ip_address_read.tags = AAZDictType()
+        common_public_ip_address_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.zones = AAZListType()
+        common_public_ip_address_read.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties
+        properties = _schema_common_public_ip_address_read.properties
         properties.ddos_settings = AAZObjectType(
             serialized_name="ddosSettings",
         )
@@ -1571,14 +1587,14 @@ class _ShowHelper:
             serialized_name="ipConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_ip_configuration_read(properties.ip_configuration)
+        cls._build_schema_common_ip_configuration_read(properties.ip_configuration)
         properties.ip_tags = AAZListType(
             serialized_name="ipTags",
         )
         properties.linked_public_ip_address = AAZObjectType(
             serialized_name="linkedPublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.linked_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.linked_public_ip_address)
         properties.migration_phase = AAZStrType(
             serialized_name="migrationPhase",
         )
@@ -1598,7 +1614,7 @@ class _ShowHelper:
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.resource_guid = AAZStrType(
             serialized_name="resourceGuid",
             flags={"read_only": True},
@@ -1606,18 +1622,22 @@ class _ShowHelper:
         properties.service_public_ip_address = AAZObjectType(
             serialized_name="servicePublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.service_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.service_public_ip_address)
 
-        ddos_settings = _schema_public_ip_address_read.properties.ddos_settings
+        ddos_settings = _schema_common_public_ip_address_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
         ddos_settings.ddos_protection_plan = AAZObjectType(
             serialized_name="ddosProtectionPlan",
         )
-        cls._build_schema_sub_resource_read(ddos_settings.ddos_protection_plan)
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_protection_plan)
         ddos_settings.protection_mode = AAZStrType(
             serialized_name="protectionMode",
         )
 
-        dns_settings = _schema_public_ip_address_read.properties.dns_settings
+        dns_settings = _schema_common_public_ip_address_read.properties.dns_settings
         dns_settings.domain_name_label = AAZStrType(
             serialized_name="domainNameLabel",
         )
@@ -1629,16 +1649,16 @@ class _ShowHelper:
             serialized_name="reverseFqdn",
         )
 
-        ip_tags = _schema_public_ip_address_read.properties.ip_tags
+        ip_tags = _schema_common_public_ip_address_read.properties.ip_tags
         ip_tags.Element = AAZObjectType()
 
-        _element = _schema_public_ip_address_read.properties.ip_tags.Element
+        _element = _schema_common_public_ip_address_read.properties.ip_tags.Element
         _element.ip_tag_type = AAZStrType(
             serialized_name="ipTagType",
         )
         _element.tag = AAZStrType()
 
-        nat_gateway = _schema_public_ip_address_read.properties.nat_gateway
+        nat_gateway = _schema_common_public_ip_address_read.properties.nat_gateway
         nat_gateway.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1657,10 +1677,11 @@ class _ShowHelper:
         )
         nat_gateway.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties.nat_gateway.properties
+        properties = _schema_common_public_ip_address_read.properties.nat_gateway.properties
         properties.idle_timeout_in_minutes = AAZIntType(
             serialized_name="idleTimeoutInMinutes",
         )
+        properties.nat64 = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -1681,90 +1702,96 @@ class _ShowHelper:
             serialized_name="resourceGuid",
             flags={"read_only": True},
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.source_virtual_network = AAZObjectType(
             serialized_name="sourceVirtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.source_virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.source_virtual_network)
         properties.subnets = AAZListType(
             flags={"read_only": True},
         )
 
-        public_ip_addresses = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
+        public_ip_addresses = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
         public_ip_addresses.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
+        public_ip_addresses_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
+        public_ip_prefixes = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
-        subnets = _schema_public_ip_address_read.properties.nat_gateway.properties.subnets
+        subnets = _schema_common_public_ip_address_read.properties.nat_gateway.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(subnets.Element)
+        cls._build_schema_common_sub_resource_read(subnets.Element)
 
-        sku = _schema_public_ip_address_read.properties.nat_gateway.sku
+        sku = _schema_common_public_ip_address_read.properties.nat_gateway.sku
         sku.name = AAZStrType()
 
-        tags = _schema_public_ip_address_read.properties.nat_gateway.tags
+        tags = _schema_common_public_ip_address_read.properties.nat_gateway.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.properties.nat_gateway.zones
+        zones = _schema_common_public_ip_address_read.properties.nat_gateway.zones
         zones.Element = AAZStrType()
 
-        sku = _schema_public_ip_address_read.sku
+        sku = _schema_common_public_ip_address_read.sku
         sku.name = AAZStrType()
         sku.tier = AAZStrType()
 
-        tags = _schema_public_ip_address_read.tags
+        tags = _schema_common_public_ip_address_read.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.zones
+        zones = _schema_common_public_ip_address_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_public_ip_address_read.etag
-        _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-        _schema.id = cls._schema_public_ip_address_read.id
-        _schema.location = cls._schema_public_ip_address_read.location
-        _schema.name = cls._schema_public_ip_address_read.name
-        _schema.properties = cls._schema_public_ip_address_read.properties
-        _schema.sku = cls._schema_public_ip_address_read.sku
-        _schema.tags = cls._schema_public_ip_address_read.tags
-        _schema.type = cls._schema_public_ip_address_read.type
-        _schema.zones = cls._schema_public_ip_address_read.zones
+        _schema.etag = cls._schema_common_public_ip_address_read.etag
+        _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+        _schema.id = cls._schema_common_public_ip_address_read.id
+        _schema.location = cls._schema_common_public_ip_address_read.location
+        _schema.name = cls._schema_common_public_ip_address_read.name
+        _schema.properties = cls._schema_common_public_ip_address_read.properties
+        _schema.sku = cls._schema_common_public_ip_address_read.sku
+        _schema.tags = cls._schema_common_public_ip_address_read.tags
+        _schema.type = cls._schema_common_public_ip_address_read.type
+        _schema.zones = cls._schema_common_public_ip_address_read.zones
 
-    _schema_security_rule_read = None
+    _schema_common_security_rule_read = None
 
     @classmethod
-    def _build_schema_security_rule_read(cls, _schema):
-        if cls._schema_security_rule_read is not None:
-            _schema.etag = cls._schema_security_rule_read.etag
-            _schema.id = cls._schema_security_rule_read.id
-            _schema.name = cls._schema_security_rule_read.name
-            _schema.properties = cls._schema_security_rule_read.properties
-            _schema.type = cls._schema_security_rule_read.type
+    def _build_schema_common_security_rule_read(cls, _schema):
+        if cls._schema_common_security_rule_read is not None:
+            _schema.etag = cls._schema_common_security_rule_read.etag
+            _schema.id = cls._schema_common_security_rule_read.id
+            _schema.name = cls._schema_common_security_rule_read.name
+            _schema.properties = cls._schema_common_security_rule_read.properties
+            _schema.type = cls._schema_common_security_rule_read.type
             return
 
-        cls._schema_security_rule_read = _schema_security_rule_read = AAZObjectType()
+        cls._schema_common_security_rule_read = _schema_common_security_rule_read = AAZObjectType()
 
-        security_rule_read = _schema_security_rule_read
-        security_rule_read.etag = AAZStrType(
+        common_security_rule_read = _schema_common_security_rule_read
+        common_security_rule_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        security_rule_read.id = AAZStrType()
-        security_rule_read.name = AAZStrType()
-        security_rule_read.properties = AAZObjectType(
+        common_security_rule_read.id = AAZStrType()
+        common_security_rule_read.name = AAZStrType()
+        common_security_rule_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        security_rule_read.type = AAZStrType()
+        common_security_rule_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_security_rule_read.properties
+        properties = _schema_common_security_rule_read.properties
         properties.access = AAZStrType(
             flags={"required": True},
         )
@@ -1813,75 +1840,77 @@ class _ShowHelper:
             serialized_name="sourcePortRanges",
         )
 
-        destination_address_prefixes = _schema_security_rule_read.properties.destination_address_prefixes
+        destination_address_prefixes = _schema_common_security_rule_read.properties.destination_address_prefixes
         destination_address_prefixes.Element = AAZStrType()
 
-        destination_application_security_groups = _schema_security_rule_read.properties.destination_application_security_groups
+        destination_application_security_groups = _schema_common_security_rule_read.properties.destination_application_security_groups
         destination_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(destination_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(destination_application_security_groups.Element)
 
-        destination_port_ranges = _schema_security_rule_read.properties.destination_port_ranges
+        destination_port_ranges = _schema_common_security_rule_read.properties.destination_port_ranges
         destination_port_ranges.Element = AAZStrType()
 
-        source_address_prefixes = _schema_security_rule_read.properties.source_address_prefixes
+        source_address_prefixes = _schema_common_security_rule_read.properties.source_address_prefixes
         source_address_prefixes.Element = AAZStrType()
 
-        source_application_security_groups = _schema_security_rule_read.properties.source_application_security_groups
+        source_application_security_groups = _schema_common_security_rule_read.properties.source_application_security_groups
         source_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(source_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(source_application_security_groups.Element)
 
-        source_port_ranges = _schema_security_rule_read.properties.source_port_ranges
+        source_port_ranges = _schema_common_security_rule_read.properties.source_port_ranges
         source_port_ranges.Element = AAZStrType()
 
-        _schema.etag = cls._schema_security_rule_read.etag
-        _schema.id = cls._schema_security_rule_read.id
-        _schema.name = cls._schema_security_rule_read.name
-        _schema.properties = cls._schema_security_rule_read.properties
-        _schema.type = cls._schema_security_rule_read.type
+        _schema.etag = cls._schema_common_security_rule_read.etag
+        _schema.id = cls._schema_common_security_rule_read.id
+        _schema.name = cls._schema_common_security_rule_read.name
+        _schema.properties = cls._schema_common_security_rule_read.properties
+        _schema.type = cls._schema_common_security_rule_read.type
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType(
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
-    _schema_subnet_read = None
+    _schema_common_subnet_read = None
 
     @classmethod
-    def _build_schema_subnet_read(cls, _schema):
-        if cls._schema_subnet_read is not None:
-            _schema.etag = cls._schema_subnet_read.etag
-            _schema.id = cls._schema_subnet_read.id
-            _schema.name = cls._schema_subnet_read.name
-            _schema.properties = cls._schema_subnet_read.properties
-            _schema.type = cls._schema_subnet_read.type
+    def _build_schema_common_subnet_read(cls, _schema):
+        if cls._schema_common_subnet_read is not None:
+            _schema.etag = cls._schema_common_subnet_read.etag
+            _schema.id = cls._schema_common_subnet_read.id
+            _schema.name = cls._schema_common_subnet_read.name
+            _schema.properties = cls._schema_common_subnet_read.properties
+            _schema.type = cls._schema_common_subnet_read.type
             return
 
-        cls._schema_subnet_read = _schema_subnet_read = AAZObjectType()
+        cls._schema_common_subnet_read = _schema_common_subnet_read = AAZObjectType()
 
-        subnet_read = _schema_subnet_read
-        subnet_read.etag = AAZStrType(
+        common_subnet_read = _schema_common_subnet_read
+        common_subnet_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        subnet_read.id = AAZStrType()
-        subnet_read.name = AAZStrType()
-        subnet_read.properties = AAZObjectType(
+        common_subnet_read.id = AAZStrType()
+        common_subnet_read.name = AAZStrType()
+        common_subnet_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        subnet_read.type = AAZStrType()
+        common_subnet_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties
+        properties = _schema_common_subnet_read.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
@@ -1912,11 +1941,11 @@ class _ShowHelper:
         properties.nat_gateway = AAZObjectType(
             serialized_name="natGateway",
         )
-        cls._build_schema_sub_resource_read(properties.nat_gateway)
+        cls._build_schema_common_sub_resource_read(properties.nat_gateway)
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.private_endpoint_network_policies = AAZStrType(
             serialized_name="privateEndpointNetworkPolicies",
         )
@@ -1951,17 +1980,21 @@ class _ShowHelper:
         properties.service_endpoints = AAZListType(
             serialized_name="serviceEndpoints",
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.sharing_scope = AAZStrType(
             serialized_name="sharingScope",
         )
 
-        address_prefixes = _schema_subnet_read.properties.address_prefixes
+        address_prefixes = _schema_common_subnet_read.properties.address_prefixes
         address_prefixes.Element = AAZStrType()
 
-        application_gateway_ip_configurations = _schema_subnet_read.properties.application_gateway_ip_configurations
+        application_gateway_ip_configurations = _schema_common_subnet_read.properties.application_gateway_ip_configurations
         application_gateway_ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.application_gateway_ip_configurations.Element
+        _element = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1974,18 +2007,18 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.application_gateway_ip_configurations.Element.properties
+        properties = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
 
-        delegations = _schema_subnet_read.properties.delegations
+        delegations = _schema_common_subnet_read.properties.delegations
         delegations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.delegations.Element
+        _element = _schema_common_subnet_read.properties.delegations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1996,7 +2029,7 @@ class _ShowHelper:
         )
         _element.type = AAZStrType()
 
-        properties = _schema_subnet_read.properties.delegations.Element.properties
+        properties = _schema_common_subnet_read.properties.delegations.Element.properties
         properties.actions = AAZListType(
             flags={"read_only": True},
         )
@@ -2008,17 +2041,17 @@ class _ShowHelper:
             serialized_name="serviceName",
         )
 
-        actions = _schema_subnet_read.properties.delegations.Element.properties.actions
+        actions = _schema_common_subnet_read.properties.delegations.Element.properties.actions
         actions.Element = AAZStrType()
 
-        ip_allocations = _schema_subnet_read.properties.ip_allocations
+        ip_allocations = _schema_common_subnet_read.properties.ip_allocations
         ip_allocations.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(ip_allocations.Element)
+        cls._build_schema_common_sub_resource_read(ip_allocations.Element)
 
-        ip_configuration_profiles = _schema_subnet_read.properties.ip_configuration_profiles
+        ip_configuration_profiles = _schema_common_subnet_read.properties.ip_configuration_profiles
         ip_configuration_profiles.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ip_configuration_profiles.Element
+        _element = _schema_common_subnet_read.properties.ip_configuration_profiles.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2031,22 +2064,22 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.ip_configuration_profiles.Element.properties
+        properties = _schema_common_subnet_read.properties.ip_configuration_profiles.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        ip_configurations = _schema_subnet_read.properties.ip_configurations
+        ip_configurations = _schema_common_subnet_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_ip_configuration_read(ip_configurations.Element)
 
-        ipam_pool_prefix_allocations = _schema_subnet_read.properties.ipam_pool_prefix_allocations
+        ipam_pool_prefix_allocations = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations
         ipam_pool_prefix_allocations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element
+        _element = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element
         _element.allocated_address_prefixes = AAZListType(
             serialized_name="allocatedAddressPrefixes",
             flags={"read_only": True},
@@ -2058,20 +2091,20 @@ class _ShowHelper:
             flags={"client_flatten": True},
         )
 
-        allocated_address_prefixes = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
+        allocated_address_prefixes = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
         allocated_address_prefixes.Element = AAZStrType()
 
-        pool = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
+        pool = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
         pool.id = AAZStrType()
 
-        private_endpoints = _schema_subnet_read.properties.private_endpoints
+        private_endpoints = _schema_common_subnet_read.properties.private_endpoints
         private_endpoints.Element = AAZObjectType()
-        cls._build_schema_private_endpoint_read(private_endpoints.Element)
+        cls._build_schema_common_private_endpoint_read(private_endpoints.Element)
 
-        resource_navigation_links = _schema_subnet_read.properties.resource_navigation_links
+        resource_navigation_links = _schema_common_subnet_read.properties.resource_navigation_links
         resource_navigation_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.resource_navigation_links.Element
+        _element = _schema_common_subnet_read.properties.resource_navigation_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2086,7 +2119,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.resource_navigation_links.Element.properties
+        properties = _schema_common_subnet_read.properties.resource_navigation_links.Element.properties
         properties.link = AAZStrType()
         properties.linked_resource_type = AAZStrType(
             serialized_name="linkedResourceType",
@@ -2096,7 +2129,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        route_table = _schema_subnet_read.properties.route_table
+        route_table = _schema_common_subnet_read.properties.route_table
         route_table.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2113,9 +2146,12 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.route_table.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties
         properties.disable_bgp_route_propagation = AAZBoolType(
             serialized_name="disableBgpRoutePropagation",
+        )
+        properties.disable_peering_route = AAZStrType(
+            serialized_name="disablePeeringRoute",
         )
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2130,10 +2166,10 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        routes = _schema_subnet_read.properties.route_table.properties.routes
+        routes = _schema_common_subnet_read.properties.route_table.properties.routes
         routes.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.route_table.properties.routes.Element
+        _element = _schema_common_subnet_read.properties.route_table.properties.routes.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2142,15 +2178,20 @@ class _ShowHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.route_table.properties.routes.Element.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
         properties.has_bgp_override = AAZBoolType(
             serialized_name="hasBgpOverride",
             flags={"read_only": True},
+        )
+        properties.next_hop = AAZObjectType(
+            serialized_name="nextHop",
         )
         properties.next_hop_ip_address = AAZStrType(
             serialized_name="nextHopIpAddress",
@@ -2164,17 +2205,26 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        subnets = _schema_subnet_read.properties.route_table.properties.subnets
-        subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        next_hop = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop
+        next_hop.next_hop_ip_addresses = AAZListType(
+            serialized_name="nextHopIpAddresses",
+            flags={"required": True},
+        )
 
-        tags = _schema_subnet_read.properties.route_table.tags
+        next_hop_ip_addresses = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop.next_hop_ip_addresses
+        next_hop_ip_addresses.Element = AAZStrType()
+
+        subnets = _schema_common_subnet_read.properties.route_table.properties.subnets
+        subnets.Element = AAZObjectType()
+        cls._build_schema_common_subnet_read(subnets.Element)
+
+        tags = _schema_common_subnet_read.properties.route_table.tags
         tags.Element = AAZStrType()
 
-        service_association_links = _schema_subnet_read.properties.service_association_links
+        service_association_links = _schema_common_subnet_read.properties.service_association_links
         service_association_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_association_links.Element
+        _element = _schema_common_subnet_read.properties.service_association_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2187,7 +2237,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_association_links.Element.properties
+        properties = _schema_common_subnet_read.properties.service_association_links.Element.properties
         properties.allow_delete = AAZBoolType(
             serialized_name="allowDelete",
         )
@@ -2201,13 +2251,13 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        locations = _schema_subnet_read.properties.service_association_links.Element.properties.locations
+        locations = _schema_common_subnet_read.properties.service_association_links.Element.properties.locations
         locations.Element = AAZStrType()
 
-        service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies
+        service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies
         service_endpoint_policies.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2227,7 +2277,7 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties
         properties.contextual_service_endpoint_policies = AAZListType(
             serialized_name="contextualServiceEndpointPolicies",
         )
@@ -2249,13 +2299,13 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        contextual_service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
+        contextual_service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
         contextual_service_endpoint_policies.Element = AAZStrType()
 
-        service_endpoint_policy_definitions = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
+        service_endpoint_policy_definitions = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
         service_endpoint_policy_definitions.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2264,9 +2314,11 @@ class _ShowHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
         properties.description = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2277,82 +2329,82 @@ class _ShowHelper:
             serialized_name="serviceResources",
         )
 
-        service_resources = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
+        service_resources = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
         service_resources.Element = AAZStrType()
 
-        subnets = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
+        subnets = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_subnet_read.properties.service_endpoint_policies.Element.tags
+        tags = _schema_common_subnet_read.properties.service_endpoint_policies.Element.tags
         tags.Element = AAZStrType()
 
-        service_endpoints = _schema_subnet_read.properties.service_endpoints
+        service_endpoints = _schema_common_subnet_read.properties.service_endpoints
         service_endpoints.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoints.Element
+        _element = _schema_common_subnet_read.properties.service_endpoints.Element
         _element.locations = AAZListType()
         _element.network_identifier = AAZObjectType(
             serialized_name="networkIdentifier",
         )
-        cls._build_schema_sub_resource_read(_element.network_identifier)
+        cls._build_schema_common_sub_resource_read(_element.network_identifier)
         _element.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         _element.service = AAZStrType()
 
-        locations = _schema_subnet_read.properties.service_endpoints.Element.locations
+        locations = _schema_common_subnet_read.properties.service_endpoints.Element.locations
         locations.Element = AAZStrType()
 
-        _schema.etag = cls._schema_subnet_read.etag
-        _schema.id = cls._schema_subnet_read.id
-        _schema.name = cls._schema_subnet_read.name
-        _schema.properties = cls._schema_subnet_read.properties
-        _schema.type = cls._schema_subnet_read.type
+        _schema.etag = cls._schema_common_subnet_read.etag
+        _schema.id = cls._schema_common_subnet_read.id
+        _schema.name = cls._schema_common_subnet_read.name
+        _schema.properties = cls._schema_common_subnet_read.properties
+        _schema.type = cls._schema_common_subnet_read.type
 
-    _schema_virtual_network_tap_read = None
+    _schema_common_virtual_network_tap_read = None
 
     @classmethod
-    def _build_schema_virtual_network_tap_read(cls, _schema):
-        if cls._schema_virtual_network_tap_read is not None:
-            _schema.etag = cls._schema_virtual_network_tap_read.etag
-            _schema.id = cls._schema_virtual_network_tap_read.id
-            _schema.location = cls._schema_virtual_network_tap_read.location
-            _schema.name = cls._schema_virtual_network_tap_read.name
-            _schema.properties = cls._schema_virtual_network_tap_read.properties
-            _schema.tags = cls._schema_virtual_network_tap_read.tags
-            _schema.type = cls._schema_virtual_network_tap_read.type
+    def _build_schema_common_virtual_network_tap_read(cls, _schema):
+        if cls._schema_common_virtual_network_tap_read is not None:
+            _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+            _schema.id = cls._schema_common_virtual_network_tap_read.id
+            _schema.location = cls._schema_common_virtual_network_tap_read.location
+            _schema.name = cls._schema_common_virtual_network_tap_read.name
+            _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+            _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+            _schema.type = cls._schema_common_virtual_network_tap_read.type
             return
 
-        cls._schema_virtual_network_tap_read = _schema_virtual_network_tap_read = AAZObjectType()
+        cls._schema_common_virtual_network_tap_read = _schema_common_virtual_network_tap_read = AAZObjectType()
 
-        virtual_network_tap_read = _schema_virtual_network_tap_read
-        virtual_network_tap_read.etag = AAZStrType(
+        common_virtual_network_tap_read = _schema_common_virtual_network_tap_read
+        common_virtual_network_tap_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.id = AAZStrType()
-        virtual_network_tap_read.location = AAZStrType()
-        virtual_network_tap_read.name = AAZStrType(
+        common_virtual_network_tap_read.id = AAZStrType()
+        common_virtual_network_tap_read.location = AAZStrType()
+        common_virtual_network_tap_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.properties = AAZObjectType(
+        common_virtual_network_tap_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        virtual_network_tap_read.tags = AAZDictType()
-        virtual_network_tap_read.type = AAZStrType(
+        common_virtual_network_tap_read.tags = AAZDictType()
+        common_virtual_network_tap_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_virtual_network_tap_read.properties
+        properties = _schema_common_virtual_network_tap_read.properties
         properties.destination_load_balancer_front_end_ip_configuration = AAZObjectType(
             serialized_name="destinationLoadBalancerFrontEndIPConfiguration",
         )
-        cls._build_schema_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
+        cls._build_schema_common_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
         properties.destination_network_interface_ip_configuration = AAZObjectType(
             serialized_name="destinationNetworkInterfaceIPConfiguration",
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
         properties.destination_port = AAZIntType(
             serialized_name="destinationPort",
         )
@@ -2369,20 +2421,20 @@ class _ShowHelper:
             flags={"read_only": True},
         )
 
-        network_interface_tap_configurations = _schema_virtual_network_tap_read.properties.network_interface_tap_configurations
+        network_interface_tap_configurations = _schema_common_virtual_network_tap_read.properties.network_interface_tap_configurations
         network_interface_tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
 
-        tags = _schema_virtual_network_tap_read.tags
+        tags = _schema_common_virtual_network_tap_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_virtual_network_tap_read.etag
-        _schema.id = cls._schema_virtual_network_tap_read.id
-        _schema.location = cls._schema_virtual_network_tap_read.location
-        _schema.name = cls._schema_virtual_network_tap_read.name
-        _schema.properties = cls._schema_virtual_network_tap_read.properties
-        _schema.tags = cls._schema_virtual_network_tap_read.tags
-        _schema.type = cls._schema_virtual_network_tap_read.type
+        _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+        _schema.id = cls._schema_common_virtual_network_tap_read.id
+        _schema.location = cls._schema_common_virtual_network_tap_read.location
+        _schema.name = cls._schema_common_virtual_network_tap_read.name
+        _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+        _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+        _schema.type = cls._schema_common_virtual_network_tap_read.type
 
 
 __all__ = ["Show"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_show.py
@@ -56,6 +56,10 @@ class Show(AAZCommand):
         _args_schema.resource_group = AAZResourceGroupNameArg(
             required=True,
         )
+        _args_schema.expand = AAZStrArg(
+            options=["--expand"],
+            help="Expands referenced resources.",
+        )
         return cls._args_schema
 
     def _execute_operations(self):
@@ -122,6 +126,9 @@ class Show(AAZCommand):
         @property
         def query_parameters(self):
             parameters = {
+                **self.serialize_query_param(
+                    "$expand", self.ctx.args.expand,
+                ),
                 **self.serialize_query_param(
                     "api-version", "2025-07-01",
                     required=True,

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_update.py
@@ -25,9 +25,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2025-07-01"],
         ]
     }
 
@@ -148,6 +148,17 @@ class Update(AAZCommand):
             nullable=True,
         )
 
+        # define Arg Group "DdosSettings"
+
+        _args_schema = cls._args_schema
+        _args_schema.ddos_custom_policy = AAZObjectArg(
+            options=["--ddos-custom-policy"],
+            arg_group="DdosSettings",
+            help="The DDoS custom policy associated with the public IP.",
+            nullable=True,
+        )
+        cls._build_args_common_sub_resource_update(_args_schema.ddos_custom_policy)
+
         # define Arg Group "DnsSettings"
 
         # define Arg Group "ExtendedLocation"
@@ -159,144 +170,134 @@ class Update(AAZCommand):
         # define Arg Group "Sku"
         return cls._args_schema
 
-    _args_public_ip_address_update = None
+    _args_common_public_ip_address_update = None
 
     @classmethod
-    def _build_args_public_ip_address_update(cls, _schema):
-        if cls._args_public_ip_address_update is not None:
-            _schema.ddos_settings = cls._args_public_ip_address_update.ddos_settings
-            _schema.delete_option = cls._args_public_ip_address_update.delete_option
-            _schema.dns_settings = cls._args_public_ip_address_update.dns_settings
-            _schema.extended_location = cls._args_public_ip_address_update.extended_location
-            _schema.id = cls._args_public_ip_address_update.id
-            _schema.idle_timeout_in_minutes = cls._args_public_ip_address_update.idle_timeout_in_minutes
-            _schema.ip_address = cls._args_public_ip_address_update.ip_address
-            _schema.ip_tags = cls._args_public_ip_address_update.ip_tags
-            _schema.linked_public_ip_address = cls._args_public_ip_address_update.linked_public_ip_address
-            _schema.location = cls._args_public_ip_address_update.location
-            _schema.migration_phase = cls._args_public_ip_address_update.migration_phase
-            _schema.nat_gateway = cls._args_public_ip_address_update.nat_gateway
-            _schema.public_ip_address_version = cls._args_public_ip_address_update.public_ip_address_version
-            _schema.public_ip_allocation_method = cls._args_public_ip_address_update.public_ip_allocation_method
-            _schema.public_ip_prefix = cls._args_public_ip_address_update.public_ip_prefix
-            _schema.service_public_ip_address = cls._args_public_ip_address_update.service_public_ip_address
-            _schema.sku = cls._args_public_ip_address_update.sku
-            _schema.tags = cls._args_public_ip_address_update.tags
-            _schema.zones = cls._args_public_ip_address_update.zones
+    def _build_args_common_public_ip_address_update(cls, _schema):
+        if cls._args_common_public_ip_address_update is not None:
+            _schema.ddos_settings = cls._args_common_public_ip_address_update.ddos_settings
+            _schema.delete_option = cls._args_common_public_ip_address_update.delete_option
+            _schema.dns_settings = cls._args_common_public_ip_address_update.dns_settings
+            _schema.extended_location = cls._args_common_public_ip_address_update.extended_location
+            _schema.idle_timeout_in_minutes = cls._args_common_public_ip_address_update.idle_timeout_in_minutes
+            _schema.ip_address = cls._args_common_public_ip_address_update.ip_address
+            _schema.ip_tags = cls._args_common_public_ip_address_update.ip_tags
+            _schema.linked_public_ip_address = cls._args_common_public_ip_address_update.linked_public_ip_address
+            _schema.location = cls._args_common_public_ip_address_update.location
+            _schema.migration_phase = cls._args_common_public_ip_address_update.migration_phase
+            _schema.nat_gateway = cls._args_common_public_ip_address_update.nat_gateway
+            _schema.public_ip_address_version = cls._args_common_public_ip_address_update.public_ip_address_version
+            _schema.public_ip_allocation_method = cls._args_common_public_ip_address_update.public_ip_allocation_method
+            _schema.public_ip_prefix = cls._args_common_public_ip_address_update.public_ip_prefix
+            _schema.service_public_ip_address = cls._args_common_public_ip_address_update.service_public_ip_address
+            _schema.sku = cls._args_common_public_ip_address_update.sku
+            _schema.tags = cls._args_common_public_ip_address_update.tags
+            _schema.zones = cls._args_common_public_ip_address_update.zones
             return
 
-        cls._args_public_ip_address_update = AAZObjectArg(
+        cls._args_common_public_ip_address_update = AAZObjectArg(
             nullable=True,
         )
 
-        public_ip_address_update = cls._args_public_ip_address_update
-        public_ip_address_update.extended_location = AAZObjectArg(
+        common_public_ip_address_update = cls._args_common_public_ip_address_update
+        common_public_ip_address_update.extended_location = AAZObjectArg(
             options=["extended-location"],
             help="The extended location of the public ip address.",
             nullable=True,
         )
-        public_ip_address_update.id = AAZResourceIdArg(
-            options=["id"],
-            help="Resource ID.",
-            nullable=True,
-            fmt=AAZResourceIdArgFormat(
-                template="/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/publicIPAddresses/{}",
-            ),
-        )
-        public_ip_address_update.location = AAZResourceLocationArg(
+        common_public_ip_address_update.location = AAZResourceLocationArg(
             options=["l", "location"],
             help="Resource location.",
             nullable=True,
         )
-        public_ip_address_update.ddos_settings = AAZObjectArg(
+        common_public_ip_address_update.ddos_settings = AAZObjectArg(
             options=["ddos-settings"],
             help="The DDoS protection custom policy associated with the public IP address.",
             nullable=True,
         )
-        public_ip_address_update.delete_option = AAZStrArg(
+        common_public_ip_address_update.delete_option = AAZStrArg(
             options=["delete-option"],
             help="Specify what happens to the public IP address when the VM using it is deleted",
             nullable=True,
             enum={"Delete": "Delete", "Detach": "Detach"},
         )
-        public_ip_address_update.dns_settings = AAZObjectArg(
+        common_public_ip_address_update.dns_settings = AAZObjectArg(
             options=["dns-settings"],
             help="The FQDN of the DNS record associated with the public IP address.",
             nullable=True,
         )
-        public_ip_address_update.idle_timeout_in_minutes = AAZIntArg(
+        common_public_ip_address_update.idle_timeout_in_minutes = AAZIntArg(
             options=["idle-timeout-in-minutes"],
             help="The idle timeout of the public IP address.",
             nullable=True,
         )
-        public_ip_address_update.ip_address = AAZStrArg(
+        common_public_ip_address_update.ip_address = AAZStrArg(
             options=["ip-address"],
             help="The IP address associated with the public IP address resource.",
             nullable=True,
         )
-        public_ip_address_update.ip_tags = AAZListArg(
+        common_public_ip_address_update.ip_tags = AAZListArg(
             options=["ip-tags"],
             help="The list of tags associated with the public IP address.",
             nullable=True,
         )
-        public_ip_address_update.linked_public_ip_address = AAZObjectArg(
+        common_public_ip_address_update.linked_public_ip_address = AAZObjectArg(
             options=["linked-public-ip-address"],
             help="The linked public IP address of the public IP address resource.",
             nullable=True,
         )
-        cls._build_args_public_ip_address_update(public_ip_address_update.linked_public_ip_address)
-        public_ip_address_update.migration_phase = AAZStrArg(
+        cls._build_args_common_public_ip_address_update(common_public_ip_address_update.linked_public_ip_address)
+        common_public_ip_address_update.migration_phase = AAZStrArg(
             options=["migration-phase"],
             help="Migration phase of Public IP Address.",
             nullable=True,
             enum={"Abort": "Abort", "Commit": "Commit", "Committed": "Committed", "None": "None", "Prepare": "Prepare"},
         )
-        public_ip_address_update.nat_gateway = AAZObjectArg(
+        common_public_ip_address_update.nat_gateway = AAZObjectArg(
             options=["nat-gateway"],
             help="The NatGateway for the Public IP address.",
             nullable=True,
         )
-        public_ip_address_update.public_ip_address_version = AAZStrArg(
+        common_public_ip_address_update.public_ip_address_version = AAZStrArg(
             options=["public-ip-address-version"],
             help="The public IP address version.",
             nullable=True,
             enum={"IPv4": "IPv4", "IPv6": "IPv6"},
         )
-        public_ip_address_update.public_ip_allocation_method = AAZStrArg(
+        common_public_ip_address_update.public_ip_allocation_method = AAZStrArg(
             options=["public-ip-allocation-method"],
             help="The public IP address allocation method.",
             nullable=True,
             enum={"Dynamic": "Dynamic", "Static": "Static"},
         )
-        public_ip_address_update.public_ip_prefix = AAZObjectArg(
+        common_public_ip_address_update.public_ip_prefix = AAZObjectArg(
             options=["public-ip-prefix"],
             help="The Public IP Prefix this Public IP Address should be allocated from.",
             nullable=True,
         )
-        cls._build_args_sub_resource_update(public_ip_address_update.public_ip_prefix)
-        public_ip_address_update.service_public_ip_address = AAZObjectArg(
+        common_public_ip_address_update.service_public_ip_address = AAZObjectArg(
             options=["service-public-ip-address"],
             help="The service public IP address of the public IP address resource.",
             nullable=True,
         )
-        cls._build_args_public_ip_address_update(public_ip_address_update.service_public_ip_address)
-        public_ip_address_update.sku = AAZObjectArg(
+        cls._build_args_common_public_ip_address_update(common_public_ip_address_update.service_public_ip_address)
+        common_public_ip_address_update.sku = AAZObjectArg(
             options=["sku"],
             help="The public IP address SKU.",
             nullable=True,
         )
-        public_ip_address_update.tags = AAZDictArg(
+        common_public_ip_address_update.tags = AAZDictArg(
             options=["tags"],
             help="Resource tags.",
             nullable=True,
         )
-        public_ip_address_update.zones = AAZListArg(
+        common_public_ip_address_update.zones = AAZListArg(
             options=["zones"],
             help="A list of availability zones denoting the IP allocated for the resource needs to come from.",
             nullable=True,
         )
 
-        extended_location = cls._args_public_ip_address_update.extended_location
+        extended_location = cls._args_common_public_ip_address_update.extended_location
         extended_location.name = AAZStrArg(
             options=["name"],
             help="The name of the extended location.",
@@ -309,13 +310,18 @@ class Update(AAZCommand):
             enum={"EdgeZone": "EdgeZone"},
         )
 
-        ddos_settings = cls._args_public_ip_address_update.ddos_settings
+        ddos_settings = cls._args_common_public_ip_address_update.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectArg(
+            options=["ddos-custom-policy"],
+            help="The DDoS custom policy associated with the public IP.",
+            nullable=True,
+        )
+        cls._build_args_common_sub_resource_update(ddos_settings.ddos_custom_policy)
         ddos_settings.ddos_protection_plan = AAZObjectArg(
             options=["ddos-protection-plan"],
             help="The DDoS protection plan associated with the public IP. Can only be set if ProtectionMode is Enabled",
             nullable=True,
         )
-        cls._build_args_sub_resource_update(ddos_settings.ddos_protection_plan)
         ddos_settings.protection_mode = AAZStrArg(
             options=["protection-mode"],
             help="The DDoS protection mode of the public IP",
@@ -323,7 +329,14 @@ class Update(AAZCommand):
             enum={"Disabled": "Disabled", "Enabled": "Enabled", "VirtualNetworkInherited": "VirtualNetworkInherited"},
         )
 
-        dns_settings = cls._args_public_ip_address_update.dns_settings
+        ddos_protection_plan = cls._args_common_public_ip_address_update.ddos_settings.ddos_protection_plan
+        ddos_protection_plan.id = AAZStrArg(
+            options=["id"],
+            help="Resource ID.",
+            nullable=True,
+        )
+
+        dns_settings = cls._args_common_public_ip_address_update.dns_settings
         dns_settings.domain_name_label = AAZStrArg(
             options=["domain-name-label"],
             help="The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.",
@@ -346,12 +359,12 @@ class Update(AAZCommand):
             nullable=True,
         )
 
-        ip_tags = cls._args_public_ip_address_update.ip_tags
+        ip_tags = cls._args_common_public_ip_address_update.ip_tags
         ip_tags.Element = AAZObjectArg(
             nullable=True,
         )
 
-        _element = cls._args_public_ip_address_update.ip_tags.Element
+        _element = cls._args_common_public_ip_address_update.ip_tags.Element
         _element.ip_tag_type = AAZStrArg(
             options=["ip-tag-type"],
             help="The IP tag type. Example: FirstPartyUsage.",
@@ -363,14 +376,11 @@ class Update(AAZCommand):
             nullable=True,
         )
 
-        nat_gateway = cls._args_public_ip_address_update.nat_gateway
+        nat_gateway = cls._args_common_public_ip_address_update.nat_gateway
         nat_gateway.id = AAZResourceIdArg(
             options=["id"],
             help="Resource ID.",
             nullable=True,
-            fmt=AAZResourceIdArgFormat(
-                template="/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/natGateways/{}",
-            ),
         )
         nat_gateway.location = AAZResourceLocationArg(
             options=["l", "location"],
@@ -382,9 +392,15 @@ class Update(AAZCommand):
             help="The idle timeout of the nat gateway.",
             nullable=True,
         )
+        nat_gateway.nat64 = AAZStrArg(
+            options=["nat64"],
+            help="Whether Nat64 is enabled for the NAT gateway resource.",
+            nullable=True,
+            enum={"Disabled": "Disabled", "Enabled": "Enabled", "None": "None"},
+        )
         nat_gateway.public_ip_addresses = AAZListArg(
             options=["public-ip-addresses"],
-            help="An array of public ip addresses associated with the nat gateway resource.",
+            help="An array of public ip addresses V4 associated with the nat gateway resource.",
             nullable=True,
         )
         nat_gateway.public_ip_addresses_v6 = AAZListArg(
@@ -394,7 +410,7 @@ class Update(AAZCommand):
         )
         nat_gateway.public_ip_prefixes = AAZListArg(
             options=["public-ip-prefixes"],
-            help="An array of public ip prefixes associated with the nat gateway resource.",
+            help="An array of public ip prefixes V4 associated with the nat gateway resource.",
             nullable=True,
         )
         nat_gateway.public_ip_prefixes_v6 = AAZListArg(
@@ -402,12 +418,18 @@ class Update(AAZCommand):
             help="An array of public ip prefixes V6 associated with the nat gateway resource.",
             nullable=True,
         )
+        nat_gateway.service_gateway = AAZObjectArg(
+            options=["service-gateway"],
+            help="Reference to an existing service gateway.",
+            nullable=True,
+        )
+        cls._build_args_common_sub_resource_update(nat_gateway.service_gateway)
         nat_gateway.source_virtual_network = AAZObjectArg(
             options=["source-virtual-network"],
             help="A reference to the source virtual network using this nat gateway resource.",
             nullable=True,
         )
-        cls._build_args_sub_resource_update(nat_gateway.source_virtual_network)
+        cls._build_args_common_sub_resource_update(nat_gateway.source_virtual_network)
         nat_gateway.sku = AAZObjectArg(
             options=["sku"],
             help="The nat gateway SKU.",
@@ -424,31 +446,31 @@ class Update(AAZCommand):
             nullable=True,
         )
 
-        public_ip_addresses = cls._args_public_ip_address_update.nat_gateway.public_ip_addresses
+        public_ip_addresses = cls._args_common_public_ip_address_update.nat_gateway.public_ip_addresses
         public_ip_addresses.Element = AAZObjectArg(
             nullable=True,
         )
-        cls._build_args_sub_resource_update(public_ip_addresses.Element)
+        cls._build_args_common_sub_resource_update(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = cls._args_public_ip_address_update.nat_gateway.public_ip_addresses_v6
+        public_ip_addresses_v6 = cls._args_common_public_ip_address_update.nat_gateway.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectArg(
             nullable=True,
         )
-        cls._build_args_sub_resource_update(public_ip_addresses_v6.Element)
+        cls._build_args_common_sub_resource_update(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = cls._args_public_ip_address_update.nat_gateway.public_ip_prefixes
+        public_ip_prefixes = cls._args_common_public_ip_address_update.nat_gateway.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectArg(
             nullable=True,
         )
-        cls._build_args_sub_resource_update(public_ip_prefixes.Element)
+        cls._build_args_common_sub_resource_update(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = cls._args_public_ip_address_update.nat_gateway.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = cls._args_common_public_ip_address_update.nat_gateway.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectArg(
             nullable=True,
         )
-        cls._build_args_sub_resource_update(public_ip_prefixes_v6.Element)
+        cls._build_args_common_sub_resource_update(public_ip_prefixes_v6.Element)
 
-        sku = cls._args_public_ip_address_update.nat_gateway.sku
+        sku = cls._args_common_public_ip_address_update.nat_gateway.sku
         sku.name = AAZStrArg(
             options=["name"],
             help="Name of Nat Gateway SKU.",
@@ -456,17 +478,24 @@ class Update(AAZCommand):
             enum={"Standard": "Standard", "StandardV2": "StandardV2"},
         )
 
-        tags = cls._args_public_ip_address_update.nat_gateway.tags
+        tags = cls._args_common_public_ip_address_update.nat_gateway.tags
         tags.Element = AAZStrArg(
             nullable=True,
         )
 
-        zones = cls._args_public_ip_address_update.nat_gateway.zones
+        zones = cls._args_common_public_ip_address_update.nat_gateway.zones
         zones.Element = AAZStrArg(
             nullable=True,
         )
 
-        sku = cls._args_public_ip_address_update.sku
+        public_ip_prefix = cls._args_common_public_ip_address_update.public_ip_prefix
+        public_ip_prefix.id = AAZStrArg(
+            options=["id"],
+            help="Resource ID.",
+            nullable=True,
+        )
+
+        sku = cls._args_common_public_ip_address_update.sku
         sku.name = AAZStrArg(
             options=["name"],
             help="Name of a public IP address SKU.",
@@ -480,65 +509,64 @@ class Update(AAZCommand):
             enum={"Global": "Global", "Regional": "Regional"},
         )
 
-        tags = cls._args_public_ip_address_update.tags
+        tags = cls._args_common_public_ip_address_update.tags
         tags.Element = AAZStrArg(
             nullable=True,
         )
 
-        zones = cls._args_public_ip_address_update.zones
+        zones = cls._args_common_public_ip_address_update.zones
         zones.Element = AAZStrArg(
             nullable=True,
         )
 
-        _schema.ddos_settings = cls._args_public_ip_address_update.ddos_settings
-        _schema.delete_option = cls._args_public_ip_address_update.delete_option
-        _schema.dns_settings = cls._args_public_ip_address_update.dns_settings
-        _schema.extended_location = cls._args_public_ip_address_update.extended_location
-        _schema.id = cls._args_public_ip_address_update.id
-        _schema.idle_timeout_in_minutes = cls._args_public_ip_address_update.idle_timeout_in_minutes
-        _schema.ip_address = cls._args_public_ip_address_update.ip_address
-        _schema.ip_tags = cls._args_public_ip_address_update.ip_tags
-        _schema.linked_public_ip_address = cls._args_public_ip_address_update.linked_public_ip_address
-        _schema.location = cls._args_public_ip_address_update.location
-        _schema.migration_phase = cls._args_public_ip_address_update.migration_phase
-        _schema.nat_gateway = cls._args_public_ip_address_update.nat_gateway
-        _schema.public_ip_address_version = cls._args_public_ip_address_update.public_ip_address_version
-        _schema.public_ip_allocation_method = cls._args_public_ip_address_update.public_ip_allocation_method
-        _schema.public_ip_prefix = cls._args_public_ip_address_update.public_ip_prefix
-        _schema.service_public_ip_address = cls._args_public_ip_address_update.service_public_ip_address
-        _schema.sku = cls._args_public_ip_address_update.sku
-        _schema.tags = cls._args_public_ip_address_update.tags
-        _schema.zones = cls._args_public_ip_address_update.zones
+        _schema.ddos_settings = cls._args_common_public_ip_address_update.ddos_settings
+        _schema.delete_option = cls._args_common_public_ip_address_update.delete_option
+        _schema.dns_settings = cls._args_common_public_ip_address_update.dns_settings
+        _schema.extended_location = cls._args_common_public_ip_address_update.extended_location
+        _schema.idle_timeout_in_minutes = cls._args_common_public_ip_address_update.idle_timeout_in_minutes
+        _schema.ip_address = cls._args_common_public_ip_address_update.ip_address
+        _schema.ip_tags = cls._args_common_public_ip_address_update.ip_tags
+        _schema.linked_public_ip_address = cls._args_common_public_ip_address_update.linked_public_ip_address
+        _schema.location = cls._args_common_public_ip_address_update.location
+        _schema.migration_phase = cls._args_common_public_ip_address_update.migration_phase
+        _schema.nat_gateway = cls._args_common_public_ip_address_update.nat_gateway
+        _schema.public_ip_address_version = cls._args_common_public_ip_address_update.public_ip_address_version
+        _schema.public_ip_allocation_method = cls._args_common_public_ip_address_update.public_ip_allocation_method
+        _schema.public_ip_prefix = cls._args_common_public_ip_address_update.public_ip_prefix
+        _schema.service_public_ip_address = cls._args_common_public_ip_address_update.service_public_ip_address
+        _schema.sku = cls._args_common_public_ip_address_update.sku
+        _schema.tags = cls._args_common_public_ip_address_update.tags
+        _schema.zones = cls._args_common_public_ip_address_update.zones
 
-    _args_sub_resource_update = None
+    _args_common_sub_resource_update = None
 
     @classmethod
-    def _build_args_sub_resource_update(cls, _schema):
-        if cls._args_sub_resource_update is not None:
-            _schema.id = cls._args_sub_resource_update.id
+    def _build_args_common_sub_resource_update(cls, _schema):
+        if cls._args_common_sub_resource_update is not None:
+            _schema.id = cls._args_common_sub_resource_update.id
             return
 
-        cls._args_sub_resource_update = AAZObjectArg(
+        cls._args_common_sub_resource_update = AAZObjectArg(
             nullable=True,
         )
 
-        sub_resource_update = cls._args_sub_resource_update
-        sub_resource_update.id = AAZStrArg(
+        common_sub_resource_update = cls._args_common_sub_resource_update
+        common_sub_resource_update.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
             nullable=True,
         )
 
-        _schema.id = cls._args_sub_resource_update.id
+        _schema.id = cls._args_common_sub_resource_update.id
 
     def _execute_operations(self):
         self.pre_operations()
-        self.PublicIPAddressesGet(ctx=self.ctx)()
+        self.PublicIpAddressOperationGroupGet(ctx=self.ctx)()
         self.pre_instance_update(self.ctx.vars.instance)
         self.InstanceUpdateByJson(ctx=self.ctx)()
         self.InstanceUpdateByGeneric(ctx=self.ctx)()
         self.post_instance_update(self.ctx.vars.instance)
-        yield self.PublicIPAddressesCreateOrUpdate(ctx=self.ctx)()
+        yield self.PublicIpAddressOperationGroupCreateOrUpdate(ctx=self.ctx)()
         self.post_operations()
 
     @register_callback
@@ -561,7 +589,7 @@ class Update(AAZCommand):
         result = self.deserialize_output(self.ctx.vars.instance, client_flatten=True)
         return result
 
-    class PublicIPAddressesGet(AAZHttpOperation):
+    class PublicIpAddressOperationGroupGet(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -609,7 +637,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -640,11 +668,11 @@ class Update(AAZCommand):
                 return cls._schema_on_200
 
             cls._schema_on_200 = AAZObjectType()
-            _UpdateHelper._build_schema_public_ip_address_read(cls._schema_on_200)
+            _UpdateHelper._build_schema_common_public_ip_address_read(cls._schema_on_200)
 
             return cls._schema_on_200
 
-    class PublicIPAddressesCreateOrUpdate(AAZHttpOperation):
+    class PublicIpAddressOperationGroupCreateOrUpdate(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -708,7 +736,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -751,7 +779,7 @@ class Update(AAZCommand):
                 return cls._schema_on_200_201
 
             cls._schema_on_200_201 = AAZObjectType()
-            _UpdateHelper._build_schema_public_ip_address_read(cls._schema_on_200_201)
+            _UpdateHelper._build_schema_common_public_ip_address_read(cls._schema_on_200_201)
 
             return cls._schema_on_200_201
 
@@ -783,6 +811,7 @@ class Update(AAZCommand):
 
             ddos_settings = _builder.get(".properties.ddosSettings")
             if ddos_settings is not None:
+                _UpdateHelper._build_schema_common_sub_resource_update(ddos_settings.set_prop("ddosCustomPolicy", AAZObjectType, ".ddos_custom_policy"))
                 ddos_settings.set_prop("ddosProtectionPlan", AAZObjectType)
                 ddos_settings.set_prop("protectionMode", AAZStrType, ".ddos_protection_mode")
 
@@ -832,11 +861,10 @@ class _UpdateHelper:
     """Helper class for Update"""
 
     @classmethod
-    def _build_schema_public_ip_address_update(cls, _builder):
+    def _build_schema_common_public_ip_address_update(cls, _builder):
         if _builder is None:
             return
         _builder.set_prop("extendedLocation", AAZObjectType, ".extended_location")
-        _builder.set_prop("id", AAZStrType, ".id")
         _builder.set_prop("location", AAZStrType, ".location")
         _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
         _builder.set_prop("sku", AAZObjectType, ".sku")
@@ -856,18 +884,23 @@ class _UpdateHelper:
             properties.set_prop("idleTimeoutInMinutes", AAZIntType, ".idle_timeout_in_minutes")
             properties.set_prop("ipAddress", AAZStrType, ".ip_address")
             properties.set_prop("ipTags", AAZListType, ".ip_tags")
-            cls._build_schema_public_ip_address_update(properties.set_prop("linkedPublicIPAddress", AAZObjectType, ".linked_public_ip_address"))
+            cls._build_schema_common_public_ip_address_update(properties.set_prop("linkedPublicIPAddress", AAZObjectType, ".linked_public_ip_address"))
             properties.set_prop("migrationPhase", AAZStrType, ".migration_phase")
             properties.set_prop("natGateway", AAZObjectType, ".nat_gateway")
             properties.set_prop("publicIPAddressVersion", AAZStrType, ".public_ip_address_version")
             properties.set_prop("publicIPAllocationMethod", AAZStrType, ".public_ip_allocation_method")
-            cls._build_schema_sub_resource_update(properties.set_prop("publicIPPrefix", AAZObjectType, ".public_ip_prefix"))
-            cls._build_schema_public_ip_address_update(properties.set_prop("servicePublicIPAddress", AAZObjectType, ".service_public_ip_address"))
+            properties.set_prop("publicIPPrefix", AAZObjectType, ".public_ip_prefix")
+            cls._build_schema_common_public_ip_address_update(properties.set_prop("servicePublicIPAddress", AAZObjectType, ".service_public_ip_address"))
 
         ddos_settings = _builder.get(".properties.ddosSettings")
         if ddos_settings is not None:
-            cls._build_schema_sub_resource_update(ddos_settings.set_prop("ddosProtectionPlan", AAZObjectType, ".ddos_protection_plan"))
+            cls._build_schema_common_sub_resource_update(ddos_settings.set_prop("ddosCustomPolicy", AAZObjectType, ".ddos_custom_policy"))
+            ddos_settings.set_prop("ddosProtectionPlan", AAZObjectType, ".ddos_protection_plan")
             ddos_settings.set_prop("protectionMode", AAZStrType, ".protection_mode")
+
+        ddos_protection_plan = _builder.get(".properties.ddosSettings.ddosProtectionPlan")
+        if ddos_protection_plan is not None:
+            ddos_protection_plan.set_prop("id", AAZStrType, ".id")
 
         dns_settings = _builder.get(".properties.dnsSettings")
         if dns_settings is not None:
@@ -897,27 +930,29 @@ class _UpdateHelper:
         properties = _builder.get(".properties.natGateway.properties")
         if properties is not None:
             properties.set_prop("idleTimeoutInMinutes", AAZIntType, ".idle_timeout_in_minutes")
+            properties.set_prop("nat64", AAZStrType, ".nat64")
             properties.set_prop("publicIpAddresses", AAZListType, ".public_ip_addresses")
             properties.set_prop("publicIpAddressesV6", AAZListType, ".public_ip_addresses_v6")
             properties.set_prop("publicIpPrefixes", AAZListType, ".public_ip_prefixes")
             properties.set_prop("publicIpPrefixesV6", AAZListType, ".public_ip_prefixes_v6")
-            cls._build_schema_sub_resource_update(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_virtual_network"))
+            cls._build_schema_common_sub_resource_update(properties.set_prop("serviceGateway", AAZObjectType, ".service_gateway"))
+            cls._build_schema_common_sub_resource_update(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_virtual_network"))
 
         public_ip_addresses = _builder.get(".properties.natGateway.properties.publicIpAddresses")
         if public_ip_addresses is not None:
-            cls._build_schema_sub_resource_update(public_ip_addresses.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_update(public_ip_addresses.set_elements(AAZObjectType, "."))
 
         public_ip_addresses_v6 = _builder.get(".properties.natGateway.properties.publicIpAddressesV6")
         if public_ip_addresses_v6 is not None:
-            cls._build_schema_sub_resource_update(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_update(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
 
         public_ip_prefixes = _builder.get(".properties.natGateway.properties.publicIpPrefixes")
         if public_ip_prefixes is not None:
-            cls._build_schema_sub_resource_update(public_ip_prefixes.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_update(public_ip_prefixes.set_elements(AAZObjectType, "."))
 
         public_ip_prefixes_v6 = _builder.get(".properties.natGateway.properties.publicIpPrefixesV6")
         if public_ip_prefixes_v6 is not None:
-            cls._build_schema_sub_resource_update(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
+            cls._build_schema_common_sub_resource_update(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
 
         sku = _builder.get(".properties.natGateway.sku")
         if sku is not None:
@@ -930,6 +965,10 @@ class _UpdateHelper:
         zones = _builder.get(".properties.natGateway.zones")
         if zones is not None:
             zones.set_elements(AAZStrType, ".")
+
+        public_ip_prefix = _builder.get(".properties.publicIPPrefix")
+        if public_ip_prefix is not None:
+            public_ip_prefix.set_prop("id", AAZStrType, ".id")
 
         sku = _builder.get(".sku")
         if sku is not None:
@@ -945,45 +984,45 @@ class _UpdateHelper:
             zones.set_elements(AAZStrType, ".")
 
     @classmethod
-    def _build_schema_sub_resource_update(cls, _builder):
+    def _build_schema_common_sub_resource_update(cls, _builder):
         if _builder is None:
             return
         _builder.set_prop("id", AAZStrType, ".id")
 
-    _schema_application_security_group_read = None
+    _schema_common_application_security_group_read = None
 
     @classmethod
-    def _build_schema_application_security_group_read(cls, _schema):
-        if cls._schema_application_security_group_read is not None:
-            _schema.etag = cls._schema_application_security_group_read.etag
-            _schema.id = cls._schema_application_security_group_read.id
-            _schema.location = cls._schema_application_security_group_read.location
-            _schema.name = cls._schema_application_security_group_read.name
-            _schema.properties = cls._schema_application_security_group_read.properties
-            _schema.tags = cls._schema_application_security_group_read.tags
-            _schema.type = cls._schema_application_security_group_read.type
+    def _build_schema_common_application_security_group_read(cls, _schema):
+        if cls._schema_common_application_security_group_read is not None:
+            _schema.etag = cls._schema_common_application_security_group_read.etag
+            _schema.id = cls._schema_common_application_security_group_read.id
+            _schema.location = cls._schema_common_application_security_group_read.location
+            _schema.name = cls._schema_common_application_security_group_read.name
+            _schema.properties = cls._schema_common_application_security_group_read.properties
+            _schema.tags = cls._schema_common_application_security_group_read.tags
+            _schema.type = cls._schema_common_application_security_group_read.type
             return
 
-        cls._schema_application_security_group_read = _schema_application_security_group_read = AAZObjectType()
+        cls._schema_common_application_security_group_read = _schema_common_application_security_group_read = AAZObjectType()
 
-        application_security_group_read = _schema_application_security_group_read
-        application_security_group_read.etag = AAZStrType(
+        common_application_security_group_read = _schema_common_application_security_group_read
+        common_application_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.id = AAZStrType()
-        application_security_group_read.location = AAZStrType()
-        application_security_group_read.name = AAZStrType(
+        common_application_security_group_read.id = AAZStrType()
+        common_application_security_group_read.location = AAZStrType()
+        common_application_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.properties = AAZObjectType(
+        common_application_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        application_security_group_read.tags = AAZDictType()
-        application_security_group_read.type = AAZStrType(
+        common_application_security_group_read.tags = AAZDictType()
+        common_application_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_application_security_group_read.properties
+        properties = _schema_common_application_security_group_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -993,69 +1032,72 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        tags = _schema_application_security_group_read.tags
+        tags = _schema_common_application_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_application_security_group_read.etag
-        _schema.id = cls._schema_application_security_group_read.id
-        _schema.location = cls._schema_application_security_group_read.location
-        _schema.name = cls._schema_application_security_group_read.name
-        _schema.properties = cls._schema_application_security_group_read.properties
-        _schema.tags = cls._schema_application_security_group_read.tags
-        _schema.type = cls._schema_application_security_group_read.type
+        _schema.etag = cls._schema_common_application_security_group_read.etag
+        _schema.id = cls._schema_common_application_security_group_read.id
+        _schema.location = cls._schema_common_application_security_group_read.location
+        _schema.name = cls._schema_common_application_security_group_read.name
+        _schema.properties = cls._schema_common_application_security_group_read.properties
+        _schema.tags = cls._schema_common_application_security_group_read.tags
+        _schema.type = cls._schema_common_application_security_group_read.type
 
-    _schema_extended_location_read = None
-
-    @classmethod
-    def _build_schema_extended_location_read(cls, _schema):
-        if cls._schema_extended_location_read is not None:
-            _schema.name = cls._schema_extended_location_read.name
-            _schema.type = cls._schema_extended_location_read.type
-            return
-
-        cls._schema_extended_location_read = _schema_extended_location_read = AAZObjectType()
-
-        extended_location_read = _schema_extended_location_read
-        extended_location_read.name = AAZStrType()
-        extended_location_read.type = AAZStrType()
-
-        _schema.name = cls._schema_extended_location_read.name
-        _schema.type = cls._schema_extended_location_read.type
-
-    _schema_frontend_ip_configuration_read = None
+    _schema_common_extended_location_read = None
 
     @classmethod
-    def _build_schema_frontend_ip_configuration_read(cls, _schema):
-        if cls._schema_frontend_ip_configuration_read is not None:
-            _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-            _schema.id = cls._schema_frontend_ip_configuration_read.id
-            _schema.name = cls._schema_frontend_ip_configuration_read.name
-            _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-            _schema.type = cls._schema_frontend_ip_configuration_read.type
-            _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+    def _build_schema_common_extended_location_read(cls, _schema):
+        if cls._schema_common_extended_location_read is not None:
+            _schema.name = cls._schema_common_extended_location_read.name
+            _schema.type = cls._schema_common_extended_location_read.type
             return
 
-        cls._schema_frontend_ip_configuration_read = _schema_frontend_ip_configuration_read = AAZObjectType()
+        cls._schema_common_extended_location_read = _schema_common_extended_location_read = AAZObjectType()
 
-        frontend_ip_configuration_read = _schema_frontend_ip_configuration_read
-        frontend_ip_configuration_read.etag = AAZStrType(
+        common_extended_location_read = _schema_common_extended_location_read
+        common_extended_location_read.name = AAZStrType()
+        common_extended_location_read.type = AAZStrType()
+
+        _schema.name = cls._schema_common_extended_location_read.name
+        _schema.type = cls._schema_common_extended_location_read.type
+
+    _schema_common_frontend_ip_configuration_read = None
+
+    @classmethod
+    def _build_schema_common_frontend_ip_configuration_read(cls, _schema):
+        if cls._schema_common_frontend_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+            _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+            _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+            _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+            _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+            _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
+            return
+
+        cls._schema_common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read = AAZObjectType()
+
+        common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read
+        common_frontend_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.id = AAZStrType()
-        frontend_ip_configuration_read.name = AAZStrType()
-        frontend_ip_configuration_read.properties = AAZObjectType(
+        common_frontend_ip_configuration_read.id = AAZStrType()
+        common_frontend_ip_configuration_read.name = AAZStrType()
+        common_frontend_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        frontend_ip_configuration_read.type = AAZStrType(
+        common_frontend_ip_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.zones = AAZListType()
+        common_frontend_ip_configuration_read.zones = AAZListType()
 
-        properties = _schema_frontend_ip_configuration_read.properties
+        properties = _schema_common_frontend_ip_configuration_read.properties
+        properties.ddos_settings = AAZObjectType(
+            serialized_name="ddosSettings",
+        )
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.inbound_nat_pools = AAZListType(
             serialized_name="inboundNatPools",
             flags={"read_only": True},
@@ -1088,66 +1130,72 @@ class _UpdateHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        inbound_nat_pools = _schema_frontend_ip_configuration_read.properties.inbound_nat_pools
+        ddos_settings = _schema_common_frontend_ip_configuration_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
+
+        inbound_nat_pools = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_pools
         inbound_nat_pools.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_pools.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_pools.Element)
 
-        inbound_nat_rules = _schema_frontend_ip_configuration_read.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancing_rules = _schema_frontend_ip_configuration_read.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_frontend_ip_configuration_read.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_frontend_ip_configuration_read.properties.outbound_rules
+        outbound_rules = _schema_common_frontend_ip_configuration_read.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        zones = _schema_frontend_ip_configuration_read.zones
+        zones = _schema_common_frontend_ip_configuration_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-        _schema.id = cls._schema_frontend_ip_configuration_read.id
-        _schema.name = cls._schema_frontend_ip_configuration_read.name
-        _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-        _schema.type = cls._schema_frontend_ip_configuration_read.type
-        _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+        _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+        _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+        _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+        _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+        _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+        _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
 
-    _schema_ip_configuration_read = None
+    _schema_common_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_ip_configuration_read(cls, _schema):
-        if cls._schema_ip_configuration_read is not None:
-            _schema.etag = cls._schema_ip_configuration_read.etag
-            _schema.id = cls._schema_ip_configuration_read.id
-            _schema.name = cls._schema_ip_configuration_read.name
-            _schema.properties = cls._schema_ip_configuration_read.properties
+    def _build_schema_common_ip_configuration_read(cls, _schema):
+        if cls._schema_common_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_ip_configuration_read.etag
+            _schema.id = cls._schema_common_ip_configuration_read.id
+            _schema.name = cls._schema_common_ip_configuration_read.name
+            _schema.properties = cls._schema_common_ip_configuration_read.properties
             return
 
-        cls._schema_ip_configuration_read = _schema_ip_configuration_read = AAZObjectType(
+        cls._schema_common_ip_configuration_read = _schema_common_ip_configuration_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        ip_configuration_read = _schema_ip_configuration_read
-        ip_configuration_read.etag = AAZStrType(
+        common_ip_configuration_read = _schema_common_ip_configuration_read
+        common_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        ip_configuration_read.id = AAZStrType()
-        ip_configuration_read.name = AAZStrType()
-        ip_configuration_read.properties = AAZObjectType(
+        common_ip_configuration_read.id = AAZStrType()
+        common_ip_configuration_read.name = AAZStrType()
+        common_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_ip_configuration_read.properties
+        properties = _schema_common_ip_configuration_read.properties
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
         )
@@ -1161,41 +1209,43 @@ class _UpdateHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        _schema.etag = cls._schema_ip_configuration_read.etag
-        _schema.id = cls._schema_ip_configuration_read.id
-        _schema.name = cls._schema_ip_configuration_read.name
-        _schema.properties = cls._schema_ip_configuration_read.properties
+        _schema.etag = cls._schema_common_ip_configuration_read.etag
+        _schema.id = cls._schema_common_ip_configuration_read.id
+        _schema.name = cls._schema_common_ip_configuration_read.name
+        _schema.properties = cls._schema_common_ip_configuration_read.properties
 
-    _schema_network_interface_ip_configuration_read = None
+    _schema_common_network_interface_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_ip_configuration_read(cls, _schema):
-        if cls._schema_network_interface_ip_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-            _schema.id = cls._schema_network_interface_ip_configuration_read.id
-            _schema.name = cls._schema_network_interface_ip_configuration_read.name
-            _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-            _schema.type = cls._schema_network_interface_ip_configuration_read.type
+    def _build_schema_common_network_interface_ip_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
             return
 
-        cls._schema_network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read = AAZObjectType()
 
-        network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read
-        network_interface_ip_configuration_read.etag = AAZStrType(
+        common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read
+        common_network_interface_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_ip_configuration_read.id = AAZStrType()
-        network_interface_ip_configuration_read.name = AAZStrType()
-        network_interface_ip_configuration_read.properties = AAZObjectType(
+        common_network_interface_ip_configuration_read.id = AAZStrType()
+        common_network_interface_ip_configuration_read.name = AAZStrType()
+        common_network_interface_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_ip_configuration_read.type = AAZStrType()
+        common_network_interface_ip_configuration_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_network_interface_ip_configuration_read.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties
         properties.application_gateway_backend_address_pools = AAZListType(
             serialized_name="applicationGatewayBackendAddressPools",
         )
@@ -1205,7 +1255,7 @@ class _UpdateHelper:
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.load_balancer_backend_address_pools = AAZListType(
             serialized_name="loadBalancerBackendAddressPools",
         )
@@ -1237,17 +1287,17 @@ class _UpdateHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
         properties.virtual_network_taps = AAZListType(
             serialized_name="virtualNetworkTaps",
         )
 
-        application_gateway_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
+        application_gateway_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
         application_gateway_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1260,7 +1310,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
         properties.backend_addresses = AAZListType(
             serialized_name="backendAddresses",
         )
@@ -1273,27 +1323,27 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        backend_addresses = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
+        backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
         backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
         _element.fqdn = AAZStrType()
         _element.ip_address = AAZStrType(
             serialized_name="ipAddress",
         )
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        application_security_groups = _schema_network_interface_ip_configuration_read.properties.application_security_groups
+        application_security_groups = _schema_common_network_interface_ip_configuration_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        load_balancer_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
+        load_balancer_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
         load_balancer_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1306,7 +1356,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
         properties.backend_ip_configurations = AAZListType(
             serialized_name="backendIPConfigurations",
             flags={"read_only": True},
@@ -1330,7 +1380,7 @@ class _UpdateHelper:
             serialized_name="outboundRule",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.outbound_rule)
+        cls._build_schema_common_sub_resource_read(properties.outbound_rule)
         properties.outbound_rules = AAZListType(
             serialized_name="outboundRules",
             flags={"read_only": True},
@@ -1348,26 +1398,26 @@ class _UpdateHelper:
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancer_backend_addresses = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
+        load_balancer_backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
         load_balancer_backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
         _element.name = AAZStrType()
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
         properties.admin_state = AAZStrType(
             serialized_name="adminState",
         )
@@ -1381,23 +1431,23 @@ class _UpdateHelper:
         properties.load_balancer_frontend_ip_configuration = AAZObjectType(
             serialized_name="loadBalancerFrontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
         properties.network_interface_ip_configuration = AAZObjectType(
             serialized_name="networkInterfaceIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.network_interface_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.network_interface_ip_configuration)
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        inbound_nat_rules_port_mapping = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
+        inbound_nat_rules_port_mapping = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
         inbound_nat_rules_port_mapping.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
         _element.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -1408,27 +1458,27 @@ class _UpdateHelper:
             serialized_name="inboundNatRuleName",
         )
 
-        load_balancing_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
+        outbound_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        tunnel_interfaces = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
+        tunnel_interfaces = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
         tunnel_interfaces.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
         _element.identifier = AAZIntType()
         _element.port = AAZIntType()
         _element.protocol = AAZStrType()
         _element.type = AAZStrType()
 
-        load_balancer_inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
+        load_balancer_inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
         load_balancer_inbound_nat_rules.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1441,16 +1491,16 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
         properties.backend_address_pool = AAZObjectType(
             serialized_name="backendAddressPool",
         )
-        cls._build_schema_sub_resource_read(properties.backend_address_pool)
+        cls._build_schema_common_sub_resource_read(properties.backend_address_pool)
         properties.backend_ip_configuration = AAZObjectType(
             serialized_name="backendIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.backend_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.backend_ip_configuration)
         properties.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -1463,7 +1513,7 @@ class _UpdateHelper:
         properties.frontend_ip_configuration = AAZObjectType(
             serialized_name="frontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.frontend_ip_configuration)
         properties.frontend_port = AAZIntType(
             serialized_name="frontendPort",
         )
@@ -1482,7 +1532,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        private_link_connection_properties = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties
+        private_link_connection_properties = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties
         private_link_connection_properties.fqdns = AAZListType(
             flags={"read_only": True},
         )
@@ -1495,47 +1545,47 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        fqdns = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
+        fqdns = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
         fqdns.Element = AAZStrType()
 
-        virtual_network_taps = _schema_network_interface_ip_configuration_read.properties.virtual_network_taps
+        virtual_network_taps = _schema_common_network_interface_ip_configuration_read.properties.virtual_network_taps
         virtual_network_taps.Element = AAZObjectType()
-        cls._build_schema_virtual_network_tap_read(virtual_network_taps.Element)
+        cls._build_schema_common_virtual_network_tap_read(virtual_network_taps.Element)
 
-        _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-        _schema.id = cls._schema_network_interface_ip_configuration_read.id
-        _schema.name = cls._schema_network_interface_ip_configuration_read.name
-        _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-        _schema.type = cls._schema_network_interface_ip_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
 
-    _schema_network_interface_tap_configuration_read = None
+    _schema_common_network_interface_tap_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_tap_configuration_read(cls, _schema):
-        if cls._schema_network_interface_tap_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-            _schema.id = cls._schema_network_interface_tap_configuration_read.id
-            _schema.name = cls._schema_network_interface_tap_configuration_read.name
-            _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-            _schema.type = cls._schema_network_interface_tap_configuration_read.type
+    def _build_schema_common_network_interface_tap_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_tap_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
             return
 
-        cls._schema_network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read = AAZObjectType()
 
-        network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read
-        network_interface_tap_configuration_read.etag = AAZStrType(
+        common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read
+        common_network_interface_tap_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_tap_configuration_read.id = AAZStrType()
-        network_interface_tap_configuration_read.name = AAZStrType()
-        network_interface_tap_configuration_read.properties = AAZObjectType(
+        common_network_interface_tap_configuration_read.id = AAZStrType()
+        common_network_interface_tap_configuration_read.name = AAZStrType()
+        common_network_interface_tap_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_tap_configuration_read.type = AAZStrType(
+        common_network_interface_tap_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_tap_configuration_read.properties
+        properties = _schema_common_network_interface_tap_configuration_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -1543,53 +1593,53 @@ class _UpdateHelper:
         properties.virtual_network_tap = AAZObjectType(
             serialized_name="virtualNetworkTap",
         )
-        cls._build_schema_virtual_network_tap_read(properties.virtual_network_tap)
+        cls._build_schema_common_virtual_network_tap_read(properties.virtual_network_tap)
 
-        _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-        _schema.id = cls._schema_network_interface_tap_configuration_read.id
-        _schema.name = cls._schema_network_interface_tap_configuration_read.name
-        _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-        _schema.type = cls._schema_network_interface_tap_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
 
-    _schema_network_interface_read = None
+    _schema_common_network_interface_read = None
 
     @classmethod
-    def _build_schema_network_interface_read(cls, _schema):
-        if cls._schema_network_interface_read is not None:
-            _schema.etag = cls._schema_network_interface_read.etag
-            _schema.extended_location = cls._schema_network_interface_read.extended_location
-            _schema.id = cls._schema_network_interface_read.id
-            _schema.location = cls._schema_network_interface_read.location
-            _schema.name = cls._schema_network_interface_read.name
-            _schema.properties = cls._schema_network_interface_read.properties
-            _schema.tags = cls._schema_network_interface_read.tags
-            _schema.type = cls._schema_network_interface_read.type
+    def _build_schema_common_network_interface_read(cls, _schema):
+        if cls._schema_common_network_interface_read is not None:
+            _schema.etag = cls._schema_common_network_interface_read.etag
+            _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+            _schema.id = cls._schema_common_network_interface_read.id
+            _schema.location = cls._schema_common_network_interface_read.location
+            _schema.name = cls._schema_common_network_interface_read.name
+            _schema.properties = cls._schema_common_network_interface_read.properties
+            _schema.tags = cls._schema_common_network_interface_read.tags
+            _schema.type = cls._schema_common_network_interface_read.type
             return
 
-        cls._schema_network_interface_read = _schema_network_interface_read = AAZObjectType()
+        cls._schema_common_network_interface_read = _schema_common_network_interface_read = AAZObjectType()
 
-        network_interface_read = _schema_network_interface_read
-        network_interface_read.etag = AAZStrType(
+        common_network_interface_read = _schema_common_network_interface_read
+        common_network_interface_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.extended_location = AAZObjectType(
+        common_network_interface_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(network_interface_read.extended_location)
-        network_interface_read.id = AAZStrType()
-        network_interface_read.location = AAZStrType()
-        network_interface_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_network_interface_read.extended_location)
+        common_network_interface_read.id = AAZStrType()
+        common_network_interface_read.location = AAZStrType()
+        common_network_interface_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.properties = AAZObjectType(
+        common_network_interface_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_read.tags = AAZDictType()
-        network_interface_read.type = AAZStrType(
+        common_network_interface_read.tags = AAZDictType()
+        common_network_interface_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties
+        properties = _schema_common_network_interface_read.properties
         properties.auxiliary_mode = AAZStrType(
             serialized_name="auxiliaryMode",
         )
@@ -1610,7 +1660,7 @@ class _UpdateHelper:
             serialized_name="dscpConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.dscp_configuration)
+        cls._build_schema_common_sub_resource_read(properties.dscp_configuration)
         properties.enable_accelerated_networking = AAZBoolType(
             serialized_name="enableAcceleratedNetworking",
         )
@@ -1634,7 +1684,7 @@ class _UpdateHelper:
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.nic_type = AAZStrType(
             serialized_name="nicType",
         )
@@ -1645,7 +1695,7 @@ class _UpdateHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_link_service = AAZObjectType(
             serialized_name="privateLinkService",
         )
@@ -1665,7 +1715,7 @@ class _UpdateHelper:
             serialized_name="virtualMachine",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.virtual_machine)
+        cls._build_schema_common_sub_resource_read(properties.virtual_machine)
         properties.vnet_encryption_supported = AAZBoolType(
             serialized_name="vnetEncryptionSupported",
             flags={"read_only": True},
@@ -1674,7 +1724,7 @@ class _UpdateHelper:
             serialized_name="workloadType",
         )
 
-        dns_settings = _schema_network_interface_read.properties.dns_settings
+        dns_settings = _schema_common_network_interface_read.properties.dns_settings
         dns_settings.applied_dns_servers = AAZListType(
             serialized_name="appliedDnsServers",
             flags={"read_only": True},
@@ -1694,27 +1744,27 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        applied_dns_servers = _schema_network_interface_read.properties.dns_settings.applied_dns_servers
+        applied_dns_servers = _schema_common_network_interface_read.properties.dns_settings.applied_dns_servers
         applied_dns_servers.Element = AAZStrType()
 
-        dns_servers = _schema_network_interface_read.properties.dns_settings.dns_servers
+        dns_servers = _schema_common_network_interface_read.properties.dns_settings.dns_servers
         dns_servers.Element = AAZStrType()
 
-        hosted_workloads = _schema_network_interface_read.properties.hosted_workloads
+        hosted_workloads = _schema_common_network_interface_read.properties.hosted_workloads
         hosted_workloads.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(ip_configurations.Element)
 
-        private_link_service = _schema_network_interface_read.properties.private_link_service
+        private_link_service = _schema_common_network_interface_read.properties.private_link_service
         private_link_service.etag = AAZStrType(
             flags={"read_only": True},
         )
         private_link_service.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_link_service.extended_location)
+        cls._build_schema_common_extended_location_read(private_link_service.extended_location)
         private_link_service.id = AAZStrType()
         private_link_service.location = AAZStrType()
         private_link_service.name = AAZStrType(
@@ -1728,7 +1778,10 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties
+        properties.access_mode = AAZStrType(
+            serialized_name="accessMode",
+        )
         properties.alias = AAZStrType(
             flags={"read_only": True},
         )
@@ -1762,19 +1815,19 @@ class _UpdateHelper:
         )
         properties.visibility = AAZObjectType()
 
-        auto_approval = _schema_network_interface_read.properties.private_link_service.properties.auto_approval
+        auto_approval = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval
         auto_approval.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
         subscriptions.Element = AAZStrType()
 
-        fqdns = _schema_network_interface_read.properties.private_link_service.properties.fqdns
+        fqdns = _schema_common_network_interface_read.properties.private_link_service.properties.fqdns
         fqdns.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1787,7 +1840,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
         properties.primary = AAZBoolType()
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
@@ -1803,20 +1856,20 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        load_balancer_frontend_ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
+        load_balancer_frontend_ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
         load_balancer_frontend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
+        cls._build_schema_common_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
 
-        network_interfaces = _schema_network_interface_read.properties.private_link_service.properties.network_interfaces
+        network_interfaces = _schema_common_network_interface_read.properties.private_link_service.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_endpoint_connections = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
+        private_endpoint_connections = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
         private_endpoint_connections.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1829,7 +1882,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
         properties.link_identifier = AAZStrType(
             serialized_name="linkIdentifier",
             flags={"read_only": True},
@@ -1838,7 +1891,7 @@ class _UpdateHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_endpoint_location = AAZStrType(
             serialized_name="privateEndpointLocation",
             flags={"read_only": True},
@@ -1846,71 +1899,71 @@ class _UpdateHelper:
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
 
-        visibility = _schema_network_interface_read.properties.private_link_service.properties.visibility
+        visibility = _schema_common_network_interface_read.properties.private_link_service.properties.visibility
         visibility.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
         subscriptions.Element = AAZStrType()
 
-        tags = _schema_network_interface_read.properties.private_link_service.tags
+        tags = _schema_common_network_interface_read.properties.private_link_service.tags
         tags.Element = AAZStrType()
 
-        tap_configurations = _schema_network_interface_read.properties.tap_configurations
+        tap_configurations = _schema_common_network_interface_read.properties.tap_configurations
         tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(tap_configurations.Element)
 
-        tags = _schema_network_interface_read.tags
+        tags = _schema_common_network_interface_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_interface_read.etag
-        _schema.extended_location = cls._schema_network_interface_read.extended_location
-        _schema.id = cls._schema_network_interface_read.id
-        _schema.location = cls._schema_network_interface_read.location
-        _schema.name = cls._schema_network_interface_read.name
-        _schema.properties = cls._schema_network_interface_read.properties
-        _schema.tags = cls._schema_network_interface_read.tags
-        _schema.type = cls._schema_network_interface_read.type
+        _schema.etag = cls._schema_common_network_interface_read.etag
+        _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+        _schema.id = cls._schema_common_network_interface_read.id
+        _schema.location = cls._schema_common_network_interface_read.location
+        _schema.name = cls._schema_common_network_interface_read.name
+        _schema.properties = cls._schema_common_network_interface_read.properties
+        _schema.tags = cls._schema_common_network_interface_read.tags
+        _schema.type = cls._schema_common_network_interface_read.type
 
-    _schema_network_security_group_read = None
+    _schema_common_network_security_group_read = None
 
     @classmethod
-    def _build_schema_network_security_group_read(cls, _schema):
-        if cls._schema_network_security_group_read is not None:
-            _schema.etag = cls._schema_network_security_group_read.etag
-            _schema.id = cls._schema_network_security_group_read.id
-            _schema.location = cls._schema_network_security_group_read.location
-            _schema.name = cls._schema_network_security_group_read.name
-            _schema.properties = cls._schema_network_security_group_read.properties
-            _schema.tags = cls._schema_network_security_group_read.tags
-            _schema.type = cls._schema_network_security_group_read.type
+    def _build_schema_common_network_security_group_read(cls, _schema):
+        if cls._schema_common_network_security_group_read is not None:
+            _schema.etag = cls._schema_common_network_security_group_read.etag
+            _schema.id = cls._schema_common_network_security_group_read.id
+            _schema.location = cls._schema_common_network_security_group_read.location
+            _schema.name = cls._schema_common_network_security_group_read.name
+            _schema.properties = cls._schema_common_network_security_group_read.properties
+            _schema.tags = cls._schema_common_network_security_group_read.tags
+            _schema.type = cls._schema_common_network_security_group_read.type
             return
 
-        cls._schema_network_security_group_read = _schema_network_security_group_read = AAZObjectType()
+        cls._schema_common_network_security_group_read = _schema_common_network_security_group_read = AAZObjectType()
 
-        network_security_group_read = _schema_network_security_group_read
-        network_security_group_read.etag = AAZStrType(
+        common_network_security_group_read = _schema_common_network_security_group_read
+        common_network_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.id = AAZStrType()
-        network_security_group_read.location = AAZStrType()
-        network_security_group_read.name = AAZStrType(
+        common_network_security_group_read.id = AAZStrType()
+        common_network_security_group_read.location = AAZStrType()
+        common_network_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.properties = AAZObjectType(
+        common_network_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_security_group_read.tags = AAZDictType()
-        network_security_group_read.type = AAZStrType(
+        common_network_security_group_read.tags = AAZDictType()
+        common_network_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties
+        properties = _schema_common_network_security_group_read.properties
         properties.default_security_rules = AAZListType(
             serialized_name="defaultSecurityRules",
             flags={"read_only": True},
@@ -1941,14 +1994,14 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        default_security_rules = _schema_network_security_group_read.properties.default_security_rules
+        default_security_rules = _schema_common_network_security_group_read.properties.default_security_rules
         default_security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(default_security_rules.Element)
+        cls._build_schema_common_security_rule_read(default_security_rules.Element)
 
-        flow_logs = _schema_network_security_group_read.properties.flow_logs
+        flow_logs = _schema_common_network_security_group_read.properties.flow_logs
         flow_logs.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1966,7 +2019,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        identity = _schema_network_security_group_read.properties.flow_logs.Element.identity
+        identity = _schema_common_network_security_group_read.properties.flow_logs.Element.identity
         identity.principal_id = AAZStrType(
             serialized_name="principalId",
             flags={"read_only": True},
@@ -1980,10 +2033,10 @@ class _UpdateHelper:
             serialized_name="userAssignedIdentities",
         )
 
-        user_assigned_identities = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
+        user_assigned_identities = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
         user_assigned_identities.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
         _element.client_id = AAZStrType(
             serialized_name="clientId",
             flags={"read_only": True},
@@ -1993,7 +2046,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties.flow_logs.Element.properties
+        properties = _schema_common_network_security_group_read.properties.flow_logs.Element.properties
         properties.enabled = AAZBoolType()
         properties.enabled_filtering_criteria = AAZStrType(
             serialized_name="enabledFilteringCriteria",
@@ -2005,6 +2058,9 @@ class _UpdateHelper:
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
+        )
+        properties.record_types = AAZStrType(
+            serialized_name="recordTypes",
         )
         properties.retention_policy = AAZObjectType(
             serialized_name="retentionPolicy",
@@ -2022,12 +2078,12 @@ class _UpdateHelper:
             flags={"required": True},
         )
 
-        flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
+        flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
         flow_analytics_configuration.network_watcher_flow_analytics_configuration = AAZObjectType(
             serialized_name="networkWatcherFlowAnalyticsConfiguration",
         )
 
-        network_watcher_flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
+        network_watcher_flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
         network_watcher_flow_analytics_configuration.enabled = AAZBoolType()
         network_watcher_flow_analytics_configuration.traffic_analytics_interval = AAZIntType(
             serialized_name="trafficAnalyticsInterval",
@@ -2042,83 +2098,86 @@ class _UpdateHelper:
             serialized_name="workspaceResourceId",
         )
 
-        format = _schema_network_security_group_read.properties.flow_logs.Element.properties.format
+        format = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.format
         format.type = AAZStrType()
         format.version = AAZIntType()
 
-        retention_policy = _schema_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
+        retention_policy = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
         retention_policy.days = AAZIntType()
         retention_policy.enabled = AAZBoolType()
 
-        tags = _schema_network_security_group_read.properties.flow_logs.Element.tags
+        tags = _schema_common_network_security_group_read.properties.flow_logs.Element.tags
         tags.Element = AAZStrType()
 
-        network_interfaces = _schema_network_security_group_read.properties.network_interfaces
+        network_interfaces = _schema_common_network_security_group_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        security_rules = _schema_network_security_group_read.properties.security_rules
+        security_rules = _schema_common_network_security_group_read.properties.security_rules
         security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(security_rules.Element)
+        cls._build_schema_common_security_rule_read(security_rules.Element)
 
-        subnets = _schema_network_security_group_read.properties.subnets
+        subnets = _schema_common_network_security_group_read.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_network_security_group_read.tags
+        tags = _schema_common_network_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_security_group_read.etag
-        _schema.id = cls._schema_network_security_group_read.id
-        _schema.location = cls._schema_network_security_group_read.location
-        _schema.name = cls._schema_network_security_group_read.name
-        _schema.properties = cls._schema_network_security_group_read.properties
-        _schema.tags = cls._schema_network_security_group_read.tags
-        _schema.type = cls._schema_network_security_group_read.type
+        _schema.etag = cls._schema_common_network_security_group_read.etag
+        _schema.id = cls._schema_common_network_security_group_read.id
+        _schema.location = cls._schema_common_network_security_group_read.location
+        _schema.name = cls._schema_common_network_security_group_read.name
+        _schema.properties = cls._schema_common_network_security_group_read.properties
+        _schema.tags = cls._schema_common_network_security_group_read.tags
+        _schema.type = cls._schema_common_network_security_group_read.type
 
-    _schema_private_endpoint_read = None
+    _schema_common_private_endpoint_read = None
 
     @classmethod
-    def _build_schema_private_endpoint_read(cls, _schema):
-        if cls._schema_private_endpoint_read is not None:
-            _schema.etag = cls._schema_private_endpoint_read.etag
-            _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-            _schema.id = cls._schema_private_endpoint_read.id
-            _schema.location = cls._schema_private_endpoint_read.location
-            _schema.name = cls._schema_private_endpoint_read.name
-            _schema.properties = cls._schema_private_endpoint_read.properties
-            _schema.tags = cls._schema_private_endpoint_read.tags
-            _schema.type = cls._schema_private_endpoint_read.type
+    def _build_schema_common_private_endpoint_read(cls, _schema):
+        if cls._schema_common_private_endpoint_read is not None:
+            _schema.etag = cls._schema_common_private_endpoint_read.etag
+            _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+            _schema.id = cls._schema_common_private_endpoint_read.id
+            _schema.location = cls._schema_common_private_endpoint_read.location
+            _schema.name = cls._schema_common_private_endpoint_read.name
+            _schema.properties = cls._schema_common_private_endpoint_read.properties
+            _schema.tags = cls._schema_common_private_endpoint_read.tags
+            _schema.type = cls._schema_common_private_endpoint_read.type
             return
 
-        cls._schema_private_endpoint_read = _schema_private_endpoint_read = AAZObjectType(
+        cls._schema_common_private_endpoint_read = _schema_common_private_endpoint_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        private_endpoint_read = _schema_private_endpoint_read
-        private_endpoint_read.etag = AAZStrType(
+        common_private_endpoint_read = _schema_common_private_endpoint_read
+        common_private_endpoint_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.extended_location = AAZObjectType(
+        common_private_endpoint_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_endpoint_read.extended_location)
-        private_endpoint_read.id = AAZStrType()
-        private_endpoint_read.location = AAZStrType()
-        private_endpoint_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_private_endpoint_read.extended_location)
+        common_private_endpoint_read.id = AAZStrType()
+        common_private_endpoint_read.location = AAZStrType()
+        common_private_endpoint_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.properties = AAZObjectType(
+        common_private_endpoint_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_endpoint_read.tags = AAZDictType()
-        private_endpoint_read.type = AAZStrType(
+        common_private_endpoint_read.tags = AAZDictType()
+        common_private_endpoint_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties
+        properties = _schema_common_private_endpoint_read.properties
         properties.application_security_groups = AAZListType(
             serialized_name="applicationSecurityGroups",
+        )
+        properties.billing_sku = AAZStrType(
+            serialized_name="billingSku",
         )
         properties.custom_dns_configs = AAZListType(
             serialized_name="customDnsConfigs",
@@ -2128,6 +2187,9 @@ class _UpdateHelper:
         )
         properties.ip_configurations = AAZListType(
             serialized_name="ipConfigurations",
+        )
+        properties.ip_version_type = AAZStrType(
+            serialized_name="ipVersionType",
         )
         properties.manual_private_link_service_connections = AAZListType(
             serialized_name="manualPrivateLinkServiceConnections",
@@ -2144,28 +2206,28 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        application_security_groups = _schema_private_endpoint_read.properties.application_security_groups
+        application_security_groups = _schema_common_private_endpoint_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        custom_dns_configs = _schema_private_endpoint_read.properties.custom_dns_configs
+        custom_dns_configs = _schema_common_private_endpoint_read.properties.custom_dns_configs
         custom_dns_configs.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.custom_dns_configs.Element
+        _element = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element
         _element.fqdn = AAZStrType()
         _element.ip_addresses = AAZListType(
             serialized_name="ipAddresses",
         )
 
-        ip_addresses = _schema_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
+        ip_addresses = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
         ip_addresses.Element = AAZStrType()
 
-        ip_configurations = _schema_private_endpoint_read.properties.ip_configurations
+        ip_configurations = _schema_common_private_endpoint_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.ip_configurations.Element
+        _element = _schema_common_private_endpoint_read.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2177,7 +2239,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties.ip_configurations.Element.properties
+        properties = _schema_common_private_endpoint_read.properties.ip_configurations.Element.properties
         properties.group_id = AAZStrType(
             serialized_name="groupId",
         )
@@ -2188,88 +2250,88 @@ class _UpdateHelper:
             serialized_name="privateIPAddress",
         )
 
-        manual_private_link_service_connections = _schema_private_endpoint_read.properties.manual_private_link_service_connections
+        manual_private_link_service_connections = _schema_common_private_endpoint_read.properties.manual_private_link_service_connections
         manual_private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(manual_private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(manual_private_link_service_connections.Element)
 
-        network_interfaces = _schema_private_endpoint_read.properties.network_interfaces
+        network_interfaces = _schema_common_private_endpoint_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_link_service_connections = _schema_private_endpoint_read.properties.private_link_service_connections
+        private_link_service_connections = _schema_common_private_endpoint_read.properties.private_link_service_connections
         private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(private_link_service_connections.Element)
 
-        tags = _schema_private_endpoint_read.tags
+        tags = _schema_common_private_endpoint_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_endpoint_read.etag
-        _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-        _schema.id = cls._schema_private_endpoint_read.id
-        _schema.location = cls._schema_private_endpoint_read.location
-        _schema.name = cls._schema_private_endpoint_read.name
-        _schema.properties = cls._schema_private_endpoint_read.properties
-        _schema.tags = cls._schema_private_endpoint_read.tags
-        _schema.type = cls._schema_private_endpoint_read.type
+        _schema.etag = cls._schema_common_private_endpoint_read.etag
+        _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+        _schema.id = cls._schema_common_private_endpoint_read.id
+        _schema.location = cls._schema_common_private_endpoint_read.location
+        _schema.name = cls._schema_common_private_endpoint_read.name
+        _schema.properties = cls._schema_common_private_endpoint_read.properties
+        _schema.tags = cls._schema_common_private_endpoint_read.tags
+        _schema.type = cls._schema_common_private_endpoint_read.type
 
-    _schema_private_link_service_connection_state_read = None
+    _schema_common_private_link_service_connection_state_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_state_read(cls, _schema):
-        if cls._schema_private_link_service_connection_state_read is not None:
-            _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-            _schema.description = cls._schema_private_link_service_connection_state_read.description
-            _schema.status = cls._schema_private_link_service_connection_state_read.status
+    def _build_schema_common_private_link_service_connection_state_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_state_read is not None:
+            _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+            _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+            _schema.status = cls._schema_common_private_link_service_connection_state_read.status
             return
 
-        cls._schema_private_link_service_connection_state_read = _schema_private_link_service_connection_state_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read = AAZObjectType()
 
-        private_link_service_connection_state_read = _schema_private_link_service_connection_state_read
-        private_link_service_connection_state_read.actions_required = AAZStrType(
+        common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read
+        common_private_link_service_connection_state_read.actions_required = AAZStrType(
             serialized_name="actionsRequired",
         )
-        private_link_service_connection_state_read.description = AAZStrType()
-        private_link_service_connection_state_read.status = AAZStrType()
+        common_private_link_service_connection_state_read.description = AAZStrType()
+        common_private_link_service_connection_state_read.status = AAZStrType()
 
-        _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-        _schema.description = cls._schema_private_link_service_connection_state_read.description
-        _schema.status = cls._schema_private_link_service_connection_state_read.status
+        _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+        _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+        _schema.status = cls._schema_common_private_link_service_connection_state_read.status
 
-    _schema_private_link_service_connection_read = None
+    _schema_common_private_link_service_connection_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_read(cls, _schema):
-        if cls._schema_private_link_service_connection_read is not None:
-            _schema.etag = cls._schema_private_link_service_connection_read.etag
-            _schema.id = cls._schema_private_link_service_connection_read.id
-            _schema.name = cls._schema_private_link_service_connection_read.name
-            _schema.properties = cls._schema_private_link_service_connection_read.properties
-            _schema.type = cls._schema_private_link_service_connection_read.type
+    def _build_schema_common_private_link_service_connection_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_read is not None:
+            _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+            _schema.id = cls._schema_common_private_link_service_connection_read.id
+            _schema.name = cls._schema_common_private_link_service_connection_read.name
+            _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+            _schema.type = cls._schema_common_private_link_service_connection_read.type
             return
 
-        cls._schema_private_link_service_connection_read = _schema_private_link_service_connection_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_read = _schema_common_private_link_service_connection_read = AAZObjectType()
 
-        private_link_service_connection_read = _schema_private_link_service_connection_read
-        private_link_service_connection_read.etag = AAZStrType(
+        common_private_link_service_connection_read = _schema_common_private_link_service_connection_read
+        common_private_link_service_connection_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_link_service_connection_read.id = AAZStrType()
-        private_link_service_connection_read.name = AAZStrType()
-        private_link_service_connection_read.properties = AAZObjectType(
+        common_private_link_service_connection_read.id = AAZStrType()
+        common_private_link_service_connection_read.name = AAZStrType()
+        common_private_link_service_connection_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_link_service_connection_read.type = AAZStrType(
+        common_private_link_service_connection_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_link_service_connection_read.properties
+        properties = _schema_common_private_link_service_connection_read.properties
         properties.group_ids = AAZListType(
             serialized_name="groupIds",
         )
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.private_link_service_id = AAZStrType(
             serialized_name="privateLinkServiceId",
         )
@@ -2281,58 +2343,58 @@ class _UpdateHelper:
             serialized_name="requestMessage",
         )
 
-        group_ids = _schema_private_link_service_connection_read.properties.group_ids
+        group_ids = _schema_common_private_link_service_connection_read.properties.group_ids
         group_ids.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_link_service_connection_read.etag
-        _schema.id = cls._schema_private_link_service_connection_read.id
-        _schema.name = cls._schema_private_link_service_connection_read.name
-        _schema.properties = cls._schema_private_link_service_connection_read.properties
-        _schema.type = cls._schema_private_link_service_connection_read.type
+        _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+        _schema.id = cls._schema_common_private_link_service_connection_read.id
+        _schema.name = cls._schema_common_private_link_service_connection_read.name
+        _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+        _schema.type = cls._schema_common_private_link_service_connection_read.type
 
-    _schema_public_ip_address_read = None
+    _schema_common_public_ip_address_read = None
 
     @classmethod
-    def _build_schema_public_ip_address_read(cls, _schema):
-        if cls._schema_public_ip_address_read is not None:
-            _schema.etag = cls._schema_public_ip_address_read.etag
-            _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-            _schema.id = cls._schema_public_ip_address_read.id
-            _schema.location = cls._schema_public_ip_address_read.location
-            _schema.name = cls._schema_public_ip_address_read.name
-            _schema.properties = cls._schema_public_ip_address_read.properties
-            _schema.sku = cls._schema_public_ip_address_read.sku
-            _schema.tags = cls._schema_public_ip_address_read.tags
-            _schema.type = cls._schema_public_ip_address_read.type
-            _schema.zones = cls._schema_public_ip_address_read.zones
+    def _build_schema_common_public_ip_address_read(cls, _schema):
+        if cls._schema_common_public_ip_address_read is not None:
+            _schema.etag = cls._schema_common_public_ip_address_read.etag
+            _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+            _schema.id = cls._schema_common_public_ip_address_read.id
+            _schema.location = cls._schema_common_public_ip_address_read.location
+            _schema.name = cls._schema_common_public_ip_address_read.name
+            _schema.properties = cls._schema_common_public_ip_address_read.properties
+            _schema.sku = cls._schema_common_public_ip_address_read.sku
+            _schema.tags = cls._schema_common_public_ip_address_read.tags
+            _schema.type = cls._schema_common_public_ip_address_read.type
+            _schema.zones = cls._schema_common_public_ip_address_read.zones
             return
 
-        cls._schema_public_ip_address_read = _schema_public_ip_address_read = AAZObjectType()
+        cls._schema_common_public_ip_address_read = _schema_common_public_ip_address_read = AAZObjectType()
 
-        public_ip_address_read = _schema_public_ip_address_read
-        public_ip_address_read.etag = AAZStrType(
+        common_public_ip_address_read = _schema_common_public_ip_address_read
+        common_public_ip_address_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.extended_location = AAZObjectType(
+        common_public_ip_address_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(public_ip_address_read.extended_location)
-        public_ip_address_read.id = AAZStrType()
-        public_ip_address_read.location = AAZStrType()
-        public_ip_address_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_public_ip_address_read.extended_location)
+        common_public_ip_address_read.id = AAZStrType()
+        common_public_ip_address_read.location = AAZStrType()
+        common_public_ip_address_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.properties = AAZObjectType(
+        common_public_ip_address_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        public_ip_address_read.sku = AAZObjectType()
-        public_ip_address_read.tags = AAZDictType()
-        public_ip_address_read.type = AAZStrType(
+        common_public_ip_address_read.sku = AAZObjectType()
+        common_public_ip_address_read.tags = AAZDictType()
+        common_public_ip_address_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.zones = AAZListType()
+        common_public_ip_address_read.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties
+        properties = _schema_common_public_ip_address_read.properties
         properties.ddos_settings = AAZObjectType(
             serialized_name="ddosSettings",
         )
@@ -2352,14 +2414,14 @@ class _UpdateHelper:
             serialized_name="ipConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_ip_configuration_read(properties.ip_configuration)
+        cls._build_schema_common_ip_configuration_read(properties.ip_configuration)
         properties.ip_tags = AAZListType(
             serialized_name="ipTags",
         )
         properties.linked_public_ip_address = AAZObjectType(
             serialized_name="linkedPublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.linked_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.linked_public_ip_address)
         properties.migration_phase = AAZStrType(
             serialized_name="migrationPhase",
         )
@@ -2379,7 +2441,7 @@ class _UpdateHelper:
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.resource_guid = AAZStrType(
             serialized_name="resourceGuid",
             flags={"read_only": True},
@@ -2387,18 +2449,22 @@ class _UpdateHelper:
         properties.service_public_ip_address = AAZObjectType(
             serialized_name="servicePublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.service_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.service_public_ip_address)
 
-        ddos_settings = _schema_public_ip_address_read.properties.ddos_settings
+        ddos_settings = _schema_common_public_ip_address_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
         ddos_settings.ddos_protection_plan = AAZObjectType(
             serialized_name="ddosProtectionPlan",
         )
-        cls._build_schema_sub_resource_read(ddos_settings.ddos_protection_plan)
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_protection_plan)
         ddos_settings.protection_mode = AAZStrType(
             serialized_name="protectionMode",
         )
 
-        dns_settings = _schema_public_ip_address_read.properties.dns_settings
+        dns_settings = _schema_common_public_ip_address_read.properties.dns_settings
         dns_settings.domain_name_label = AAZStrType(
             serialized_name="domainNameLabel",
         )
@@ -2410,16 +2476,16 @@ class _UpdateHelper:
             serialized_name="reverseFqdn",
         )
 
-        ip_tags = _schema_public_ip_address_read.properties.ip_tags
+        ip_tags = _schema_common_public_ip_address_read.properties.ip_tags
         ip_tags.Element = AAZObjectType()
 
-        _element = _schema_public_ip_address_read.properties.ip_tags.Element
+        _element = _schema_common_public_ip_address_read.properties.ip_tags.Element
         _element.ip_tag_type = AAZStrType(
             serialized_name="ipTagType",
         )
         _element.tag = AAZStrType()
 
-        nat_gateway = _schema_public_ip_address_read.properties.nat_gateway
+        nat_gateway = _schema_common_public_ip_address_read.properties.nat_gateway
         nat_gateway.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2438,10 +2504,11 @@ class _UpdateHelper:
         )
         nat_gateway.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties.nat_gateway.properties
+        properties = _schema_common_public_ip_address_read.properties.nat_gateway.properties
         properties.idle_timeout_in_minutes = AAZIntType(
             serialized_name="idleTimeoutInMinutes",
         )
+        properties.nat64 = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -2462,90 +2529,96 @@ class _UpdateHelper:
             serialized_name="resourceGuid",
             flags={"read_only": True},
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.source_virtual_network = AAZObjectType(
             serialized_name="sourceVirtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.source_virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.source_virtual_network)
         properties.subnets = AAZListType(
             flags={"read_only": True},
         )
 
-        public_ip_addresses = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
+        public_ip_addresses = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
         public_ip_addresses.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
+        public_ip_addresses_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
+        public_ip_prefixes = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
-        subnets = _schema_public_ip_address_read.properties.nat_gateway.properties.subnets
+        subnets = _schema_common_public_ip_address_read.properties.nat_gateway.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(subnets.Element)
+        cls._build_schema_common_sub_resource_read(subnets.Element)
 
-        sku = _schema_public_ip_address_read.properties.nat_gateway.sku
+        sku = _schema_common_public_ip_address_read.properties.nat_gateway.sku
         sku.name = AAZStrType()
 
-        tags = _schema_public_ip_address_read.properties.nat_gateway.tags
+        tags = _schema_common_public_ip_address_read.properties.nat_gateway.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.properties.nat_gateway.zones
+        zones = _schema_common_public_ip_address_read.properties.nat_gateway.zones
         zones.Element = AAZStrType()
 
-        sku = _schema_public_ip_address_read.sku
+        sku = _schema_common_public_ip_address_read.sku
         sku.name = AAZStrType()
         sku.tier = AAZStrType()
 
-        tags = _schema_public_ip_address_read.tags
+        tags = _schema_common_public_ip_address_read.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.zones
+        zones = _schema_common_public_ip_address_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_public_ip_address_read.etag
-        _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-        _schema.id = cls._schema_public_ip_address_read.id
-        _schema.location = cls._schema_public_ip_address_read.location
-        _schema.name = cls._schema_public_ip_address_read.name
-        _schema.properties = cls._schema_public_ip_address_read.properties
-        _schema.sku = cls._schema_public_ip_address_read.sku
-        _schema.tags = cls._schema_public_ip_address_read.tags
-        _schema.type = cls._schema_public_ip_address_read.type
-        _schema.zones = cls._schema_public_ip_address_read.zones
+        _schema.etag = cls._schema_common_public_ip_address_read.etag
+        _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+        _schema.id = cls._schema_common_public_ip_address_read.id
+        _schema.location = cls._schema_common_public_ip_address_read.location
+        _schema.name = cls._schema_common_public_ip_address_read.name
+        _schema.properties = cls._schema_common_public_ip_address_read.properties
+        _schema.sku = cls._schema_common_public_ip_address_read.sku
+        _schema.tags = cls._schema_common_public_ip_address_read.tags
+        _schema.type = cls._schema_common_public_ip_address_read.type
+        _schema.zones = cls._schema_common_public_ip_address_read.zones
 
-    _schema_security_rule_read = None
+    _schema_common_security_rule_read = None
 
     @classmethod
-    def _build_schema_security_rule_read(cls, _schema):
-        if cls._schema_security_rule_read is not None:
-            _schema.etag = cls._schema_security_rule_read.etag
-            _schema.id = cls._schema_security_rule_read.id
-            _schema.name = cls._schema_security_rule_read.name
-            _schema.properties = cls._schema_security_rule_read.properties
-            _schema.type = cls._schema_security_rule_read.type
+    def _build_schema_common_security_rule_read(cls, _schema):
+        if cls._schema_common_security_rule_read is not None:
+            _schema.etag = cls._schema_common_security_rule_read.etag
+            _schema.id = cls._schema_common_security_rule_read.id
+            _schema.name = cls._schema_common_security_rule_read.name
+            _schema.properties = cls._schema_common_security_rule_read.properties
+            _schema.type = cls._schema_common_security_rule_read.type
             return
 
-        cls._schema_security_rule_read = _schema_security_rule_read = AAZObjectType()
+        cls._schema_common_security_rule_read = _schema_common_security_rule_read = AAZObjectType()
 
-        security_rule_read = _schema_security_rule_read
-        security_rule_read.etag = AAZStrType(
+        common_security_rule_read = _schema_common_security_rule_read
+        common_security_rule_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        security_rule_read.id = AAZStrType()
-        security_rule_read.name = AAZStrType()
-        security_rule_read.properties = AAZObjectType(
+        common_security_rule_read.id = AAZStrType()
+        common_security_rule_read.name = AAZStrType()
+        common_security_rule_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        security_rule_read.type = AAZStrType()
+        common_security_rule_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_security_rule_read.properties
+        properties = _schema_common_security_rule_read.properties
         properties.access = AAZStrType(
             flags={"required": True},
         )
@@ -2594,75 +2667,77 @@ class _UpdateHelper:
             serialized_name="sourcePortRanges",
         )
 
-        destination_address_prefixes = _schema_security_rule_read.properties.destination_address_prefixes
+        destination_address_prefixes = _schema_common_security_rule_read.properties.destination_address_prefixes
         destination_address_prefixes.Element = AAZStrType()
 
-        destination_application_security_groups = _schema_security_rule_read.properties.destination_application_security_groups
+        destination_application_security_groups = _schema_common_security_rule_read.properties.destination_application_security_groups
         destination_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(destination_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(destination_application_security_groups.Element)
 
-        destination_port_ranges = _schema_security_rule_read.properties.destination_port_ranges
+        destination_port_ranges = _schema_common_security_rule_read.properties.destination_port_ranges
         destination_port_ranges.Element = AAZStrType()
 
-        source_address_prefixes = _schema_security_rule_read.properties.source_address_prefixes
+        source_address_prefixes = _schema_common_security_rule_read.properties.source_address_prefixes
         source_address_prefixes.Element = AAZStrType()
 
-        source_application_security_groups = _schema_security_rule_read.properties.source_application_security_groups
+        source_application_security_groups = _schema_common_security_rule_read.properties.source_application_security_groups
         source_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(source_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(source_application_security_groups.Element)
 
-        source_port_ranges = _schema_security_rule_read.properties.source_port_ranges
+        source_port_ranges = _schema_common_security_rule_read.properties.source_port_ranges
         source_port_ranges.Element = AAZStrType()
 
-        _schema.etag = cls._schema_security_rule_read.etag
-        _schema.id = cls._schema_security_rule_read.id
-        _schema.name = cls._schema_security_rule_read.name
-        _schema.properties = cls._schema_security_rule_read.properties
-        _schema.type = cls._schema_security_rule_read.type
+        _schema.etag = cls._schema_common_security_rule_read.etag
+        _schema.id = cls._schema_common_security_rule_read.id
+        _schema.name = cls._schema_common_security_rule_read.name
+        _schema.properties = cls._schema_common_security_rule_read.properties
+        _schema.type = cls._schema_common_security_rule_read.type
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType(
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
-    _schema_subnet_read = None
+    _schema_common_subnet_read = None
 
     @classmethod
-    def _build_schema_subnet_read(cls, _schema):
-        if cls._schema_subnet_read is not None:
-            _schema.etag = cls._schema_subnet_read.etag
-            _schema.id = cls._schema_subnet_read.id
-            _schema.name = cls._schema_subnet_read.name
-            _schema.properties = cls._schema_subnet_read.properties
-            _schema.type = cls._schema_subnet_read.type
+    def _build_schema_common_subnet_read(cls, _schema):
+        if cls._schema_common_subnet_read is not None:
+            _schema.etag = cls._schema_common_subnet_read.etag
+            _schema.id = cls._schema_common_subnet_read.id
+            _schema.name = cls._schema_common_subnet_read.name
+            _schema.properties = cls._schema_common_subnet_read.properties
+            _schema.type = cls._schema_common_subnet_read.type
             return
 
-        cls._schema_subnet_read = _schema_subnet_read = AAZObjectType()
+        cls._schema_common_subnet_read = _schema_common_subnet_read = AAZObjectType()
 
-        subnet_read = _schema_subnet_read
-        subnet_read.etag = AAZStrType(
+        common_subnet_read = _schema_common_subnet_read
+        common_subnet_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        subnet_read.id = AAZStrType()
-        subnet_read.name = AAZStrType()
-        subnet_read.properties = AAZObjectType(
+        common_subnet_read.id = AAZStrType()
+        common_subnet_read.name = AAZStrType()
+        common_subnet_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        subnet_read.type = AAZStrType()
+        common_subnet_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties
+        properties = _schema_common_subnet_read.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
@@ -2693,11 +2768,11 @@ class _UpdateHelper:
         properties.nat_gateway = AAZObjectType(
             serialized_name="natGateway",
         )
-        cls._build_schema_sub_resource_read(properties.nat_gateway)
+        cls._build_schema_common_sub_resource_read(properties.nat_gateway)
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.private_endpoint_network_policies = AAZStrType(
             serialized_name="privateEndpointNetworkPolicies",
         )
@@ -2732,17 +2807,21 @@ class _UpdateHelper:
         properties.service_endpoints = AAZListType(
             serialized_name="serviceEndpoints",
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.sharing_scope = AAZStrType(
             serialized_name="sharingScope",
         )
 
-        address_prefixes = _schema_subnet_read.properties.address_prefixes
+        address_prefixes = _schema_common_subnet_read.properties.address_prefixes
         address_prefixes.Element = AAZStrType()
 
-        application_gateway_ip_configurations = _schema_subnet_read.properties.application_gateway_ip_configurations
+        application_gateway_ip_configurations = _schema_common_subnet_read.properties.application_gateway_ip_configurations
         application_gateway_ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.application_gateway_ip_configurations.Element
+        _element = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2755,18 +2834,18 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.application_gateway_ip_configurations.Element.properties
+        properties = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
 
-        delegations = _schema_subnet_read.properties.delegations
+        delegations = _schema_common_subnet_read.properties.delegations
         delegations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.delegations.Element
+        _element = _schema_common_subnet_read.properties.delegations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2777,7 +2856,7 @@ class _UpdateHelper:
         )
         _element.type = AAZStrType()
 
-        properties = _schema_subnet_read.properties.delegations.Element.properties
+        properties = _schema_common_subnet_read.properties.delegations.Element.properties
         properties.actions = AAZListType(
             flags={"read_only": True},
         )
@@ -2789,17 +2868,17 @@ class _UpdateHelper:
             serialized_name="serviceName",
         )
 
-        actions = _schema_subnet_read.properties.delegations.Element.properties.actions
+        actions = _schema_common_subnet_read.properties.delegations.Element.properties.actions
         actions.Element = AAZStrType()
 
-        ip_allocations = _schema_subnet_read.properties.ip_allocations
+        ip_allocations = _schema_common_subnet_read.properties.ip_allocations
         ip_allocations.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(ip_allocations.Element)
+        cls._build_schema_common_sub_resource_read(ip_allocations.Element)
 
-        ip_configuration_profiles = _schema_subnet_read.properties.ip_configuration_profiles
+        ip_configuration_profiles = _schema_common_subnet_read.properties.ip_configuration_profiles
         ip_configuration_profiles.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ip_configuration_profiles.Element
+        _element = _schema_common_subnet_read.properties.ip_configuration_profiles.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2812,22 +2891,22 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.ip_configuration_profiles.Element.properties
+        properties = _schema_common_subnet_read.properties.ip_configuration_profiles.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        ip_configurations = _schema_subnet_read.properties.ip_configurations
+        ip_configurations = _schema_common_subnet_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_ip_configuration_read(ip_configurations.Element)
 
-        ipam_pool_prefix_allocations = _schema_subnet_read.properties.ipam_pool_prefix_allocations
+        ipam_pool_prefix_allocations = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations
         ipam_pool_prefix_allocations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element
+        _element = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element
         _element.allocated_address_prefixes = AAZListType(
             serialized_name="allocatedAddressPrefixes",
             flags={"read_only": True},
@@ -2839,20 +2918,20 @@ class _UpdateHelper:
             flags={"client_flatten": True},
         )
 
-        allocated_address_prefixes = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
+        allocated_address_prefixes = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
         allocated_address_prefixes.Element = AAZStrType()
 
-        pool = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
+        pool = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
         pool.id = AAZStrType()
 
-        private_endpoints = _schema_subnet_read.properties.private_endpoints
+        private_endpoints = _schema_common_subnet_read.properties.private_endpoints
         private_endpoints.Element = AAZObjectType()
-        cls._build_schema_private_endpoint_read(private_endpoints.Element)
+        cls._build_schema_common_private_endpoint_read(private_endpoints.Element)
 
-        resource_navigation_links = _schema_subnet_read.properties.resource_navigation_links
+        resource_navigation_links = _schema_common_subnet_read.properties.resource_navigation_links
         resource_navigation_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.resource_navigation_links.Element
+        _element = _schema_common_subnet_read.properties.resource_navigation_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2867,7 +2946,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.resource_navigation_links.Element.properties
+        properties = _schema_common_subnet_read.properties.resource_navigation_links.Element.properties
         properties.link = AAZStrType()
         properties.linked_resource_type = AAZStrType(
             serialized_name="linkedResourceType",
@@ -2877,7 +2956,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        route_table = _schema_subnet_read.properties.route_table
+        route_table = _schema_common_subnet_read.properties.route_table
         route_table.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2894,9 +2973,12 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.route_table.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties
         properties.disable_bgp_route_propagation = AAZBoolType(
             serialized_name="disableBgpRoutePropagation",
+        )
+        properties.disable_peering_route = AAZStrType(
+            serialized_name="disablePeeringRoute",
         )
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2911,10 +2993,10 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        routes = _schema_subnet_read.properties.route_table.properties.routes
+        routes = _schema_common_subnet_read.properties.route_table.properties.routes
         routes.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.route_table.properties.routes.Element
+        _element = _schema_common_subnet_read.properties.route_table.properties.routes.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2923,15 +3005,20 @@ class _UpdateHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.route_table.properties.routes.Element.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
         properties.has_bgp_override = AAZBoolType(
             serialized_name="hasBgpOverride",
             flags={"read_only": True},
+        )
+        properties.next_hop = AAZObjectType(
+            serialized_name="nextHop",
         )
         properties.next_hop_ip_address = AAZStrType(
             serialized_name="nextHopIpAddress",
@@ -2945,17 +3032,26 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        subnets = _schema_subnet_read.properties.route_table.properties.subnets
-        subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        next_hop = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop
+        next_hop.next_hop_ip_addresses = AAZListType(
+            serialized_name="nextHopIpAddresses",
+            flags={"required": True},
+        )
 
-        tags = _schema_subnet_read.properties.route_table.tags
+        next_hop_ip_addresses = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop.next_hop_ip_addresses
+        next_hop_ip_addresses.Element = AAZStrType()
+
+        subnets = _schema_common_subnet_read.properties.route_table.properties.subnets
+        subnets.Element = AAZObjectType()
+        cls._build_schema_common_subnet_read(subnets.Element)
+
+        tags = _schema_common_subnet_read.properties.route_table.tags
         tags.Element = AAZStrType()
 
-        service_association_links = _schema_subnet_read.properties.service_association_links
+        service_association_links = _schema_common_subnet_read.properties.service_association_links
         service_association_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_association_links.Element
+        _element = _schema_common_subnet_read.properties.service_association_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2968,7 +3064,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_association_links.Element.properties
+        properties = _schema_common_subnet_read.properties.service_association_links.Element.properties
         properties.allow_delete = AAZBoolType(
             serialized_name="allowDelete",
         )
@@ -2982,13 +3078,13 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        locations = _schema_subnet_read.properties.service_association_links.Element.properties.locations
+        locations = _schema_common_subnet_read.properties.service_association_links.Element.properties.locations
         locations.Element = AAZStrType()
 
-        service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies
+        service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies
         service_endpoint_policies.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -3008,7 +3104,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties
         properties.contextual_service_endpoint_policies = AAZListType(
             serialized_name="contextualServiceEndpointPolicies",
         )
@@ -3030,13 +3126,13 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        contextual_service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
+        contextual_service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
         contextual_service_endpoint_policies.Element = AAZStrType()
 
-        service_endpoint_policy_definitions = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
+        service_endpoint_policy_definitions = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
         service_endpoint_policy_definitions.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -3045,9 +3141,11 @@ class _UpdateHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
         properties.description = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -3058,82 +3156,82 @@ class _UpdateHelper:
             serialized_name="serviceResources",
         )
 
-        service_resources = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
+        service_resources = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
         service_resources.Element = AAZStrType()
 
-        subnets = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
+        subnets = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_subnet_read.properties.service_endpoint_policies.Element.tags
+        tags = _schema_common_subnet_read.properties.service_endpoint_policies.Element.tags
         tags.Element = AAZStrType()
 
-        service_endpoints = _schema_subnet_read.properties.service_endpoints
+        service_endpoints = _schema_common_subnet_read.properties.service_endpoints
         service_endpoints.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoints.Element
+        _element = _schema_common_subnet_read.properties.service_endpoints.Element
         _element.locations = AAZListType()
         _element.network_identifier = AAZObjectType(
             serialized_name="networkIdentifier",
         )
-        cls._build_schema_sub_resource_read(_element.network_identifier)
+        cls._build_schema_common_sub_resource_read(_element.network_identifier)
         _element.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         _element.service = AAZStrType()
 
-        locations = _schema_subnet_read.properties.service_endpoints.Element.locations
+        locations = _schema_common_subnet_read.properties.service_endpoints.Element.locations
         locations.Element = AAZStrType()
 
-        _schema.etag = cls._schema_subnet_read.etag
-        _schema.id = cls._schema_subnet_read.id
-        _schema.name = cls._schema_subnet_read.name
-        _schema.properties = cls._schema_subnet_read.properties
-        _schema.type = cls._schema_subnet_read.type
+        _schema.etag = cls._schema_common_subnet_read.etag
+        _schema.id = cls._schema_common_subnet_read.id
+        _schema.name = cls._schema_common_subnet_read.name
+        _schema.properties = cls._schema_common_subnet_read.properties
+        _schema.type = cls._schema_common_subnet_read.type
 
-    _schema_virtual_network_tap_read = None
+    _schema_common_virtual_network_tap_read = None
 
     @classmethod
-    def _build_schema_virtual_network_tap_read(cls, _schema):
-        if cls._schema_virtual_network_tap_read is not None:
-            _schema.etag = cls._schema_virtual_network_tap_read.etag
-            _schema.id = cls._schema_virtual_network_tap_read.id
-            _schema.location = cls._schema_virtual_network_tap_read.location
-            _schema.name = cls._schema_virtual_network_tap_read.name
-            _schema.properties = cls._schema_virtual_network_tap_read.properties
-            _schema.tags = cls._schema_virtual_network_tap_read.tags
-            _schema.type = cls._schema_virtual_network_tap_read.type
+    def _build_schema_common_virtual_network_tap_read(cls, _schema):
+        if cls._schema_common_virtual_network_tap_read is not None:
+            _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+            _schema.id = cls._schema_common_virtual_network_tap_read.id
+            _schema.location = cls._schema_common_virtual_network_tap_read.location
+            _schema.name = cls._schema_common_virtual_network_tap_read.name
+            _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+            _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+            _schema.type = cls._schema_common_virtual_network_tap_read.type
             return
 
-        cls._schema_virtual_network_tap_read = _schema_virtual_network_tap_read = AAZObjectType()
+        cls._schema_common_virtual_network_tap_read = _schema_common_virtual_network_tap_read = AAZObjectType()
 
-        virtual_network_tap_read = _schema_virtual_network_tap_read
-        virtual_network_tap_read.etag = AAZStrType(
+        common_virtual_network_tap_read = _schema_common_virtual_network_tap_read
+        common_virtual_network_tap_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.id = AAZStrType()
-        virtual_network_tap_read.location = AAZStrType()
-        virtual_network_tap_read.name = AAZStrType(
+        common_virtual_network_tap_read.id = AAZStrType()
+        common_virtual_network_tap_read.location = AAZStrType()
+        common_virtual_network_tap_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.properties = AAZObjectType(
+        common_virtual_network_tap_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        virtual_network_tap_read.tags = AAZDictType()
-        virtual_network_tap_read.type = AAZStrType(
+        common_virtual_network_tap_read.tags = AAZDictType()
+        common_virtual_network_tap_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_virtual_network_tap_read.properties
+        properties = _schema_common_virtual_network_tap_read.properties
         properties.destination_load_balancer_front_end_ip_configuration = AAZObjectType(
             serialized_name="destinationLoadBalancerFrontEndIPConfiguration",
         )
-        cls._build_schema_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
+        cls._build_schema_common_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
         properties.destination_network_interface_ip_configuration = AAZObjectType(
             serialized_name="destinationNetworkInterfaceIPConfiguration",
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
         properties.destination_port = AAZIntType(
             serialized_name="destinationPort",
         )
@@ -3150,20 +3248,20 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
 
-        network_interface_tap_configurations = _schema_virtual_network_tap_read.properties.network_interface_tap_configurations
+        network_interface_tap_configurations = _schema_common_virtual_network_tap_read.properties.network_interface_tap_configurations
         network_interface_tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
 
-        tags = _schema_virtual_network_tap_read.tags
+        tags = _schema_common_virtual_network_tap_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_virtual_network_tap_read.etag
-        _schema.id = cls._schema_virtual_network_tap_read.id
-        _schema.location = cls._schema_virtual_network_tap_read.location
-        _schema.name = cls._schema_virtual_network_tap_read.name
-        _schema.properties = cls._schema_virtual_network_tap_read.properties
-        _schema.tags = cls._schema_virtual_network_tap_read.tags
-        _schema.type = cls._schema_virtual_network_tap_read.type
+        _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+        _schema.id = cls._schema_common_virtual_network_tap_read.id
+        _schema.location = cls._schema_common_virtual_network_tap_read.location
+        _schema.name = cls._schema_common_virtual_network_tap_read.name
+        _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+        _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+        _schema.type = cls._schema_common_virtual_network_tap_read.type
 
 
 __all__ = ["Update"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_wait.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_wait.py
@@ -49,6 +49,10 @@ class Wait(AAZWaitCommand):
         _args_schema.resource_group = AAZResourceGroupNameArg(
             required=True,
         )
+        _args_schema.expand = AAZStrArg(
+            options=["--expand"],
+            help="Expands referenced resources.",
+        )
         return cls._args_schema
 
     def _execute_operations(self):
@@ -115,6 +119,9 @@ class Wait(AAZWaitCommand):
         @property
         def query_parameters(self):
             parameters = {
+                **self.serialize_query_param(
+                    "$expand", self.ctx.args.expand,
+                ),
                 **self.serialize_query_param(
                     "api-version", "2025-07-01",
                     required=True,

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_wait.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/public_ip/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/publicipaddresses/{}", "2025-07-01"],
         ]
     }
 
@@ -49,15 +49,11 @@ class Wait(AAZWaitCommand):
         _args_schema.resource_group = AAZResourceGroupNameArg(
             required=True,
         )
-        _args_schema.expand = AAZStrArg(
-            options=["--expand"],
-            help="Expands referenced resources.",
-        )
         return cls._args_schema
 
     def _execute_operations(self):
         self.pre_operations()
-        self.PublicIPAddressesGet(ctx=self.ctx)()
+        self.PublicIpAddressOperationGroupGet(ctx=self.ctx)()
         self.post_operations()
 
     @register_callback
@@ -72,7 +68,7 @@ class Wait(AAZWaitCommand):
         result = self.deserialize_output(self.ctx.vars.instance, client_flatten=False)
         return result
 
-    class PublicIPAddressesGet(AAZHttpOperation):
+    class PublicIpAddressOperationGroupGet(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -120,10 +116,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "$expand", self.ctx.args.expand,
-                ),
-                **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -154,7 +147,7 @@ class Wait(AAZWaitCommand):
                 return cls._schema_on_200
 
             cls._schema_on_200 = AAZObjectType()
-            _WaitHelper._build_schema_public_ip_address_read(cls._schema_on_200)
+            _WaitHelper._build_schema_common_public_ip_address_read(cls._schema_on_200)
 
             return cls._schema_on_200
 
@@ -162,40 +155,40 @@ class Wait(AAZWaitCommand):
 class _WaitHelper:
     """Helper class for Wait"""
 
-    _schema_application_security_group_read = None
+    _schema_common_application_security_group_read = None
 
     @classmethod
-    def _build_schema_application_security_group_read(cls, _schema):
-        if cls._schema_application_security_group_read is not None:
-            _schema.etag = cls._schema_application_security_group_read.etag
-            _schema.id = cls._schema_application_security_group_read.id
-            _schema.location = cls._schema_application_security_group_read.location
-            _schema.name = cls._schema_application_security_group_read.name
-            _schema.properties = cls._schema_application_security_group_read.properties
-            _schema.tags = cls._schema_application_security_group_read.tags
-            _schema.type = cls._schema_application_security_group_read.type
+    def _build_schema_common_application_security_group_read(cls, _schema):
+        if cls._schema_common_application_security_group_read is not None:
+            _schema.etag = cls._schema_common_application_security_group_read.etag
+            _schema.id = cls._schema_common_application_security_group_read.id
+            _schema.location = cls._schema_common_application_security_group_read.location
+            _schema.name = cls._schema_common_application_security_group_read.name
+            _schema.properties = cls._schema_common_application_security_group_read.properties
+            _schema.tags = cls._schema_common_application_security_group_read.tags
+            _schema.type = cls._schema_common_application_security_group_read.type
             return
 
-        cls._schema_application_security_group_read = _schema_application_security_group_read = AAZObjectType()
+        cls._schema_common_application_security_group_read = _schema_common_application_security_group_read = AAZObjectType()
 
-        application_security_group_read = _schema_application_security_group_read
-        application_security_group_read.etag = AAZStrType(
+        common_application_security_group_read = _schema_common_application_security_group_read
+        common_application_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.id = AAZStrType()
-        application_security_group_read.location = AAZStrType()
-        application_security_group_read.name = AAZStrType(
+        common_application_security_group_read.id = AAZStrType()
+        common_application_security_group_read.location = AAZStrType()
+        common_application_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        application_security_group_read.properties = AAZObjectType(
+        common_application_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        application_security_group_read.tags = AAZDictType()
-        application_security_group_read.type = AAZStrType(
+        common_application_security_group_read.tags = AAZDictType()
+        common_application_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_application_security_group_read.properties
+        properties = _schema_common_application_security_group_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -205,69 +198,72 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        tags = _schema_application_security_group_read.tags
+        tags = _schema_common_application_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_application_security_group_read.etag
-        _schema.id = cls._schema_application_security_group_read.id
-        _schema.location = cls._schema_application_security_group_read.location
-        _schema.name = cls._schema_application_security_group_read.name
-        _schema.properties = cls._schema_application_security_group_read.properties
-        _schema.tags = cls._schema_application_security_group_read.tags
-        _schema.type = cls._schema_application_security_group_read.type
+        _schema.etag = cls._schema_common_application_security_group_read.etag
+        _schema.id = cls._schema_common_application_security_group_read.id
+        _schema.location = cls._schema_common_application_security_group_read.location
+        _schema.name = cls._schema_common_application_security_group_read.name
+        _schema.properties = cls._schema_common_application_security_group_read.properties
+        _schema.tags = cls._schema_common_application_security_group_read.tags
+        _schema.type = cls._schema_common_application_security_group_read.type
 
-    _schema_extended_location_read = None
-
-    @classmethod
-    def _build_schema_extended_location_read(cls, _schema):
-        if cls._schema_extended_location_read is not None:
-            _schema.name = cls._schema_extended_location_read.name
-            _schema.type = cls._schema_extended_location_read.type
-            return
-
-        cls._schema_extended_location_read = _schema_extended_location_read = AAZObjectType()
-
-        extended_location_read = _schema_extended_location_read
-        extended_location_read.name = AAZStrType()
-        extended_location_read.type = AAZStrType()
-
-        _schema.name = cls._schema_extended_location_read.name
-        _schema.type = cls._schema_extended_location_read.type
-
-    _schema_frontend_ip_configuration_read = None
+    _schema_common_extended_location_read = None
 
     @classmethod
-    def _build_schema_frontend_ip_configuration_read(cls, _schema):
-        if cls._schema_frontend_ip_configuration_read is not None:
-            _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-            _schema.id = cls._schema_frontend_ip_configuration_read.id
-            _schema.name = cls._schema_frontend_ip_configuration_read.name
-            _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-            _schema.type = cls._schema_frontend_ip_configuration_read.type
-            _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+    def _build_schema_common_extended_location_read(cls, _schema):
+        if cls._schema_common_extended_location_read is not None:
+            _schema.name = cls._schema_common_extended_location_read.name
+            _schema.type = cls._schema_common_extended_location_read.type
             return
 
-        cls._schema_frontend_ip_configuration_read = _schema_frontend_ip_configuration_read = AAZObjectType()
+        cls._schema_common_extended_location_read = _schema_common_extended_location_read = AAZObjectType()
 
-        frontend_ip_configuration_read = _schema_frontend_ip_configuration_read
-        frontend_ip_configuration_read.etag = AAZStrType(
+        common_extended_location_read = _schema_common_extended_location_read
+        common_extended_location_read.name = AAZStrType()
+        common_extended_location_read.type = AAZStrType()
+
+        _schema.name = cls._schema_common_extended_location_read.name
+        _schema.type = cls._schema_common_extended_location_read.type
+
+    _schema_common_frontend_ip_configuration_read = None
+
+    @classmethod
+    def _build_schema_common_frontend_ip_configuration_read(cls, _schema):
+        if cls._schema_common_frontend_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+            _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+            _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+            _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+            _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+            _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
+            return
+
+        cls._schema_common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read = AAZObjectType()
+
+        common_frontend_ip_configuration_read = _schema_common_frontend_ip_configuration_read
+        common_frontend_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.id = AAZStrType()
-        frontend_ip_configuration_read.name = AAZStrType()
-        frontend_ip_configuration_read.properties = AAZObjectType(
+        common_frontend_ip_configuration_read.id = AAZStrType()
+        common_frontend_ip_configuration_read.name = AAZStrType()
+        common_frontend_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        frontend_ip_configuration_read.type = AAZStrType(
+        common_frontend_ip_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        frontend_ip_configuration_read.zones = AAZListType()
+        common_frontend_ip_configuration_read.zones = AAZListType()
 
-        properties = _schema_frontend_ip_configuration_read.properties
+        properties = _schema_common_frontend_ip_configuration_read.properties
+        properties.ddos_settings = AAZObjectType(
+            serialized_name="ddosSettings",
+        )
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.inbound_nat_pools = AAZListType(
             serialized_name="inboundNatPools",
             flags={"read_only": True},
@@ -300,66 +296,72 @@ class _WaitHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        inbound_nat_pools = _schema_frontend_ip_configuration_read.properties.inbound_nat_pools
+        ddos_settings = _schema_common_frontend_ip_configuration_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
+
+        inbound_nat_pools = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_pools
         inbound_nat_pools.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_pools.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_pools.Element)
 
-        inbound_nat_rules = _schema_frontend_ip_configuration_read.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_frontend_ip_configuration_read.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancing_rules = _schema_frontend_ip_configuration_read.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_frontend_ip_configuration_read.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_frontend_ip_configuration_read.properties.outbound_rules
+        outbound_rules = _schema_common_frontend_ip_configuration_read.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        zones = _schema_frontend_ip_configuration_read.zones
+        zones = _schema_common_frontend_ip_configuration_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_frontend_ip_configuration_read.etag
-        _schema.id = cls._schema_frontend_ip_configuration_read.id
-        _schema.name = cls._schema_frontend_ip_configuration_read.name
-        _schema.properties = cls._schema_frontend_ip_configuration_read.properties
-        _schema.type = cls._schema_frontend_ip_configuration_read.type
-        _schema.zones = cls._schema_frontend_ip_configuration_read.zones
+        _schema.etag = cls._schema_common_frontend_ip_configuration_read.etag
+        _schema.id = cls._schema_common_frontend_ip_configuration_read.id
+        _schema.name = cls._schema_common_frontend_ip_configuration_read.name
+        _schema.properties = cls._schema_common_frontend_ip_configuration_read.properties
+        _schema.type = cls._schema_common_frontend_ip_configuration_read.type
+        _schema.zones = cls._schema_common_frontend_ip_configuration_read.zones
 
-    _schema_ip_configuration_read = None
+    _schema_common_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_ip_configuration_read(cls, _schema):
-        if cls._schema_ip_configuration_read is not None:
-            _schema.etag = cls._schema_ip_configuration_read.etag
-            _schema.id = cls._schema_ip_configuration_read.id
-            _schema.name = cls._schema_ip_configuration_read.name
-            _schema.properties = cls._schema_ip_configuration_read.properties
+    def _build_schema_common_ip_configuration_read(cls, _schema):
+        if cls._schema_common_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_ip_configuration_read.etag
+            _schema.id = cls._schema_common_ip_configuration_read.id
+            _schema.name = cls._schema_common_ip_configuration_read.name
+            _schema.properties = cls._schema_common_ip_configuration_read.properties
             return
 
-        cls._schema_ip_configuration_read = _schema_ip_configuration_read = AAZObjectType(
+        cls._schema_common_ip_configuration_read = _schema_common_ip_configuration_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        ip_configuration_read = _schema_ip_configuration_read
-        ip_configuration_read.etag = AAZStrType(
+        common_ip_configuration_read = _schema_common_ip_configuration_read
+        common_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        ip_configuration_read.id = AAZStrType()
-        ip_configuration_read.name = AAZStrType()
-        ip_configuration_read.properties = AAZObjectType(
+        common_ip_configuration_read.id = AAZStrType()
+        common_ip_configuration_read.name = AAZStrType()
+        common_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_ip_configuration_read.properties
+        properties = _schema_common_ip_configuration_read.properties
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
         )
@@ -373,41 +375,43 @@ class _WaitHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        _schema.etag = cls._schema_ip_configuration_read.etag
-        _schema.id = cls._schema_ip_configuration_read.id
-        _schema.name = cls._schema_ip_configuration_read.name
-        _schema.properties = cls._schema_ip_configuration_read.properties
+        _schema.etag = cls._schema_common_ip_configuration_read.etag
+        _schema.id = cls._schema_common_ip_configuration_read.id
+        _schema.name = cls._schema_common_ip_configuration_read.name
+        _schema.properties = cls._schema_common_ip_configuration_read.properties
 
-    _schema_network_interface_ip_configuration_read = None
+    _schema_common_network_interface_ip_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_ip_configuration_read(cls, _schema):
-        if cls._schema_network_interface_ip_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-            _schema.id = cls._schema_network_interface_ip_configuration_read.id
-            _schema.name = cls._schema_network_interface_ip_configuration_read.name
-            _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-            _schema.type = cls._schema_network_interface_ip_configuration_read.type
+    def _build_schema_common_network_interface_ip_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_ip_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
             return
 
-        cls._schema_network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read = AAZObjectType()
 
-        network_interface_ip_configuration_read = _schema_network_interface_ip_configuration_read
-        network_interface_ip_configuration_read.etag = AAZStrType(
+        common_network_interface_ip_configuration_read = _schema_common_network_interface_ip_configuration_read
+        common_network_interface_ip_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_ip_configuration_read.id = AAZStrType()
-        network_interface_ip_configuration_read.name = AAZStrType()
-        network_interface_ip_configuration_read.properties = AAZObjectType(
+        common_network_interface_ip_configuration_read.id = AAZStrType()
+        common_network_interface_ip_configuration_read.name = AAZStrType()
+        common_network_interface_ip_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_ip_configuration_read.type = AAZStrType()
+        common_network_interface_ip_configuration_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_network_interface_ip_configuration_read.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties
         properties.application_gateway_backend_address_pools = AAZListType(
             serialized_name="applicationGatewayBackendAddressPools",
         )
@@ -417,7 +421,7 @@ class _WaitHelper:
         properties.gateway_load_balancer = AAZObjectType(
             serialized_name="gatewayLoadBalancer",
         )
-        cls._build_schema_sub_resource_read(properties.gateway_load_balancer)
+        cls._build_schema_common_sub_resource_read(properties.gateway_load_balancer)
         properties.load_balancer_backend_address_pools = AAZListType(
             serialized_name="loadBalancerBackendAddressPools",
         )
@@ -449,17 +453,17 @@ class _WaitHelper:
         properties.public_ip_address = AAZObjectType(
             serialized_name="publicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.public_ip_address)
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
         properties.virtual_network_taps = AAZListType(
             serialized_name="virtualNetworkTaps",
         )
 
-        application_gateway_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
+        application_gateway_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools
         application_gateway_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -472,7 +476,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties
         properties.backend_addresses = AAZListType(
             serialized_name="backendAddresses",
         )
@@ -485,27 +489,27 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        backend_addresses = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
+        backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses
         backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_addresses.Element
         _element.fqdn = AAZStrType()
         _element.ip_address = AAZStrType(
             serialized_name="ipAddress",
         )
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.application_gateway_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        application_security_groups = _schema_network_interface_ip_configuration_read.properties.application_security_groups
+        application_security_groups = _schema_common_network_interface_ip_configuration_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        load_balancer_backend_address_pools = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
+        load_balancer_backend_address_pools = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools
         load_balancer_backend_address_pools.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -518,7 +522,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties
         properties.backend_ip_configurations = AAZListType(
             serialized_name="backendIPConfigurations",
             flags={"read_only": True},
@@ -542,7 +546,7 @@ class _WaitHelper:
             serialized_name="outboundRule",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.outbound_rule)
+        cls._build_schema_common_sub_resource_read(properties.outbound_rule)
         properties.outbound_rules = AAZListType(
             serialized_name="outboundRules",
             flags={"read_only": True},
@@ -560,26 +564,26 @@ class _WaitHelper:
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        backend_ip_configurations = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
+        backend_ip_configurations = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.backend_ip_configurations
         backend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(backend_ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(backend_ip_configurations.Element)
 
-        inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
+        inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.inbound_nat_rules
         inbound_nat_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(inbound_nat_rules.Element)
+        cls._build_schema_common_sub_resource_read(inbound_nat_rules.Element)
 
-        load_balancer_backend_addresses = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
+        load_balancer_backend_addresses = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses
         load_balancer_backend_addresses.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element
         _element.name = AAZStrType()
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties
         properties.admin_state = AAZStrType(
             serialized_name="adminState",
         )
@@ -593,23 +597,23 @@ class _WaitHelper:
         properties.load_balancer_frontend_ip_configuration = AAZObjectType(
             serialized_name="loadBalancerFrontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.load_balancer_frontend_ip_configuration)
         properties.network_interface_ip_configuration = AAZObjectType(
             serialized_name="networkInterfaceIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.network_interface_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.network_interface_ip_configuration)
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
         properties.virtual_network = AAZObjectType(
             serialized_name="virtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.virtual_network)
 
-        inbound_nat_rules_port_mapping = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
+        inbound_nat_rules_port_mapping = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping
         inbound_nat_rules_port_mapping.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancer_backend_addresses.Element.properties.inbound_nat_rules_port_mapping.Element
         _element.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -620,27 +624,27 @@ class _WaitHelper:
             serialized_name="inboundNatRuleName",
         )
 
-        load_balancing_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
+        load_balancing_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.load_balancing_rules
         load_balancing_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(load_balancing_rules.Element)
+        cls._build_schema_common_sub_resource_read(load_balancing_rules.Element)
 
-        outbound_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
+        outbound_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.outbound_rules
         outbound_rules.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(outbound_rules.Element)
+        cls._build_schema_common_sub_resource_read(outbound_rules.Element)
 
-        tunnel_interfaces = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
+        tunnel_interfaces = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces
         tunnel_interfaces.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_backend_address_pools.Element.properties.tunnel_interfaces.Element
         _element.identifier = AAZIntType()
         _element.port = AAZIntType()
         _element.protocol = AAZStrType()
         _element.type = AAZStrType()
 
-        load_balancer_inbound_nat_rules = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
+        load_balancer_inbound_nat_rules = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules
         load_balancer_inbound_nat_rules.Element = AAZObjectType()
 
-        _element = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
+        _element = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -653,16 +657,16 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
+        properties = _schema_common_network_interface_ip_configuration_read.properties.load_balancer_inbound_nat_rules.Element.properties
         properties.backend_address_pool = AAZObjectType(
             serialized_name="backendAddressPool",
         )
-        cls._build_schema_sub_resource_read(properties.backend_address_pool)
+        cls._build_schema_common_sub_resource_read(properties.backend_address_pool)
         properties.backend_ip_configuration = AAZObjectType(
             serialized_name="backendIPConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.backend_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.backend_ip_configuration)
         properties.backend_port = AAZIntType(
             serialized_name="backendPort",
         )
@@ -675,7 +679,7 @@ class _WaitHelper:
         properties.frontend_ip_configuration = AAZObjectType(
             serialized_name="frontendIPConfiguration",
         )
-        cls._build_schema_sub_resource_read(properties.frontend_ip_configuration)
+        cls._build_schema_common_sub_resource_read(properties.frontend_ip_configuration)
         properties.frontend_port = AAZIntType(
             serialized_name="frontendPort",
         )
@@ -694,7 +698,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        private_link_connection_properties = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties
+        private_link_connection_properties = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties
         private_link_connection_properties.fqdns = AAZListType(
             flags={"read_only": True},
         )
@@ -707,47 +711,47 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        fqdns = _schema_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
+        fqdns = _schema_common_network_interface_ip_configuration_read.properties.private_link_connection_properties.fqdns
         fqdns.Element = AAZStrType()
 
-        virtual_network_taps = _schema_network_interface_ip_configuration_read.properties.virtual_network_taps
+        virtual_network_taps = _schema_common_network_interface_ip_configuration_read.properties.virtual_network_taps
         virtual_network_taps.Element = AAZObjectType()
-        cls._build_schema_virtual_network_tap_read(virtual_network_taps.Element)
+        cls._build_schema_common_virtual_network_tap_read(virtual_network_taps.Element)
 
-        _schema.etag = cls._schema_network_interface_ip_configuration_read.etag
-        _schema.id = cls._schema_network_interface_ip_configuration_read.id
-        _schema.name = cls._schema_network_interface_ip_configuration_read.name
-        _schema.properties = cls._schema_network_interface_ip_configuration_read.properties
-        _schema.type = cls._schema_network_interface_ip_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_ip_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_ip_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_ip_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_ip_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_ip_configuration_read.type
 
-    _schema_network_interface_tap_configuration_read = None
+    _schema_common_network_interface_tap_configuration_read = None
 
     @classmethod
-    def _build_schema_network_interface_tap_configuration_read(cls, _schema):
-        if cls._schema_network_interface_tap_configuration_read is not None:
-            _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-            _schema.id = cls._schema_network_interface_tap_configuration_read.id
-            _schema.name = cls._schema_network_interface_tap_configuration_read.name
-            _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-            _schema.type = cls._schema_network_interface_tap_configuration_read.type
+    def _build_schema_common_network_interface_tap_configuration_read(cls, _schema):
+        if cls._schema_common_network_interface_tap_configuration_read is not None:
+            _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+            _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+            _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+            _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+            _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
             return
 
-        cls._schema_network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read = AAZObjectType()
+        cls._schema_common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read = AAZObjectType()
 
-        network_interface_tap_configuration_read = _schema_network_interface_tap_configuration_read
-        network_interface_tap_configuration_read.etag = AAZStrType(
+        common_network_interface_tap_configuration_read = _schema_common_network_interface_tap_configuration_read
+        common_network_interface_tap_configuration_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_tap_configuration_read.id = AAZStrType()
-        network_interface_tap_configuration_read.name = AAZStrType()
-        network_interface_tap_configuration_read.properties = AAZObjectType(
+        common_network_interface_tap_configuration_read.id = AAZStrType()
+        common_network_interface_tap_configuration_read.name = AAZStrType()
+        common_network_interface_tap_configuration_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_tap_configuration_read.type = AAZStrType(
+        common_network_interface_tap_configuration_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_tap_configuration_read.properties
+        properties = _schema_common_network_interface_tap_configuration_read.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -755,53 +759,53 @@ class _WaitHelper:
         properties.virtual_network_tap = AAZObjectType(
             serialized_name="virtualNetworkTap",
         )
-        cls._build_schema_virtual_network_tap_read(properties.virtual_network_tap)
+        cls._build_schema_common_virtual_network_tap_read(properties.virtual_network_tap)
 
-        _schema.etag = cls._schema_network_interface_tap_configuration_read.etag
-        _schema.id = cls._schema_network_interface_tap_configuration_read.id
-        _schema.name = cls._schema_network_interface_tap_configuration_read.name
-        _schema.properties = cls._schema_network_interface_tap_configuration_read.properties
-        _schema.type = cls._schema_network_interface_tap_configuration_read.type
+        _schema.etag = cls._schema_common_network_interface_tap_configuration_read.etag
+        _schema.id = cls._schema_common_network_interface_tap_configuration_read.id
+        _schema.name = cls._schema_common_network_interface_tap_configuration_read.name
+        _schema.properties = cls._schema_common_network_interface_tap_configuration_read.properties
+        _schema.type = cls._schema_common_network_interface_tap_configuration_read.type
 
-    _schema_network_interface_read = None
+    _schema_common_network_interface_read = None
 
     @classmethod
-    def _build_schema_network_interface_read(cls, _schema):
-        if cls._schema_network_interface_read is not None:
-            _schema.etag = cls._schema_network_interface_read.etag
-            _schema.extended_location = cls._schema_network_interface_read.extended_location
-            _schema.id = cls._schema_network_interface_read.id
-            _schema.location = cls._schema_network_interface_read.location
-            _schema.name = cls._schema_network_interface_read.name
-            _schema.properties = cls._schema_network_interface_read.properties
-            _schema.tags = cls._schema_network_interface_read.tags
-            _schema.type = cls._schema_network_interface_read.type
+    def _build_schema_common_network_interface_read(cls, _schema):
+        if cls._schema_common_network_interface_read is not None:
+            _schema.etag = cls._schema_common_network_interface_read.etag
+            _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+            _schema.id = cls._schema_common_network_interface_read.id
+            _schema.location = cls._schema_common_network_interface_read.location
+            _schema.name = cls._schema_common_network_interface_read.name
+            _schema.properties = cls._schema_common_network_interface_read.properties
+            _schema.tags = cls._schema_common_network_interface_read.tags
+            _schema.type = cls._schema_common_network_interface_read.type
             return
 
-        cls._schema_network_interface_read = _schema_network_interface_read = AAZObjectType()
+        cls._schema_common_network_interface_read = _schema_common_network_interface_read = AAZObjectType()
 
-        network_interface_read = _schema_network_interface_read
-        network_interface_read.etag = AAZStrType(
+        common_network_interface_read = _schema_common_network_interface_read
+        common_network_interface_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.extended_location = AAZObjectType(
+        common_network_interface_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(network_interface_read.extended_location)
-        network_interface_read.id = AAZStrType()
-        network_interface_read.location = AAZStrType()
-        network_interface_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_network_interface_read.extended_location)
+        common_network_interface_read.id = AAZStrType()
+        common_network_interface_read.location = AAZStrType()
+        common_network_interface_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_interface_read.properties = AAZObjectType(
+        common_network_interface_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_interface_read.tags = AAZDictType()
-        network_interface_read.type = AAZStrType(
+        common_network_interface_read.tags = AAZDictType()
+        common_network_interface_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties
+        properties = _schema_common_network_interface_read.properties
         properties.auxiliary_mode = AAZStrType(
             serialized_name="auxiliaryMode",
         )
@@ -822,7 +826,7 @@ class _WaitHelper:
             serialized_name="dscpConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.dscp_configuration)
+        cls._build_schema_common_sub_resource_read(properties.dscp_configuration)
         properties.enable_accelerated_networking = AAZBoolType(
             serialized_name="enableAcceleratedNetworking",
         )
@@ -846,7 +850,7 @@ class _WaitHelper:
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.nic_type = AAZStrType(
             serialized_name="nicType",
         )
@@ -857,7 +861,7 @@ class _WaitHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_link_service = AAZObjectType(
             serialized_name="privateLinkService",
         )
@@ -877,7 +881,7 @@ class _WaitHelper:
             serialized_name="virtualMachine",
             flags={"read_only": True},
         )
-        cls._build_schema_sub_resource_read(properties.virtual_machine)
+        cls._build_schema_common_sub_resource_read(properties.virtual_machine)
         properties.vnet_encryption_supported = AAZBoolType(
             serialized_name="vnetEncryptionSupported",
             flags={"read_only": True},
@@ -886,7 +890,7 @@ class _WaitHelper:
             serialized_name="workloadType",
         )
 
-        dns_settings = _schema_network_interface_read.properties.dns_settings
+        dns_settings = _schema_common_network_interface_read.properties.dns_settings
         dns_settings.applied_dns_servers = AAZListType(
             serialized_name="appliedDnsServers",
             flags={"read_only": True},
@@ -906,27 +910,27 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        applied_dns_servers = _schema_network_interface_read.properties.dns_settings.applied_dns_servers
+        applied_dns_servers = _schema_common_network_interface_read.properties.dns_settings.applied_dns_servers
         applied_dns_servers.Element = AAZStrType()
 
-        dns_servers = _schema_network_interface_read.properties.dns_settings.dns_servers
+        dns_servers = _schema_common_network_interface_read.properties.dns_settings.dns_servers
         dns_servers.Element = AAZStrType()
 
-        hosted_workloads = _schema_network_interface_read.properties.hosted_workloads
+        hosted_workloads = _schema_common_network_interface_read.properties.hosted_workloads
         hosted_workloads.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_network_interface_ip_configuration_read(ip_configurations.Element)
 
-        private_link_service = _schema_network_interface_read.properties.private_link_service
+        private_link_service = _schema_common_network_interface_read.properties.private_link_service
         private_link_service.etag = AAZStrType(
             flags={"read_only": True},
         )
         private_link_service.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_link_service.extended_location)
+        cls._build_schema_common_extended_location_read(private_link_service.extended_location)
         private_link_service.id = AAZStrType()
         private_link_service.location = AAZStrType()
         private_link_service.name = AAZStrType(
@@ -940,7 +944,10 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties
+        properties.access_mode = AAZStrType(
+            serialized_name="accessMode",
+        )
         properties.alias = AAZStrType(
             flags={"read_only": True},
         )
@@ -974,19 +981,19 @@ class _WaitHelper:
         )
         properties.visibility = AAZObjectType()
 
-        auto_approval = _schema_network_interface_read.properties.private_link_service.properties.auto_approval
+        auto_approval = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval
         auto_approval.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.auto_approval.subscriptions
         subscriptions.Element = AAZStrType()
 
-        fqdns = _schema_network_interface_read.properties.private_link_service.properties.fqdns
+        fqdns = _schema_common_network_interface_read.properties.private_link_service.properties.fqdns
         fqdns.Element = AAZStrType()
 
-        ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations
+        ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -999,7 +1006,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.ip_configurations.Element.properties
         properties.primary = AAZBoolType()
         properties.private_ip_address = AAZStrType(
             serialized_name="privateIPAddress",
@@ -1015,20 +1022,20 @@ class _WaitHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        load_balancer_frontend_ip_configurations = _schema_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
+        load_balancer_frontend_ip_configurations = _schema_common_network_interface_read.properties.private_link_service.properties.load_balancer_frontend_ip_configurations
         load_balancer_frontend_ip_configurations.Element = AAZObjectType()
-        cls._build_schema_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
+        cls._build_schema_common_frontend_ip_configuration_read(load_balancer_frontend_ip_configurations.Element)
 
-        network_interfaces = _schema_network_interface_read.properties.private_link_service.properties.network_interfaces
+        network_interfaces = _schema_common_network_interface_read.properties.private_link_service.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_endpoint_connections = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
+        private_endpoint_connections = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections
         private_endpoint_connections.Element = AAZObjectType()
 
-        _element = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
+        _element = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1041,7 +1048,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
+        properties = _schema_common_network_interface_read.properties.private_link_service.properties.private_endpoint_connections.Element.properties
         properties.link_identifier = AAZStrType(
             serialized_name="linkIdentifier",
             flags={"read_only": True},
@@ -1050,7 +1057,7 @@ class _WaitHelper:
             serialized_name="privateEndpoint",
             flags={"read_only": True},
         )
-        cls._build_schema_private_endpoint_read(properties.private_endpoint)
+        cls._build_schema_common_private_endpoint_read(properties.private_endpoint)
         properties.private_endpoint_location = AAZStrType(
             serialized_name="privateEndpointLocation",
             flags={"read_only": True},
@@ -1058,71 +1065,71 @@ class _WaitHelper:
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
 
-        visibility = _schema_network_interface_read.properties.private_link_service.properties.visibility
+        visibility = _schema_common_network_interface_read.properties.private_link_service.properties.visibility
         visibility.subscriptions = AAZListType()
 
-        subscriptions = _schema_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
+        subscriptions = _schema_common_network_interface_read.properties.private_link_service.properties.visibility.subscriptions
         subscriptions.Element = AAZStrType()
 
-        tags = _schema_network_interface_read.properties.private_link_service.tags
+        tags = _schema_common_network_interface_read.properties.private_link_service.tags
         tags.Element = AAZStrType()
 
-        tap_configurations = _schema_network_interface_read.properties.tap_configurations
+        tap_configurations = _schema_common_network_interface_read.properties.tap_configurations
         tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(tap_configurations.Element)
 
-        tags = _schema_network_interface_read.tags
+        tags = _schema_common_network_interface_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_interface_read.etag
-        _schema.extended_location = cls._schema_network_interface_read.extended_location
-        _schema.id = cls._schema_network_interface_read.id
-        _schema.location = cls._schema_network_interface_read.location
-        _schema.name = cls._schema_network_interface_read.name
-        _schema.properties = cls._schema_network_interface_read.properties
-        _schema.tags = cls._schema_network_interface_read.tags
-        _schema.type = cls._schema_network_interface_read.type
+        _schema.etag = cls._schema_common_network_interface_read.etag
+        _schema.extended_location = cls._schema_common_network_interface_read.extended_location
+        _schema.id = cls._schema_common_network_interface_read.id
+        _schema.location = cls._schema_common_network_interface_read.location
+        _schema.name = cls._schema_common_network_interface_read.name
+        _schema.properties = cls._schema_common_network_interface_read.properties
+        _schema.tags = cls._schema_common_network_interface_read.tags
+        _schema.type = cls._schema_common_network_interface_read.type
 
-    _schema_network_security_group_read = None
+    _schema_common_network_security_group_read = None
 
     @classmethod
-    def _build_schema_network_security_group_read(cls, _schema):
-        if cls._schema_network_security_group_read is not None:
-            _schema.etag = cls._schema_network_security_group_read.etag
-            _schema.id = cls._schema_network_security_group_read.id
-            _schema.location = cls._schema_network_security_group_read.location
-            _schema.name = cls._schema_network_security_group_read.name
-            _schema.properties = cls._schema_network_security_group_read.properties
-            _schema.tags = cls._schema_network_security_group_read.tags
-            _schema.type = cls._schema_network_security_group_read.type
+    def _build_schema_common_network_security_group_read(cls, _schema):
+        if cls._schema_common_network_security_group_read is not None:
+            _schema.etag = cls._schema_common_network_security_group_read.etag
+            _schema.id = cls._schema_common_network_security_group_read.id
+            _schema.location = cls._schema_common_network_security_group_read.location
+            _schema.name = cls._schema_common_network_security_group_read.name
+            _schema.properties = cls._schema_common_network_security_group_read.properties
+            _schema.tags = cls._schema_common_network_security_group_read.tags
+            _schema.type = cls._schema_common_network_security_group_read.type
             return
 
-        cls._schema_network_security_group_read = _schema_network_security_group_read = AAZObjectType()
+        cls._schema_common_network_security_group_read = _schema_common_network_security_group_read = AAZObjectType()
 
-        network_security_group_read = _schema_network_security_group_read
-        network_security_group_read.etag = AAZStrType(
+        common_network_security_group_read = _schema_common_network_security_group_read
+        common_network_security_group_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.id = AAZStrType()
-        network_security_group_read.location = AAZStrType()
-        network_security_group_read.name = AAZStrType(
+        common_network_security_group_read.id = AAZStrType()
+        common_network_security_group_read.location = AAZStrType()
+        common_network_security_group_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        network_security_group_read.properties = AAZObjectType(
+        common_network_security_group_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        network_security_group_read.tags = AAZDictType()
-        network_security_group_read.type = AAZStrType(
+        common_network_security_group_read.tags = AAZDictType()
+        common_network_security_group_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties
+        properties = _schema_common_network_security_group_read.properties
         properties.default_security_rules = AAZListType(
             serialized_name="defaultSecurityRules",
             flags={"read_only": True},
@@ -1153,14 +1160,14 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        default_security_rules = _schema_network_security_group_read.properties.default_security_rules
+        default_security_rules = _schema_common_network_security_group_read.properties.default_security_rules
         default_security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(default_security_rules.Element)
+        cls._build_schema_common_security_rule_read(default_security_rules.Element)
 
-        flow_logs = _schema_network_security_group_read.properties.flow_logs
+        flow_logs = _schema_common_network_security_group_read.properties.flow_logs
         flow_logs.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1178,7 +1185,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        identity = _schema_network_security_group_read.properties.flow_logs.Element.identity
+        identity = _schema_common_network_security_group_read.properties.flow_logs.Element.identity
         identity.principal_id = AAZStrType(
             serialized_name="principalId",
             flags={"read_only": True},
@@ -1192,10 +1199,10 @@ class _WaitHelper:
             serialized_name="userAssignedIdentities",
         )
 
-        user_assigned_identities = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
+        user_assigned_identities = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities
         user_assigned_identities.Element = AAZObjectType()
 
-        _element = _schema_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
+        _element = _schema_common_network_security_group_read.properties.flow_logs.Element.identity.user_assigned_identities.Element
         _element.client_id = AAZStrType(
             serialized_name="clientId",
             flags={"read_only": True},
@@ -1205,7 +1212,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_network_security_group_read.properties.flow_logs.Element.properties
+        properties = _schema_common_network_security_group_read.properties.flow_logs.Element.properties
         properties.enabled = AAZBoolType()
         properties.enabled_filtering_criteria = AAZStrType(
             serialized_name="enabledFilteringCriteria",
@@ -1217,6 +1224,9 @@ class _WaitHelper:
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
+        )
+        properties.record_types = AAZStrType(
+            serialized_name="recordTypes",
         )
         properties.retention_policy = AAZObjectType(
             serialized_name="retentionPolicy",
@@ -1234,12 +1244,12 @@ class _WaitHelper:
             flags={"required": True},
         )
 
-        flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
+        flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration
         flow_analytics_configuration.network_watcher_flow_analytics_configuration = AAZObjectType(
             serialized_name="networkWatcherFlowAnalyticsConfiguration",
         )
 
-        network_watcher_flow_analytics_configuration = _schema_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
+        network_watcher_flow_analytics_configuration = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.flow_analytics_configuration.network_watcher_flow_analytics_configuration
         network_watcher_flow_analytics_configuration.enabled = AAZBoolType()
         network_watcher_flow_analytics_configuration.traffic_analytics_interval = AAZIntType(
             serialized_name="trafficAnalyticsInterval",
@@ -1254,83 +1264,86 @@ class _WaitHelper:
             serialized_name="workspaceResourceId",
         )
 
-        format = _schema_network_security_group_read.properties.flow_logs.Element.properties.format
+        format = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.format
         format.type = AAZStrType()
         format.version = AAZIntType()
 
-        retention_policy = _schema_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
+        retention_policy = _schema_common_network_security_group_read.properties.flow_logs.Element.properties.retention_policy
         retention_policy.days = AAZIntType()
         retention_policy.enabled = AAZBoolType()
 
-        tags = _schema_network_security_group_read.properties.flow_logs.Element.tags
+        tags = _schema_common_network_security_group_read.properties.flow_logs.Element.tags
         tags.Element = AAZStrType()
 
-        network_interfaces = _schema_network_security_group_read.properties.network_interfaces
+        network_interfaces = _schema_common_network_security_group_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        security_rules = _schema_network_security_group_read.properties.security_rules
+        security_rules = _schema_common_network_security_group_read.properties.security_rules
         security_rules.Element = AAZObjectType()
-        cls._build_schema_security_rule_read(security_rules.Element)
+        cls._build_schema_common_security_rule_read(security_rules.Element)
 
-        subnets = _schema_network_security_group_read.properties.subnets
+        subnets = _schema_common_network_security_group_read.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_network_security_group_read.tags
+        tags = _schema_common_network_security_group_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_network_security_group_read.etag
-        _schema.id = cls._schema_network_security_group_read.id
-        _schema.location = cls._schema_network_security_group_read.location
-        _schema.name = cls._schema_network_security_group_read.name
-        _schema.properties = cls._schema_network_security_group_read.properties
-        _schema.tags = cls._schema_network_security_group_read.tags
-        _schema.type = cls._schema_network_security_group_read.type
+        _schema.etag = cls._schema_common_network_security_group_read.etag
+        _schema.id = cls._schema_common_network_security_group_read.id
+        _schema.location = cls._schema_common_network_security_group_read.location
+        _schema.name = cls._schema_common_network_security_group_read.name
+        _schema.properties = cls._schema_common_network_security_group_read.properties
+        _schema.tags = cls._schema_common_network_security_group_read.tags
+        _schema.type = cls._schema_common_network_security_group_read.type
 
-    _schema_private_endpoint_read = None
+    _schema_common_private_endpoint_read = None
 
     @classmethod
-    def _build_schema_private_endpoint_read(cls, _schema):
-        if cls._schema_private_endpoint_read is not None:
-            _schema.etag = cls._schema_private_endpoint_read.etag
-            _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-            _schema.id = cls._schema_private_endpoint_read.id
-            _schema.location = cls._schema_private_endpoint_read.location
-            _schema.name = cls._schema_private_endpoint_read.name
-            _schema.properties = cls._schema_private_endpoint_read.properties
-            _schema.tags = cls._schema_private_endpoint_read.tags
-            _schema.type = cls._schema_private_endpoint_read.type
+    def _build_schema_common_private_endpoint_read(cls, _schema):
+        if cls._schema_common_private_endpoint_read is not None:
+            _schema.etag = cls._schema_common_private_endpoint_read.etag
+            _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+            _schema.id = cls._schema_common_private_endpoint_read.id
+            _schema.location = cls._schema_common_private_endpoint_read.location
+            _schema.name = cls._schema_common_private_endpoint_read.name
+            _schema.properties = cls._schema_common_private_endpoint_read.properties
+            _schema.tags = cls._schema_common_private_endpoint_read.tags
+            _schema.type = cls._schema_common_private_endpoint_read.type
             return
 
-        cls._schema_private_endpoint_read = _schema_private_endpoint_read = AAZObjectType(
+        cls._schema_common_private_endpoint_read = _schema_common_private_endpoint_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        private_endpoint_read = _schema_private_endpoint_read
-        private_endpoint_read.etag = AAZStrType(
+        common_private_endpoint_read = _schema_common_private_endpoint_read
+        common_private_endpoint_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.extended_location = AAZObjectType(
+        common_private_endpoint_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(private_endpoint_read.extended_location)
-        private_endpoint_read.id = AAZStrType()
-        private_endpoint_read.location = AAZStrType()
-        private_endpoint_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_private_endpoint_read.extended_location)
+        common_private_endpoint_read.id = AAZStrType()
+        common_private_endpoint_read.location = AAZStrType()
+        common_private_endpoint_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        private_endpoint_read.properties = AAZObjectType(
+        common_private_endpoint_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_endpoint_read.tags = AAZDictType()
-        private_endpoint_read.type = AAZStrType(
+        common_private_endpoint_read.tags = AAZDictType()
+        common_private_endpoint_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties
+        properties = _schema_common_private_endpoint_read.properties
         properties.application_security_groups = AAZListType(
             serialized_name="applicationSecurityGroups",
+        )
+        properties.billing_sku = AAZStrType(
+            serialized_name="billingSku",
         )
         properties.custom_dns_configs = AAZListType(
             serialized_name="customDnsConfigs",
@@ -1340,6 +1353,9 @@ class _WaitHelper:
         )
         properties.ip_configurations = AAZListType(
             serialized_name="ipConfigurations",
+        )
+        properties.ip_version_type = AAZStrType(
+            serialized_name="ipVersionType",
         )
         properties.manual_private_link_service_connections = AAZListType(
             serialized_name="manualPrivateLinkServiceConnections",
@@ -1356,28 +1372,28 @@ class _WaitHelper:
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        application_security_groups = _schema_private_endpoint_read.properties.application_security_groups
+        application_security_groups = _schema_common_private_endpoint_read.properties.application_security_groups
         application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(application_security_groups.Element)
 
-        custom_dns_configs = _schema_private_endpoint_read.properties.custom_dns_configs
+        custom_dns_configs = _schema_common_private_endpoint_read.properties.custom_dns_configs
         custom_dns_configs.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.custom_dns_configs.Element
+        _element = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element
         _element.fqdn = AAZStrType()
         _element.ip_addresses = AAZListType(
             serialized_name="ipAddresses",
         )
 
-        ip_addresses = _schema_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
+        ip_addresses = _schema_common_private_endpoint_read.properties.custom_dns_configs.Element.ip_addresses
         ip_addresses.Element = AAZStrType()
 
-        ip_configurations = _schema_private_endpoint_read.properties.ip_configurations
+        ip_configurations = _schema_common_private_endpoint_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_private_endpoint_read.properties.ip_configurations.Element
+        _element = _schema_common_private_endpoint_read.properties.ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1389,7 +1405,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_private_endpoint_read.properties.ip_configurations.Element.properties
+        properties = _schema_common_private_endpoint_read.properties.ip_configurations.Element.properties
         properties.group_id = AAZStrType(
             serialized_name="groupId",
         )
@@ -1400,88 +1416,88 @@ class _WaitHelper:
             serialized_name="privateIPAddress",
         )
 
-        manual_private_link_service_connections = _schema_private_endpoint_read.properties.manual_private_link_service_connections
+        manual_private_link_service_connections = _schema_common_private_endpoint_read.properties.manual_private_link_service_connections
         manual_private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(manual_private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(manual_private_link_service_connections.Element)
 
-        network_interfaces = _schema_private_endpoint_read.properties.network_interfaces
+        network_interfaces = _schema_common_private_endpoint_read.properties.network_interfaces
         network_interfaces.Element = AAZObjectType()
-        cls._build_schema_network_interface_read(network_interfaces.Element)
+        cls._build_schema_common_network_interface_read(network_interfaces.Element)
 
-        private_link_service_connections = _schema_private_endpoint_read.properties.private_link_service_connections
+        private_link_service_connections = _schema_common_private_endpoint_read.properties.private_link_service_connections
         private_link_service_connections.Element = AAZObjectType()
-        cls._build_schema_private_link_service_connection_read(private_link_service_connections.Element)
+        cls._build_schema_common_private_link_service_connection_read(private_link_service_connections.Element)
 
-        tags = _schema_private_endpoint_read.tags
+        tags = _schema_common_private_endpoint_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_endpoint_read.etag
-        _schema.extended_location = cls._schema_private_endpoint_read.extended_location
-        _schema.id = cls._schema_private_endpoint_read.id
-        _schema.location = cls._schema_private_endpoint_read.location
-        _schema.name = cls._schema_private_endpoint_read.name
-        _schema.properties = cls._schema_private_endpoint_read.properties
-        _schema.tags = cls._schema_private_endpoint_read.tags
-        _schema.type = cls._schema_private_endpoint_read.type
+        _schema.etag = cls._schema_common_private_endpoint_read.etag
+        _schema.extended_location = cls._schema_common_private_endpoint_read.extended_location
+        _schema.id = cls._schema_common_private_endpoint_read.id
+        _schema.location = cls._schema_common_private_endpoint_read.location
+        _schema.name = cls._schema_common_private_endpoint_read.name
+        _schema.properties = cls._schema_common_private_endpoint_read.properties
+        _schema.tags = cls._schema_common_private_endpoint_read.tags
+        _schema.type = cls._schema_common_private_endpoint_read.type
 
-    _schema_private_link_service_connection_state_read = None
+    _schema_common_private_link_service_connection_state_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_state_read(cls, _schema):
-        if cls._schema_private_link_service_connection_state_read is not None:
-            _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-            _schema.description = cls._schema_private_link_service_connection_state_read.description
-            _schema.status = cls._schema_private_link_service_connection_state_read.status
+    def _build_schema_common_private_link_service_connection_state_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_state_read is not None:
+            _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+            _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+            _schema.status = cls._schema_common_private_link_service_connection_state_read.status
             return
 
-        cls._schema_private_link_service_connection_state_read = _schema_private_link_service_connection_state_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read = AAZObjectType()
 
-        private_link_service_connection_state_read = _schema_private_link_service_connection_state_read
-        private_link_service_connection_state_read.actions_required = AAZStrType(
+        common_private_link_service_connection_state_read = _schema_common_private_link_service_connection_state_read
+        common_private_link_service_connection_state_read.actions_required = AAZStrType(
             serialized_name="actionsRequired",
         )
-        private_link_service_connection_state_read.description = AAZStrType()
-        private_link_service_connection_state_read.status = AAZStrType()
+        common_private_link_service_connection_state_read.description = AAZStrType()
+        common_private_link_service_connection_state_read.status = AAZStrType()
 
-        _schema.actions_required = cls._schema_private_link_service_connection_state_read.actions_required
-        _schema.description = cls._schema_private_link_service_connection_state_read.description
-        _schema.status = cls._schema_private_link_service_connection_state_read.status
+        _schema.actions_required = cls._schema_common_private_link_service_connection_state_read.actions_required
+        _schema.description = cls._schema_common_private_link_service_connection_state_read.description
+        _schema.status = cls._schema_common_private_link_service_connection_state_read.status
 
-    _schema_private_link_service_connection_read = None
+    _schema_common_private_link_service_connection_read = None
 
     @classmethod
-    def _build_schema_private_link_service_connection_read(cls, _schema):
-        if cls._schema_private_link_service_connection_read is not None:
-            _schema.etag = cls._schema_private_link_service_connection_read.etag
-            _schema.id = cls._schema_private_link_service_connection_read.id
-            _schema.name = cls._schema_private_link_service_connection_read.name
-            _schema.properties = cls._schema_private_link_service_connection_read.properties
-            _schema.type = cls._schema_private_link_service_connection_read.type
+    def _build_schema_common_private_link_service_connection_read(cls, _schema):
+        if cls._schema_common_private_link_service_connection_read is not None:
+            _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+            _schema.id = cls._schema_common_private_link_service_connection_read.id
+            _schema.name = cls._schema_common_private_link_service_connection_read.name
+            _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+            _schema.type = cls._schema_common_private_link_service_connection_read.type
             return
 
-        cls._schema_private_link_service_connection_read = _schema_private_link_service_connection_read = AAZObjectType()
+        cls._schema_common_private_link_service_connection_read = _schema_common_private_link_service_connection_read = AAZObjectType()
 
-        private_link_service_connection_read = _schema_private_link_service_connection_read
-        private_link_service_connection_read.etag = AAZStrType(
+        common_private_link_service_connection_read = _schema_common_private_link_service_connection_read
+        common_private_link_service_connection_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        private_link_service_connection_read.id = AAZStrType()
-        private_link_service_connection_read.name = AAZStrType()
-        private_link_service_connection_read.properties = AAZObjectType(
+        common_private_link_service_connection_read.id = AAZStrType()
+        common_private_link_service_connection_read.name = AAZStrType()
+        common_private_link_service_connection_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        private_link_service_connection_read.type = AAZStrType(
+        common_private_link_service_connection_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_private_link_service_connection_read.properties
+        properties = _schema_common_private_link_service_connection_read.properties
         properties.group_ids = AAZListType(
             serialized_name="groupIds",
         )
         properties.private_link_service_connection_state = AAZObjectType(
             serialized_name="privateLinkServiceConnectionState",
         )
-        cls._build_schema_private_link_service_connection_state_read(properties.private_link_service_connection_state)
+        cls._build_schema_common_private_link_service_connection_state_read(properties.private_link_service_connection_state)
         properties.private_link_service_id = AAZStrType(
             serialized_name="privateLinkServiceId",
         )
@@ -1493,58 +1509,58 @@ class _WaitHelper:
             serialized_name="requestMessage",
         )
 
-        group_ids = _schema_private_link_service_connection_read.properties.group_ids
+        group_ids = _schema_common_private_link_service_connection_read.properties.group_ids
         group_ids.Element = AAZStrType()
 
-        _schema.etag = cls._schema_private_link_service_connection_read.etag
-        _schema.id = cls._schema_private_link_service_connection_read.id
-        _schema.name = cls._schema_private_link_service_connection_read.name
-        _schema.properties = cls._schema_private_link_service_connection_read.properties
-        _schema.type = cls._schema_private_link_service_connection_read.type
+        _schema.etag = cls._schema_common_private_link_service_connection_read.etag
+        _schema.id = cls._schema_common_private_link_service_connection_read.id
+        _schema.name = cls._schema_common_private_link_service_connection_read.name
+        _schema.properties = cls._schema_common_private_link_service_connection_read.properties
+        _schema.type = cls._schema_common_private_link_service_connection_read.type
 
-    _schema_public_ip_address_read = None
+    _schema_common_public_ip_address_read = None
 
     @classmethod
-    def _build_schema_public_ip_address_read(cls, _schema):
-        if cls._schema_public_ip_address_read is not None:
-            _schema.etag = cls._schema_public_ip_address_read.etag
-            _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-            _schema.id = cls._schema_public_ip_address_read.id
-            _schema.location = cls._schema_public_ip_address_read.location
-            _schema.name = cls._schema_public_ip_address_read.name
-            _schema.properties = cls._schema_public_ip_address_read.properties
-            _schema.sku = cls._schema_public_ip_address_read.sku
-            _schema.tags = cls._schema_public_ip_address_read.tags
-            _schema.type = cls._schema_public_ip_address_read.type
-            _schema.zones = cls._schema_public_ip_address_read.zones
+    def _build_schema_common_public_ip_address_read(cls, _schema):
+        if cls._schema_common_public_ip_address_read is not None:
+            _schema.etag = cls._schema_common_public_ip_address_read.etag
+            _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+            _schema.id = cls._schema_common_public_ip_address_read.id
+            _schema.location = cls._schema_common_public_ip_address_read.location
+            _schema.name = cls._schema_common_public_ip_address_read.name
+            _schema.properties = cls._schema_common_public_ip_address_read.properties
+            _schema.sku = cls._schema_common_public_ip_address_read.sku
+            _schema.tags = cls._schema_common_public_ip_address_read.tags
+            _schema.type = cls._schema_common_public_ip_address_read.type
+            _schema.zones = cls._schema_common_public_ip_address_read.zones
             return
 
-        cls._schema_public_ip_address_read = _schema_public_ip_address_read = AAZObjectType()
+        cls._schema_common_public_ip_address_read = _schema_common_public_ip_address_read = AAZObjectType()
 
-        public_ip_address_read = _schema_public_ip_address_read
-        public_ip_address_read.etag = AAZStrType(
+        common_public_ip_address_read = _schema_common_public_ip_address_read
+        common_public_ip_address_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.extended_location = AAZObjectType(
+        common_public_ip_address_read.extended_location = AAZObjectType(
             serialized_name="extendedLocation",
         )
-        cls._build_schema_extended_location_read(public_ip_address_read.extended_location)
-        public_ip_address_read.id = AAZStrType()
-        public_ip_address_read.location = AAZStrType()
-        public_ip_address_read.name = AAZStrType(
+        cls._build_schema_common_extended_location_read(common_public_ip_address_read.extended_location)
+        common_public_ip_address_read.id = AAZStrType()
+        common_public_ip_address_read.location = AAZStrType()
+        common_public_ip_address_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.properties = AAZObjectType(
+        common_public_ip_address_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        public_ip_address_read.sku = AAZObjectType()
-        public_ip_address_read.tags = AAZDictType()
-        public_ip_address_read.type = AAZStrType(
+        common_public_ip_address_read.sku = AAZObjectType()
+        common_public_ip_address_read.tags = AAZDictType()
+        common_public_ip_address_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        public_ip_address_read.zones = AAZListType()
+        common_public_ip_address_read.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties
+        properties = _schema_common_public_ip_address_read.properties
         properties.ddos_settings = AAZObjectType(
             serialized_name="ddosSettings",
         )
@@ -1564,14 +1580,14 @@ class _WaitHelper:
             serialized_name="ipConfiguration",
             flags={"read_only": True},
         )
-        cls._build_schema_ip_configuration_read(properties.ip_configuration)
+        cls._build_schema_common_ip_configuration_read(properties.ip_configuration)
         properties.ip_tags = AAZListType(
             serialized_name="ipTags",
         )
         properties.linked_public_ip_address = AAZObjectType(
             serialized_name="linkedPublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.linked_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.linked_public_ip_address)
         properties.migration_phase = AAZStrType(
             serialized_name="migrationPhase",
         )
@@ -1591,7 +1607,7 @@ class _WaitHelper:
         properties.public_ip_prefix = AAZObjectType(
             serialized_name="publicIPPrefix",
         )
-        cls._build_schema_sub_resource_read(properties.public_ip_prefix)
+        cls._build_schema_common_sub_resource_read(properties.public_ip_prefix)
         properties.resource_guid = AAZStrType(
             serialized_name="resourceGuid",
             flags={"read_only": True},
@@ -1599,18 +1615,22 @@ class _WaitHelper:
         properties.service_public_ip_address = AAZObjectType(
             serialized_name="servicePublicIPAddress",
         )
-        cls._build_schema_public_ip_address_read(properties.service_public_ip_address)
+        cls._build_schema_common_public_ip_address_read(properties.service_public_ip_address)
 
-        ddos_settings = _schema_public_ip_address_read.properties.ddos_settings
+        ddos_settings = _schema_common_public_ip_address_read.properties.ddos_settings
+        ddos_settings.ddos_custom_policy = AAZObjectType(
+            serialized_name="ddosCustomPolicy",
+        )
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_custom_policy)
         ddos_settings.ddos_protection_plan = AAZObjectType(
             serialized_name="ddosProtectionPlan",
         )
-        cls._build_schema_sub_resource_read(ddos_settings.ddos_protection_plan)
+        cls._build_schema_common_sub_resource_read(ddos_settings.ddos_protection_plan)
         ddos_settings.protection_mode = AAZStrType(
             serialized_name="protectionMode",
         )
 
-        dns_settings = _schema_public_ip_address_read.properties.dns_settings
+        dns_settings = _schema_common_public_ip_address_read.properties.dns_settings
         dns_settings.domain_name_label = AAZStrType(
             serialized_name="domainNameLabel",
         )
@@ -1622,16 +1642,16 @@ class _WaitHelper:
             serialized_name="reverseFqdn",
         )
 
-        ip_tags = _schema_public_ip_address_read.properties.ip_tags
+        ip_tags = _schema_common_public_ip_address_read.properties.ip_tags
         ip_tags.Element = AAZObjectType()
 
-        _element = _schema_public_ip_address_read.properties.ip_tags.Element
+        _element = _schema_common_public_ip_address_read.properties.ip_tags.Element
         _element.ip_tag_type = AAZStrType(
             serialized_name="ipTagType",
         )
         _element.tag = AAZStrType()
 
-        nat_gateway = _schema_public_ip_address_read.properties.nat_gateway
+        nat_gateway = _schema_common_public_ip_address_read.properties.nat_gateway
         nat_gateway.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1650,10 +1670,11 @@ class _WaitHelper:
         )
         nat_gateway.zones = AAZListType()
 
-        properties = _schema_public_ip_address_read.properties.nat_gateway.properties
+        properties = _schema_common_public_ip_address_read.properties.nat_gateway.properties
         properties.idle_timeout_in_minutes = AAZIntType(
             serialized_name="idleTimeoutInMinutes",
         )
+        properties.nat64 = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -1674,90 +1695,96 @@ class _WaitHelper:
             serialized_name="resourceGuid",
             flags={"read_only": True},
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.source_virtual_network = AAZObjectType(
             serialized_name="sourceVirtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.source_virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.source_virtual_network)
         properties.subnets = AAZListType(
             flags={"read_only": True},
         )
 
-        public_ip_addresses = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
+        public_ip_addresses = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses
         public_ip_addresses.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
+        public_ip_addresses_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
+        public_ip_prefixes = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = _schema_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = _schema_common_public_ip_address_read.properties.nat_gateway.properties.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
-        subnets = _schema_public_ip_address_read.properties.nat_gateway.properties.subnets
+        subnets = _schema_common_public_ip_address_read.properties.nat_gateway.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(subnets.Element)
+        cls._build_schema_common_sub_resource_read(subnets.Element)
 
-        sku = _schema_public_ip_address_read.properties.nat_gateway.sku
+        sku = _schema_common_public_ip_address_read.properties.nat_gateway.sku
         sku.name = AAZStrType()
 
-        tags = _schema_public_ip_address_read.properties.nat_gateway.tags
+        tags = _schema_common_public_ip_address_read.properties.nat_gateway.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.properties.nat_gateway.zones
+        zones = _schema_common_public_ip_address_read.properties.nat_gateway.zones
         zones.Element = AAZStrType()
 
-        sku = _schema_public_ip_address_read.sku
+        sku = _schema_common_public_ip_address_read.sku
         sku.name = AAZStrType()
         sku.tier = AAZStrType()
 
-        tags = _schema_public_ip_address_read.tags
+        tags = _schema_common_public_ip_address_read.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_public_ip_address_read.zones
+        zones = _schema_common_public_ip_address_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_public_ip_address_read.etag
-        _schema.extended_location = cls._schema_public_ip_address_read.extended_location
-        _schema.id = cls._schema_public_ip_address_read.id
-        _schema.location = cls._schema_public_ip_address_read.location
-        _schema.name = cls._schema_public_ip_address_read.name
-        _schema.properties = cls._schema_public_ip_address_read.properties
-        _schema.sku = cls._schema_public_ip_address_read.sku
-        _schema.tags = cls._schema_public_ip_address_read.tags
-        _schema.type = cls._schema_public_ip_address_read.type
-        _schema.zones = cls._schema_public_ip_address_read.zones
+        _schema.etag = cls._schema_common_public_ip_address_read.etag
+        _schema.extended_location = cls._schema_common_public_ip_address_read.extended_location
+        _schema.id = cls._schema_common_public_ip_address_read.id
+        _schema.location = cls._schema_common_public_ip_address_read.location
+        _schema.name = cls._schema_common_public_ip_address_read.name
+        _schema.properties = cls._schema_common_public_ip_address_read.properties
+        _schema.sku = cls._schema_common_public_ip_address_read.sku
+        _schema.tags = cls._schema_common_public_ip_address_read.tags
+        _schema.type = cls._schema_common_public_ip_address_read.type
+        _schema.zones = cls._schema_common_public_ip_address_read.zones
 
-    _schema_security_rule_read = None
+    _schema_common_security_rule_read = None
 
     @classmethod
-    def _build_schema_security_rule_read(cls, _schema):
-        if cls._schema_security_rule_read is not None:
-            _schema.etag = cls._schema_security_rule_read.etag
-            _schema.id = cls._schema_security_rule_read.id
-            _schema.name = cls._schema_security_rule_read.name
-            _schema.properties = cls._schema_security_rule_read.properties
-            _schema.type = cls._schema_security_rule_read.type
+    def _build_schema_common_security_rule_read(cls, _schema):
+        if cls._schema_common_security_rule_read is not None:
+            _schema.etag = cls._schema_common_security_rule_read.etag
+            _schema.id = cls._schema_common_security_rule_read.id
+            _schema.name = cls._schema_common_security_rule_read.name
+            _schema.properties = cls._schema_common_security_rule_read.properties
+            _schema.type = cls._schema_common_security_rule_read.type
             return
 
-        cls._schema_security_rule_read = _schema_security_rule_read = AAZObjectType()
+        cls._schema_common_security_rule_read = _schema_common_security_rule_read = AAZObjectType()
 
-        security_rule_read = _schema_security_rule_read
-        security_rule_read.etag = AAZStrType(
+        common_security_rule_read = _schema_common_security_rule_read
+        common_security_rule_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        security_rule_read.id = AAZStrType()
-        security_rule_read.name = AAZStrType()
-        security_rule_read.properties = AAZObjectType(
+        common_security_rule_read.id = AAZStrType()
+        common_security_rule_read.name = AAZStrType()
+        common_security_rule_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        security_rule_read.type = AAZStrType()
+        common_security_rule_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_security_rule_read.properties
+        properties = _schema_common_security_rule_read.properties
         properties.access = AAZStrType(
             flags={"required": True},
         )
@@ -1806,75 +1833,77 @@ class _WaitHelper:
             serialized_name="sourcePortRanges",
         )
 
-        destination_address_prefixes = _schema_security_rule_read.properties.destination_address_prefixes
+        destination_address_prefixes = _schema_common_security_rule_read.properties.destination_address_prefixes
         destination_address_prefixes.Element = AAZStrType()
 
-        destination_application_security_groups = _schema_security_rule_read.properties.destination_application_security_groups
+        destination_application_security_groups = _schema_common_security_rule_read.properties.destination_application_security_groups
         destination_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(destination_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(destination_application_security_groups.Element)
 
-        destination_port_ranges = _schema_security_rule_read.properties.destination_port_ranges
+        destination_port_ranges = _schema_common_security_rule_read.properties.destination_port_ranges
         destination_port_ranges.Element = AAZStrType()
 
-        source_address_prefixes = _schema_security_rule_read.properties.source_address_prefixes
+        source_address_prefixes = _schema_common_security_rule_read.properties.source_address_prefixes
         source_address_prefixes.Element = AAZStrType()
 
-        source_application_security_groups = _schema_security_rule_read.properties.source_application_security_groups
+        source_application_security_groups = _schema_common_security_rule_read.properties.source_application_security_groups
         source_application_security_groups.Element = AAZObjectType()
-        cls._build_schema_application_security_group_read(source_application_security_groups.Element)
+        cls._build_schema_common_application_security_group_read(source_application_security_groups.Element)
 
-        source_port_ranges = _schema_security_rule_read.properties.source_port_ranges
+        source_port_ranges = _schema_common_security_rule_read.properties.source_port_ranges
         source_port_ranges.Element = AAZStrType()
 
-        _schema.etag = cls._schema_security_rule_read.etag
-        _schema.id = cls._schema_security_rule_read.id
-        _schema.name = cls._schema_security_rule_read.name
-        _schema.properties = cls._schema_security_rule_read.properties
-        _schema.type = cls._schema_security_rule_read.type
+        _schema.etag = cls._schema_common_security_rule_read.etag
+        _schema.id = cls._schema_common_security_rule_read.id
+        _schema.name = cls._schema_common_security_rule_read.name
+        _schema.properties = cls._schema_common_security_rule_read.properties
+        _schema.type = cls._schema_common_security_rule_read.type
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType(
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType(
             flags={"read_only": True}
         )
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
-    _schema_subnet_read = None
+    _schema_common_subnet_read = None
 
     @classmethod
-    def _build_schema_subnet_read(cls, _schema):
-        if cls._schema_subnet_read is not None:
-            _schema.etag = cls._schema_subnet_read.etag
-            _schema.id = cls._schema_subnet_read.id
-            _schema.name = cls._schema_subnet_read.name
-            _schema.properties = cls._schema_subnet_read.properties
-            _schema.type = cls._schema_subnet_read.type
+    def _build_schema_common_subnet_read(cls, _schema):
+        if cls._schema_common_subnet_read is not None:
+            _schema.etag = cls._schema_common_subnet_read.etag
+            _schema.id = cls._schema_common_subnet_read.id
+            _schema.name = cls._schema_common_subnet_read.name
+            _schema.properties = cls._schema_common_subnet_read.properties
+            _schema.type = cls._schema_common_subnet_read.type
             return
 
-        cls._schema_subnet_read = _schema_subnet_read = AAZObjectType()
+        cls._schema_common_subnet_read = _schema_common_subnet_read = AAZObjectType()
 
-        subnet_read = _schema_subnet_read
-        subnet_read.etag = AAZStrType(
+        common_subnet_read = _schema_common_subnet_read
+        common_subnet_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        subnet_read.id = AAZStrType()
-        subnet_read.name = AAZStrType()
-        subnet_read.properties = AAZObjectType(
+        common_subnet_read.id = AAZStrType()
+        common_subnet_read.name = AAZStrType()
+        common_subnet_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        subnet_read.type = AAZStrType()
+        common_subnet_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties
+        properties = _schema_common_subnet_read.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
@@ -1905,11 +1934,11 @@ class _WaitHelper:
         properties.nat_gateway = AAZObjectType(
             serialized_name="natGateway",
         )
-        cls._build_schema_sub_resource_read(properties.nat_gateway)
+        cls._build_schema_common_sub_resource_read(properties.nat_gateway)
         properties.network_security_group = AAZObjectType(
             serialized_name="networkSecurityGroup",
         )
-        cls._build_schema_network_security_group_read(properties.network_security_group)
+        cls._build_schema_common_network_security_group_read(properties.network_security_group)
         properties.private_endpoint_network_policies = AAZStrType(
             serialized_name="privateEndpointNetworkPolicies",
         )
@@ -1944,17 +1973,21 @@ class _WaitHelper:
         properties.service_endpoints = AAZListType(
             serialized_name="serviceEndpoints",
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.sharing_scope = AAZStrType(
             serialized_name="sharingScope",
         )
 
-        address_prefixes = _schema_subnet_read.properties.address_prefixes
+        address_prefixes = _schema_common_subnet_read.properties.address_prefixes
         address_prefixes.Element = AAZStrType()
 
-        application_gateway_ip_configurations = _schema_subnet_read.properties.application_gateway_ip_configurations
+        application_gateway_ip_configurations = _schema_common_subnet_read.properties.application_gateway_ip_configurations
         application_gateway_ip_configurations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.application_gateway_ip_configurations.Element
+        _element = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1967,18 +2000,18 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.application_gateway_ip_configurations.Element.properties
+        properties = _schema_common_subnet_read.properties.application_gateway_ip_configurations.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_sub_resource_read(properties.subnet)
+        cls._build_schema_common_sub_resource_read(properties.subnet)
 
-        delegations = _schema_subnet_read.properties.delegations
+        delegations = _schema_common_subnet_read.properties.delegations
         delegations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.delegations.Element
+        _element = _schema_common_subnet_read.properties.delegations.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -1989,7 +2022,7 @@ class _WaitHelper:
         )
         _element.type = AAZStrType()
 
-        properties = _schema_subnet_read.properties.delegations.Element.properties
+        properties = _schema_common_subnet_read.properties.delegations.Element.properties
         properties.actions = AAZListType(
             flags={"read_only": True},
         )
@@ -2001,17 +2034,17 @@ class _WaitHelper:
             serialized_name="serviceName",
         )
 
-        actions = _schema_subnet_read.properties.delegations.Element.properties.actions
+        actions = _schema_common_subnet_read.properties.delegations.Element.properties.actions
         actions.Element = AAZStrType()
 
-        ip_allocations = _schema_subnet_read.properties.ip_allocations
+        ip_allocations = _schema_common_subnet_read.properties.ip_allocations
         ip_allocations.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(ip_allocations.Element)
+        cls._build_schema_common_sub_resource_read(ip_allocations.Element)
 
-        ip_configuration_profiles = _schema_subnet_read.properties.ip_configuration_profiles
+        ip_configuration_profiles = _schema_common_subnet_read.properties.ip_configuration_profiles
         ip_configuration_profiles.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ip_configuration_profiles.Element
+        _element = _schema_common_subnet_read.properties.ip_configuration_profiles.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2024,22 +2057,22 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.ip_configuration_profiles.Element.properties
+        properties = _schema_common_subnet_read.properties.ip_configuration_profiles.Element.properties
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         properties.subnet = AAZObjectType()
-        cls._build_schema_subnet_read(properties.subnet)
+        cls._build_schema_common_subnet_read(properties.subnet)
 
-        ip_configurations = _schema_subnet_read.properties.ip_configurations
+        ip_configurations = _schema_common_subnet_read.properties.ip_configurations
         ip_configurations.Element = AAZObjectType()
-        cls._build_schema_ip_configuration_read(ip_configurations.Element)
+        cls._build_schema_common_ip_configuration_read(ip_configurations.Element)
 
-        ipam_pool_prefix_allocations = _schema_subnet_read.properties.ipam_pool_prefix_allocations
+        ipam_pool_prefix_allocations = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations
         ipam_pool_prefix_allocations.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element
+        _element = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element
         _element.allocated_address_prefixes = AAZListType(
             serialized_name="allocatedAddressPrefixes",
             flags={"read_only": True},
@@ -2051,20 +2084,20 @@ class _WaitHelper:
             flags={"client_flatten": True},
         )
 
-        allocated_address_prefixes = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
+        allocated_address_prefixes = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.allocated_address_prefixes
         allocated_address_prefixes.Element = AAZStrType()
 
-        pool = _schema_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
+        pool = _schema_common_subnet_read.properties.ipam_pool_prefix_allocations.Element.pool
         pool.id = AAZStrType()
 
-        private_endpoints = _schema_subnet_read.properties.private_endpoints
+        private_endpoints = _schema_common_subnet_read.properties.private_endpoints
         private_endpoints.Element = AAZObjectType()
-        cls._build_schema_private_endpoint_read(private_endpoints.Element)
+        cls._build_schema_common_private_endpoint_read(private_endpoints.Element)
 
-        resource_navigation_links = _schema_subnet_read.properties.resource_navigation_links
+        resource_navigation_links = _schema_common_subnet_read.properties.resource_navigation_links
         resource_navigation_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.resource_navigation_links.Element
+        _element = _schema_common_subnet_read.properties.resource_navigation_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2079,7 +2112,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.resource_navigation_links.Element.properties
+        properties = _schema_common_subnet_read.properties.resource_navigation_links.Element.properties
         properties.link = AAZStrType()
         properties.linked_resource_type = AAZStrType(
             serialized_name="linkedResourceType",
@@ -2089,7 +2122,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        route_table = _schema_subnet_read.properties.route_table
+        route_table = _schema_common_subnet_read.properties.route_table
         route_table.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2106,9 +2139,12 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.route_table.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties
         properties.disable_bgp_route_propagation = AAZBoolType(
             serialized_name="disableBgpRoutePropagation",
+        )
+        properties.disable_peering_route = AAZStrType(
+            serialized_name="disablePeeringRoute",
         )
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2123,10 +2159,10 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        routes = _schema_subnet_read.properties.route_table.properties.routes
+        routes = _schema_common_subnet_read.properties.route_table.properties.routes
         routes.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.route_table.properties.routes.Element
+        _element = _schema_common_subnet_read.properties.route_table.properties.routes.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2135,15 +2171,20 @@ class _WaitHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.route_table.properties.routes.Element.properties
+        properties = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties
         properties.address_prefix = AAZStrType(
             serialized_name="addressPrefix",
         )
         properties.has_bgp_override = AAZBoolType(
             serialized_name="hasBgpOverride",
             flags={"read_only": True},
+        )
+        properties.next_hop = AAZObjectType(
+            serialized_name="nextHop",
         )
         properties.next_hop_ip_address = AAZStrType(
             serialized_name="nextHopIpAddress",
@@ -2157,17 +2198,26 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        subnets = _schema_subnet_read.properties.route_table.properties.subnets
-        subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        next_hop = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop
+        next_hop.next_hop_ip_addresses = AAZListType(
+            serialized_name="nextHopIpAddresses",
+            flags={"required": True},
+        )
 
-        tags = _schema_subnet_read.properties.route_table.tags
+        next_hop_ip_addresses = _schema_common_subnet_read.properties.route_table.properties.routes.Element.properties.next_hop.next_hop_ip_addresses
+        next_hop_ip_addresses.Element = AAZStrType()
+
+        subnets = _schema_common_subnet_read.properties.route_table.properties.subnets
+        subnets.Element = AAZObjectType()
+        cls._build_schema_common_subnet_read(subnets.Element)
+
+        tags = _schema_common_subnet_read.properties.route_table.tags
         tags.Element = AAZStrType()
 
-        service_association_links = _schema_subnet_read.properties.service_association_links
+        service_association_links = _schema_common_subnet_read.properties.service_association_links
         service_association_links.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_association_links.Element
+        _element = _schema_common_subnet_read.properties.service_association_links.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2180,7 +2230,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_association_links.Element.properties
+        properties = _schema_common_subnet_read.properties.service_association_links.Element.properties
         properties.allow_delete = AAZBoolType(
             serialized_name="allowDelete",
         )
@@ -2194,13 +2244,13 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        locations = _schema_subnet_read.properties.service_association_links.Element.properties.locations
+        locations = _schema_common_subnet_read.properties.service_association_links.Element.properties.locations
         locations.Element = AAZStrType()
 
-        service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies
+        service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies
         service_endpoint_policies.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2220,7 +2270,7 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties
         properties.contextual_service_endpoint_policies = AAZListType(
             serialized_name="contextualServiceEndpointPolicies",
         )
@@ -2242,13 +2292,13 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        contextual_service_endpoint_policies = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
+        contextual_service_endpoint_policies = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.contextual_service_endpoint_policies
         contextual_service_endpoint_policies.Element = AAZStrType()
 
-        service_endpoint_policy_definitions = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
+        service_endpoint_policy_definitions = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions
         service_endpoint_policy_definitions.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
+        _element = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element
         _element.etag = AAZStrType(
             flags={"read_only": True},
         )
@@ -2257,9 +2307,11 @@ class _WaitHelper:
         _element.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        _element.type = AAZStrType()
+        _element.type = AAZStrType(
+            flags={"read_only": True},
+        )
 
-        properties = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
+        properties = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties
         properties.description = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
@@ -2270,82 +2322,82 @@ class _WaitHelper:
             serialized_name="serviceResources",
         )
 
-        service_resources = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
+        service_resources = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.service_endpoint_policy_definitions.Element.properties.service_resources
         service_resources.Element = AAZStrType()
 
-        subnets = _schema_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
+        subnets = _schema_common_subnet_read.properties.service_endpoint_policies.Element.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_subnet_read(subnets.Element)
+        cls._build_schema_common_subnet_read(subnets.Element)
 
-        tags = _schema_subnet_read.properties.service_endpoint_policies.Element.tags
+        tags = _schema_common_subnet_read.properties.service_endpoint_policies.Element.tags
         tags.Element = AAZStrType()
 
-        service_endpoints = _schema_subnet_read.properties.service_endpoints
+        service_endpoints = _schema_common_subnet_read.properties.service_endpoints
         service_endpoints.Element = AAZObjectType()
 
-        _element = _schema_subnet_read.properties.service_endpoints.Element
+        _element = _schema_common_subnet_read.properties.service_endpoints.Element
         _element.locations = AAZListType()
         _element.network_identifier = AAZObjectType(
             serialized_name="networkIdentifier",
         )
-        cls._build_schema_sub_resource_read(_element.network_identifier)
+        cls._build_schema_common_sub_resource_read(_element.network_identifier)
         _element.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
         )
         _element.service = AAZStrType()
 
-        locations = _schema_subnet_read.properties.service_endpoints.Element.locations
+        locations = _schema_common_subnet_read.properties.service_endpoints.Element.locations
         locations.Element = AAZStrType()
 
-        _schema.etag = cls._schema_subnet_read.etag
-        _schema.id = cls._schema_subnet_read.id
-        _schema.name = cls._schema_subnet_read.name
-        _schema.properties = cls._schema_subnet_read.properties
-        _schema.type = cls._schema_subnet_read.type
+        _schema.etag = cls._schema_common_subnet_read.etag
+        _schema.id = cls._schema_common_subnet_read.id
+        _schema.name = cls._schema_common_subnet_read.name
+        _schema.properties = cls._schema_common_subnet_read.properties
+        _schema.type = cls._schema_common_subnet_read.type
 
-    _schema_virtual_network_tap_read = None
+    _schema_common_virtual_network_tap_read = None
 
     @classmethod
-    def _build_schema_virtual_network_tap_read(cls, _schema):
-        if cls._schema_virtual_network_tap_read is not None:
-            _schema.etag = cls._schema_virtual_network_tap_read.etag
-            _schema.id = cls._schema_virtual_network_tap_read.id
-            _schema.location = cls._schema_virtual_network_tap_read.location
-            _schema.name = cls._schema_virtual_network_tap_read.name
-            _schema.properties = cls._schema_virtual_network_tap_read.properties
-            _schema.tags = cls._schema_virtual_network_tap_read.tags
-            _schema.type = cls._schema_virtual_network_tap_read.type
+    def _build_schema_common_virtual_network_tap_read(cls, _schema):
+        if cls._schema_common_virtual_network_tap_read is not None:
+            _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+            _schema.id = cls._schema_common_virtual_network_tap_read.id
+            _schema.location = cls._schema_common_virtual_network_tap_read.location
+            _schema.name = cls._schema_common_virtual_network_tap_read.name
+            _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+            _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+            _schema.type = cls._schema_common_virtual_network_tap_read.type
             return
 
-        cls._schema_virtual_network_tap_read = _schema_virtual_network_tap_read = AAZObjectType()
+        cls._schema_common_virtual_network_tap_read = _schema_common_virtual_network_tap_read = AAZObjectType()
 
-        virtual_network_tap_read = _schema_virtual_network_tap_read
-        virtual_network_tap_read.etag = AAZStrType(
+        common_virtual_network_tap_read = _schema_common_virtual_network_tap_read
+        common_virtual_network_tap_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.id = AAZStrType()
-        virtual_network_tap_read.location = AAZStrType()
-        virtual_network_tap_read.name = AAZStrType(
+        common_virtual_network_tap_read.id = AAZStrType()
+        common_virtual_network_tap_read.location = AAZStrType()
+        common_virtual_network_tap_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        virtual_network_tap_read.properties = AAZObjectType(
+        common_virtual_network_tap_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        virtual_network_tap_read.tags = AAZDictType()
-        virtual_network_tap_read.type = AAZStrType(
+        common_virtual_network_tap_read.tags = AAZDictType()
+        common_virtual_network_tap_read.type = AAZStrType(
             flags={"read_only": True},
         )
 
-        properties = _schema_virtual_network_tap_read.properties
+        properties = _schema_common_virtual_network_tap_read.properties
         properties.destination_load_balancer_front_end_ip_configuration = AAZObjectType(
             serialized_name="destinationLoadBalancerFrontEndIPConfiguration",
         )
-        cls._build_schema_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
+        cls._build_schema_common_frontend_ip_configuration_read(properties.destination_load_balancer_front_end_ip_configuration)
         properties.destination_network_interface_ip_configuration = AAZObjectType(
             serialized_name="destinationNetworkInterfaceIPConfiguration",
         )
-        cls._build_schema_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
+        cls._build_schema_common_network_interface_ip_configuration_read(properties.destination_network_interface_ip_configuration)
         properties.destination_port = AAZIntType(
             serialized_name="destinationPort",
         )
@@ -2362,20 +2414,20 @@ class _WaitHelper:
             flags={"read_only": True},
         )
 
-        network_interface_tap_configurations = _schema_virtual_network_tap_read.properties.network_interface_tap_configurations
+        network_interface_tap_configurations = _schema_common_virtual_network_tap_read.properties.network_interface_tap_configurations
         network_interface_tap_configurations.Element = AAZObjectType()
-        cls._build_schema_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
+        cls._build_schema_common_network_interface_tap_configuration_read(network_interface_tap_configurations.Element)
 
-        tags = _schema_virtual_network_tap_read.tags
+        tags = _schema_common_virtual_network_tap_read.tags
         tags.Element = AAZStrType()
 
-        _schema.etag = cls._schema_virtual_network_tap_read.etag
-        _schema.id = cls._schema_virtual_network_tap_read.id
-        _schema.location = cls._schema_virtual_network_tap_read.location
-        _schema.name = cls._schema_virtual_network_tap_read.name
-        _schema.properties = cls._schema_virtual_network_tap_read.properties
-        _schema.tags = cls._schema_virtual_network_tap_read.tags
-        _schema.type = cls._schema_virtual_network_tap_read.type
+        _schema.etag = cls._schema_common_virtual_network_tap_read.etag
+        _schema.id = cls._schema_common_virtual_network_tap_read.id
+        _schema.location = cls._schema_common_virtual_network_tap_read.location
+        _schema.name = cls._schema_common_virtual_network_tap_read.name
+        _schema.properties = cls._schema_common_virtual_network_tap_read.properties
+        _schema.tags = cls._schema_common_virtual_network_tap_read.tags
+        _schema.type = cls._schema_common_virtual_network_tap_read.type
 
 
 __all__ = ["Wait"]

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -5209,7 +5209,7 @@ def create_public_ip(cmd, resource_group_name, public_ip_address_name, location=
                      allocation_method=None, dns_name=None, dns_name_scope=None,
                      idle_timeout=4, reverse_fqdn=None, version=None, sku=None, tier=None, zone=None, ip_tags=None,
                      public_ip_prefix=None, edge_zone=None, ip_address=None,
-                     protection_mode=None, ddos_protection_plan=None):
+                     protection_mode=None, ddos_protection_plan=None, ddos_custom_policy=None):
     public_ip_args = {
         'name': public_ip_address_name,
         "resource_group": resource_group_name,
@@ -5266,6 +5266,16 @@ def create_public_ip(cmd, resource_group_name, public_ip_address_name, location=
         public_ip_args['ddos_protection_mode'] = protection_mode
     if ddos_protection_plan:
         public_ip_args['ddos_protection_plan'] = ddos_protection_plan
+    if ddos_custom_policy:
+        if not is_valid_resource_id(ddos_custom_policy):
+            ddos_custom_policy = resource_id(
+                subscription=get_subscription_id(cmd.cli_ctx),
+                resource_group=resource_group_name,
+                namespace='Microsoft.Network',
+                type='ddosCustomPolicies',
+                name=ddos_custom_policy,
+            )
+        public_ip_args['ddos_custom_policy'] = {'id': ddos_custom_policy}
 
     return PublicIPCreate(cli_ctx=cmd.cli_ctx)(command_args=public_ip_args)
 
@@ -5320,6 +5330,8 @@ class PublicIPUpdate(_PublicIPUpdate):
     def post_instance_update(self, instance):
         if not has_value(instance.properties.ddos_settings.ddos_protection_plan.id):
             instance.properties.ddos_settings.ddos_protection_plan = None
+        if not has_value(instance.properties.ddos_settings.ddos_custom_policy.id):
+            instance.properties.ddos_settings.ddos_custom_policy = None
 
 
 class PublicIpPrefixCreate(_PublicIpPrefixCreate):

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_rule_create_preserves_http_settings_validate_flags.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_rule_create_preserves_http_settings_validate_flags.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_validate_flags000001/providers/Microsoft.Network/publicIPAddresses/pip000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_validate_flags000001/providers/Microsoft.Network/publicIPAddresses/pip000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_validate_flags000001/providers/Microsoft.Network/publicIPAddresses/pip000003","etag":"W/\"9bda93d1-fda2-4f5a-8ae7-acd524ed6364\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"f1c94765-a1ff-43d0-84b8-f90b8c8a3d04","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_validate_flags000001/providers/Microsoft.Network/publicIPAddresses/pip000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_validate_flags000001/providers/Microsoft.Network/publicIPAddresses/pip000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_validate_flags000001/providers/Microsoft.Network/publicIPAddresses/pip000003","etag":"W/\"77b77564-41a0-4db3-8f20-067708f518a2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1c94765-a1ff-43d0-84b8-f90b8c8a3d04","ipAddress":"40.114.31.88","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_rule_default_exists.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_rule_default_exists.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule_default_exists000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule_default_exists000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule_default_exists000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002","etag":"W/\"f96d117d-a5b1-4c81-b5d8-a79ba45024db\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"8efe7651-5414-4c1d-8cde-9fbe93b247d1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule_default_exists000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule_default_exists000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule_default_exists000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002","etag":"W/\"57ff906d-fe0b-481d-868f-09df2da08044\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8efe7651-5414-4c1d-8cde-9fbe93b247d1","ipAddress":"172.184.105.184","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_appgw_private_endpoint_with_default.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_appgw_private_endpoint_with_default.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"appgw_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip","etag":"W/\"be6ff816-b7ec-4dec-bf06-4ab49f303790\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"8b2ecd49-75a9-4c8c-b7e0-9b6bd5b32526","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"appgw_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip","etag":"W/\"b109d113-b7b2-4a6f-9cdf-86680e8b60f5\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8b2ecd49-75a9-4c8c-b7e0-9b6bd5b32526","ipAddress":"20.66.106.41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_appgw_private_endpoint_with_overwrite_default.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_appgw_private_endpoint_with_overwrite_default.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_overwrite_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_overwrite_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"appgw_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_overwrite_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip","etag":"W/\"391cf45f-7134-443a-a124-17a12eee176d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"21b26e90-4d9d-4a77-b6f8-57e3e3795f42","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_overwrite_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_overwrite_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"appgw_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_private_endpoint_with_overwrite_default000001/providers/Microsoft.Network/publicIPAddresses/appgw_ip","etag":"W/\"7598fa50-8ea7-46c1-9ce7-5a8beb38631e\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"21b26e90-4d9d-4a77-b6f8-57e3e3795f42","ipAddress":"13.93.138.50","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_appgw_with_tcp.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_appgw_with_tcp.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_with_tcp000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_with_tcp000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_with_tcp000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"4531863c-185e-48e1-b658-2f0ffc93174d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"b8369117-c10d-49eb-86bc-982b622fe26b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_with_tcp000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_with_tcp000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_appgw_with_tcp000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"795704f9-996e-4591-9661-55995540e5bd\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8369117-c10d-49eb-86bc-982b622fe26b","ipAddress":"20.245.95.128","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ddos_custom_policy_attach_to_lb_fip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ddos_custom_policy_attach_to_lb_fip.yaml
@@ -330,7 +330,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_lb000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_lb000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_lb000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"8dbd2e7e-e89f-43bb-9bd2-77fa7c4199c2\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"c1cd707b-927b-4e34-9a4f-dc50531ae141","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -441,7 +441,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_lb000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_lb000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_lb000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"63c66f43-941b-41ae-9244-709a36350354\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c1cd707b-927b-4e34-9a4f-dc50531ae141","ipAddress":"20.85.208.109","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ddos_custom_policy_attach_to_public_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ddos_custom_policy_attach_to_public_ip.yaml
@@ -1,0 +1,2637 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_ddos_cuspol_pip000001?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001","name":"test_ddos_cuspol_pip000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","test":"test_ddos_custom_policy_attach_to_public_ip","date":"2026-07-30T07:15:57Z","module":"network"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '402'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: BCE4E8AECFD04200AE21F5423CBE0D32 Ref B: SG2AA1040520034 Ref C: 2026-07-30T07:16:13Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/ddosCustomPolicies/policy1''
+        under resource group ''test_ddos_cuspol_pip000001'' was not found. For more
+        details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+      x-msedge-ref:
+      - 'Ref A: 9F632FBAF84E4E48B616CB03A9818975 Ref B: SG2AA1040519031 Ref C: 2026-07-30T07:16:15Z'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"location": "eastus", "properties": {"detectionRules": [{"name": "rule1",
+      "properties": {"detectionMode": "TrafficThreshold", "trafficDetectionRule":
+      {"packetsPerSecond": 1000000, "trafficType": "Tcp"}}}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '207'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"policy1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1","etag":"W/\"609ba872-75f9-46f5-b83e-6f0f1d39934b\"","type":"Microsoft.Network/ddosCustomPolicies","location":"eastus","properties":{"provisioningState":"Updating","detectionRules":[{"name":"rule1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1/ddosDetectionRules/rule1","etag":"W/\"609ba872-75f9-46f5-b83e-6f0f1d39934b\"","type":"Microsoft.Network/ddosCustomPolicies/ddosDetectionRules","properties":{"provisioningState":"Succeeded","detectionMode":"TrafficThreshold","trafficDetectionRule":{"trafficType":"Tcp","packetsPerSecond":1000000}}}],"frontendIpConfigurations":[],"publicIPAddresses":[]}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cec01550-645a-48f2-b04f-5c65ba6c40ef?api-version=2025-07-01&t=639209925770678966&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=EBYXtMNdAEys0ly_QlhH2O7FlcUoOSByGsmwJAtoxWn6mRddnnZStgZDJJTMg5w8HZAeKY-2JT4x4NklmvxfGrO3lyiXcQDLSA93q7jCELKZU3KsEegKjnmNTLyWSHCqguzZO1T_a25SHoImyVBTR4LvQVi4Fv5cPSgLhbW3c7eFZVdnxfJLv2gCKWgZEx53lQjDOcQkd7FBoUQuGOVcijk7xnUbpJJTHnr3pxTAOfWI6LR4JBKUNbikuN4sIb8OgcQIfyJi6i3w6OyKRHzFKqquhE9ObGajdq_VIvpMx2lbhRXbd8vxF78ek6X3ppA_JHn7sVvw7shWqYrgafiW0g&h=d-fzWNSOTN2yM4pSkV5gb4lKVPXgfZHSiZC3aw6Qrfs
+      cache-control:
+      - no-cache
+      content-length:
+      - '879'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - f5838afe-0847-4013-8957-f962041a624e
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/ff50cd31-03a2-420f-9c4b-a907bf301020
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.1,
+        etc
+      x-msedge-ref:
+      - 'Ref A: BCE90AE70322436EA0020CFA9D6011BB Ref B: SG2AA1040519031 Ref C: 2026-07-30T07:16:16Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cec01550-645a-48f2-b04f-5c65ba6c40ef?api-version=2025-07-01&t=639209925770678966&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=EBYXtMNdAEys0ly_QlhH2O7FlcUoOSByGsmwJAtoxWn6mRddnnZStgZDJJTMg5w8HZAeKY-2JT4x4NklmvxfGrO3lyiXcQDLSA93q7jCELKZU3KsEegKjnmNTLyWSHCqguzZO1T_a25SHoImyVBTR4LvQVi4Fv5cPSgLhbW3c7eFZVdnxfJLv2gCKWgZEx53lQjDOcQkd7FBoUQuGOVcijk7xnUbpJJTHnr3pxTAOfWI6LR4JBKUNbikuN4sIb8OgcQIfyJi6i3w6OyKRHzFKqquhE9ObGajdq_VIvpMx2lbhRXbd8vxF78ek6X3ppA_JHn7sVvw7shWqYrgafiW0g&h=d-fzWNSOTN2yM4pSkV5gb4lKVPXgfZHSiZC3aw6Qrfs
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - c8b10b22-5087-4baf-b109-08d7ef716fe3
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/cfab4e65-bae3-40f9-a945-e91f0970eba5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, etc
+      x-msedge-ref:
+      - 'Ref A: 14DBDAFE7B20476396A07A54645B7030 Ref B: SG2AA1040516060 Ref C: 2026-07-30T07:16:18Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"policy1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1","etag":"W/\"c7294449-0e15-4ccc-bbd6-c7c57ee25511\"","type":"Microsoft.Network/ddosCustomPolicies","location":"eastus","properties":{"provisioningState":"Succeeded","detectionRules":[{"name":"rule1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1/ddosDetectionRules/rule1","etag":"W/\"c7294449-0e15-4ccc-bbd6-c7c57ee25511\"","type":"Microsoft.Network/ddosCustomPolicies/ddosDetectionRules","properties":{"provisioningState":"Succeeded","detectionMode":"TrafficThreshold","trafficDetectionRule":{"trafficType":"Tcp","packetsPerSecond":1000000}}}],"frontendIpConfigurations":[],"publicIPAddresses":[]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '880'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:19 GMT
+      etag:
+      - W/"c7294449-0e15-4ccc-bbd6-c7c57ee25511"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - a57d5fe1-519a-49af-bca9-28e375f7e2ad
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.5, etc
+      x-msedge-ref:
+      - 'Ref A: 5ED563D667AD4AA49BB9FA9FC6DEBBB8 Ref B: SG2AA1070302031 Ref C: 2026-07-30T07:16:20Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_ddos_cuspol_pip000001?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001","name":"test_ddos_cuspol_pip000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","test":"test_ddos_custom_policy_attach_to_public_ip","date":"2026-07-30T07:15:57Z","module":"network"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '402'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: A999BDBA3F7A4BD7957EEDFCE3F70690 Ref B: SG2AA1040518025 Ref C: 2026-07-30T07:16:21Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2?api-version=2025-07-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/ddosCustomPolicies/policy2''
+        under resource group ''test_ddos_cuspol_pip000001'' was not found. For more
+        details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+      x-msedge-ref:
+      - 'Ref A: E8894A74B02A4D31817A9120E85B6C6A Ref B: SG2AA1040518060 Ref C: 2026-07-30T07:16:23Z'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"location": "eastus", "properties": {"detectionRules": [{"name": "rule1",
+      "properties": {"detectionMode": "TrafficThreshold", "trafficDetectionRule":
+      {"packetsPerSecond": 2000000, "trafficType": "Tcp"}}}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '207'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"policy2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2","etag":"W/\"ddda43f2-7948-4fa2-8046-a7858f8ba821\"","type":"Microsoft.Network/ddosCustomPolicies","location":"eastus","properties":{"provisioningState":"Updating","detectionRules":[{"name":"rule1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2/ddosDetectionRules/rule1","etag":"W/\"ddda43f2-7948-4fa2-8046-a7858f8ba821\"","type":"Microsoft.Network/ddosCustomPolicies/ddosDetectionRules","properties":{"provisioningState":"Succeeded","detectionMode":"TrafficThreshold","trafficDetectionRule":{"trafficType":"Tcp","packetsPerSecond":2000000}}}],"frontendIpConfigurations":[],"publicIPAddresses":[]}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a15479ea-2f1f-4637-8215-53b385754434?api-version=2025-07-01&t=639209925845334042&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=zF3H_KJCOX0P03K2GVILyfzUfMh1EaNy6oCvpWZ4vbn7-NqVHbxGzY-jSU2K5PexNUTcekBzO4yfOKnfpQKduYe_mckrseLqLjktXLUwNHuW9hlOUKpxMZngpYIbhSJLMDBv5dHOCdPvgLs1s2YErUEUsY_hWswJoRslGurYXatbxkg4YIMelkt_gixEGjKss2TvWtwpC8SkM_n5rSbggGufIlycRzXhFjUWVoPNDHisC5W19AJzaMVYdrrNz5GpHfgTgVXAzy_691_1VFoQU8mRNgF-puoNzwrwze-RlwdVVd2GOh49wS5r6cH0iQqg1GCpXRz5W7mlie-fGjqwzQ&h=JgmlzLdFHefxo-QzqozvgJkyfTwsiBvknKUE5E-mgt0
+      cache-control:
+      - no-cache
+      content-length:
+      - '879'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - e4998bc0-81a8-4d69-a317-beaa73c9fc45
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/6946a1b9-f428-46a6-a2f0-aa534ba48e0e
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.2,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 2081DE66578846F6A22F1F316EFCDC70 Ref B: SG2AA1040518060 Ref C: 2026-07-30T07:16:24Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a15479ea-2f1f-4637-8215-53b385754434?api-version=2025-07-01&t=639209925845334042&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=zF3H_KJCOX0P03K2GVILyfzUfMh1EaNy6oCvpWZ4vbn7-NqVHbxGzY-jSU2K5PexNUTcekBzO4yfOKnfpQKduYe_mckrseLqLjktXLUwNHuW9hlOUKpxMZngpYIbhSJLMDBv5dHOCdPvgLs1s2YErUEUsY_hWswJoRslGurYXatbxkg4YIMelkt_gixEGjKss2TvWtwpC8SkM_n5rSbggGufIlycRzXhFjUWVoPNDHisC5W19AJzaMVYdrrNz5GpHfgTgVXAzy_691_1VFoQU8mRNgF-puoNzwrwze-RlwdVVd2GOh49wS5r6cH0iQqg1GCpXRz5W7mlie-fGjqwzQ&h=JgmlzLdFHefxo-QzqozvgJkyfTwsiBvknKUE5E-mgt0
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 8b88bde2-8058-429d-ae95-d49cf51e5cfb
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/71bb5370-8d8b-4755-abbb-960810033164
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1, etc
+      x-msedge-ref:
+      - 'Ref A: 4B9EA66BEBE94B96A0CBBB7A8AA4033E Ref B: SG2AA1070303052 Ref C: 2026-07-30T07:16:25Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --detection-rule-name --detection-mode --traffic-type --packets-per-second
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"policy2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2","etag":"W/\"07a05333-83d9-420a-88a7-8ea98a01ebcc\"","type":"Microsoft.Network/ddosCustomPolicies","location":"eastus","properties":{"provisioningState":"Succeeded","detectionRules":[{"name":"rule1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2/ddosDetectionRules/rule1","etag":"W/\"07a05333-83d9-420a-88a7-8ea98a01ebcc\"","type":"Microsoft.Network/ddosCustomPolicies/ddosDetectionRules","properties":{"provisioningState":"Succeeded","detectionMode":"TrafficThreshold","trafficDetectionRule":{"trafficType":"Tcp","packetsPerSecond":2000000}}}],"frontendIpConfigurations":[],"publicIPAddresses":[]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '880'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:26 GMT
+      etag:
+      - W/"07a05333-83d9-420a-88a7-8ea98a01ebcc"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - e51f688b-b420-4a7c-989d-7dbeda304abf
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.3, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 5A3282C2424247D0BDB579ECE64D4644 Ref B: SG2AA1040517025 Ref C: 2026-07-30T07:16:27Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku --allocation-method
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_ddos_cuspol_pip000001?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001","name":"test_ddos_cuspol_pip000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","test":"test_ddos_custom_policy_attach_to_public_ip","date":"2026-07-30T07:15:57Z","module":"network"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '402'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: D73A32791470401F8CB90C5554D56299 Ref B: SG2AA1040519042 Ref C: 2026-07-30T07:16:29Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "properties": {"idleTimeoutInMinutes": 4, "publicIPAllocationMethod":
+      "Static"}, "sku": {"name": "Standard"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --sku --allocation-method
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"d37985af-e8df-49ec-a307-07dca569e835\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e2e86a0c-0cda-4d9a-8213-215459fd27a6?api-version=2025-07-01&t=639209925905983214&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=IIfv8MIa1iWPMkPGYgyrh2VspqhbGYGdmLBu5QCsbdUuhW39ua5UYoqFekA_DASRsBWKBW3atOulPs5xtED5Ap_eCxE7dXQFPW70YI-ZkdbgEpNHUBCPL5sBH0hAlLXhQFwWu3nHjkQi6YzI5TzX0JCvO8195a1zxudulVW0AkEJMCuNFz-wtBRWdkcB9BiQ7ri20TCxnf2kiha81y2A8aKbnZ2w_IVbzNjYdxLkhyr1rhFa9WK16hB5A2NeeQyp4luop6FsaK4sYGGKRnAc0JHTOUYuiJ2-UXQY3gl5mKMwb9kH53hUEeMq1OFQyMtpQMyBLLroKvz-ssFBp0czyQ&h=dnCDavOYHeqPfg3fGigSTknFkYmVK2mq4YRD5b3pqWs
+      cache-control:
+      - no-cache
+      content-length:
+      - '593'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 63a9df90-7440-4d35-8797-25b8e69bad1f
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/3acd2ab2-1ad0-443c-931f-1d66d83e6939
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.3,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 824E77CF45294CDB9DCE9F570AB01F7A Ref B: SG2AA1040519060 Ref C: 2026-07-30T07:16:30Z'
+    status:
+      code: 201
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku --allocation-method
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e2e86a0c-0cda-4d9a-8213-215459fd27a6?api-version=2025-07-01&t=639209925905983214&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=IIfv8MIa1iWPMkPGYgyrh2VspqhbGYGdmLBu5QCsbdUuhW39ua5UYoqFekA_DASRsBWKBW3atOulPs5xtED5Ap_eCxE7dXQFPW70YI-ZkdbgEpNHUBCPL5sBH0hAlLXhQFwWu3nHjkQi6YzI5TzX0JCvO8195a1zxudulVW0AkEJMCuNFz-wtBRWdkcB9BiQ7ri20TCxnf2kiha81y2A8aKbnZ2w_IVbzNjYdxLkhyr1rhFa9WK16hB5A2NeeQyp4luop6FsaK4sYGGKRnAc0JHTOUYuiJ2-UXQY3gl5mKMwb9kH53hUEeMq1OFQyMtpQMyBLLroKvz-ssFBp0czyQ&h=dnCDavOYHeqPfg3fGigSTknFkYmVK2mq4YRD5b3pqWs
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - e7326ef4-b8e8-41d6-be00-d990507e856a
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/malaysiasouth/b0fc350c-a8d3-4658-a390-50177294e6aa
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.2, etc
+      x-msedge-ref:
+      - 'Ref A: A5EC308C0B79483FB26F8E4818C8E1F8 Ref B: SG2AA1070306042 Ref C: 2026-07-30T07:16:31Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku --allocation-method
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"5639fe57-e4da-4fe5-8ece-6fa9ba6b48c5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '621'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:35 GMT
+      etag:
+      - W/"5639fe57-e4da-4fe5-8ece-6fa9ba6b48c5"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 84e8c238-f55a-43a4-9d77-57495a245d9e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.2,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 1C5A61B8269F4530BC57E1178143B474 Ref B: SG2AA1070304023 Ref C: 2026-07-30T07:16:34Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_ddos_cuspol_pip000001?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001","name":"test_ddos_cuspol_pip000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","test":"test_ddos_custom_policy_attach_to_public_ip","date":"2026-07-30T07:15:57Z","module":"network"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '402'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: D0527BF274D44C29A819EFDB796F6628 Ref B: SG2AA1070303042 Ref C: 2026-07-30T07:16:37Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "enableDdosProtection": false, "enableVmProtection": false,
+      "subnets": [{"name": "subnet1", "properties": {"addressPrefix": "10.0.0.0/24"}}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '234'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"69835c9f-ff14-43fa-98e9-0302b6690baa\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"17371528-88b5-4163-b432-f160b84e1ca1","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1","etag":"W/\"69835c9f-ff14-43fa-98e9-0302b6690baa\"","properties":{"provisioningState":"Updating","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled","defaultOutboundAccess":false},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f594f7ed-6af1-44cd-8561-da4648828dba?api-version=2025-07-01&t=639209925994634335&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=gZTbtIKuL3dYbD_Ews6mVcWN49sERqv_Tucc8tgwZHvvdf9H0M7cq3o8YToLSy9ABMHWDPm6RutISmlVYmcGk6DJd3PWlyKKXxP-tm1FxVsrVvT585smAYREVIKebMqtxX62q3kiXPwBIj1Qcq7ztSMDyVC5E33AJPfuj4-3P0Fn4xKX8j9or1SPSikK0KMic4pXZaKr4Dm5SaGz8vwWKM89UMOIWzkhr1U6zOmhjmB1EeByZn_sSnU8fIzUa0MvsP4dwDyU4nYBqBilYTShAEkYP_6n5q_sbEHJIFsEuRocREQIvl7M0OwUAshqBH_1e3rYeET682vo4Uwo7nHwyQ&h=oqgcZ1i3qpQpNIXel3xdEjqugHbFzZuANKdxxluK6kk
+      cache-control:
+      - no-cache
+      content-length:
+      - '1045'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 579329ef-994d-4503-85fc-b306735d144f
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/284d1f65-2a36-4ee1-8218-fd3a605a680a
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.4,
+        etc
+      x-msedge-ref:
+      - 'Ref A: C1C0FC43AFA54BCCB787F64F05F200C6 Ref B: SG2AA1070306036 Ref C: 2026-07-30T07:16:38Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f594f7ed-6af1-44cd-8561-da4648828dba?api-version=2025-07-01&t=639209925994634335&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=gZTbtIKuL3dYbD_Ews6mVcWN49sERqv_Tucc8tgwZHvvdf9H0M7cq3o8YToLSy9ABMHWDPm6RutISmlVYmcGk6DJd3PWlyKKXxP-tm1FxVsrVvT585smAYREVIKebMqtxX62q3kiXPwBIj1Qcq7ztSMDyVC5E33AJPfuj4-3P0Fn4xKX8j9or1SPSikK0KMic4pXZaKr4Dm5SaGz8vwWKM89UMOIWzkhr1U6zOmhjmB1EeByZn_sSnU8fIzUa0MvsP4dwDyU4nYBqBilYTShAEkYP_6n5q_sbEHJIFsEuRocREQIvl7M0OwUAshqBH_1e3rYeET682vo4Uwo7nHwyQ&h=oqgcZ1i3qpQpNIXel3xdEjqugHbFzZuANKdxxluK6kk
+  response:
+    body:
+      string: '{"status":"InProgress"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1e5a699f-79c3-4f68-a6f3-e2d13780035e
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/e6e957c4-30df-4bee-b44a-9dc1ea551936
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.3,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 66661AF3C16646DBA9AE9F85C14A22C5 Ref B: SG2AA1070301025 Ref C: 2026-07-30T07:16:40Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f594f7ed-6af1-44cd-8561-da4648828dba?api-version=2025-07-01&t=639209925994634335&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=gZTbtIKuL3dYbD_Ews6mVcWN49sERqv_Tucc8tgwZHvvdf9H0M7cq3o8YToLSy9ABMHWDPm6RutISmlVYmcGk6DJd3PWlyKKXxP-tm1FxVsrVvT585smAYREVIKebMqtxX62q3kiXPwBIj1Qcq7ztSMDyVC5E33AJPfuj4-3P0Fn4xKX8j9or1SPSikK0KMic4pXZaKr4Dm5SaGz8vwWKM89UMOIWzkhr1U6zOmhjmB1EeByZn_sSnU8fIzUa0MvsP4dwDyU4nYBqBilYTShAEkYP_6n5q_sbEHJIFsEuRocREQIvl7M0OwUAshqBH_1e3rYeET682vo4Uwo7nHwyQ&h=oqgcZ1i3qpQpNIXel3xdEjqugHbFzZuANKdxxluK6kk
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 723d59d3-d818-4cca-a46c-f4b64df57b85
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/05678257-909e-4ee7-b747-dcf4b3d14f77
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.3, etc
+      x-msedge-ref:
+      - 'Ref A: EED6FEC5471445FB8FE6E95A441EF006 Ref B: SG2AA1070301029 Ref C: 2026-07-30T07:16:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"a18c8c18-1285-433f-ba7f-ca75cf82a480\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"17371528-88b5-4163-b432-f160b84e1ca1","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1","etag":"W/\"a18c8c18-1285-433f-ba7f-ca75cf82a480\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled","defaultOutboundAccess":false},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1047'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - bd70ada9-2b26-4597-b8ed-9f3c76b343d8
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=2.0, subscriptionReadRatePct=0.3,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 9812EF826BB64E0DB815296B97FE316C Ref B: SG2AA1040518054 Ref C: 2026-07-30T07:16:53Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nic create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --public-ip-address
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_ddos_cuspol_pip000001?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001","name":"test_ddos_cuspol_pip000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","test":"test_ddos_custom_policy_attach_to_public_ip","date":"2026-07-30T07:15:57Z","module":"network"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '402'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: 23D804C0CE1D45DBB89599CD94690771 Ref B: SG2AA1070302031 Ref C: 2026-07-30T07:16:55Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "properties": {"ipConfigurations": [{"name": "ipconfig1",
+      "properties": {"privateIPAddressVersion": "IPv4", "privateIPAllocationMethod":
+      "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}}}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nic create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '530'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --public-ip-address
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1?api-version=2023-11-01
+  response:
+    body:
+      string: '{"name":"nic1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1","etag":"W/\"eb8a7afa-2b9e-4968-ab2e-1198926b2032\"","properties":{"provisioningState":"Updating","resourceGuid":"0cf38492-0216-4d08-ba57-0cee7fef1d55","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1","etag":"W/\"eb8a7afa-2b9e-4968-ab2e-1198926b2032\"","type":"Microsoft.Network/networkInterfaces/ipConfigurations","properties":{"provisioningState":"Updating","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"faktof3vrbrudnbs4fqlqtq2ub.bx.internal.cloudapp.net"},"vnetEncryptionSupported":false,"enableIPForwarding":false,"disableTcpStateTracking":false,"hostedWorkloads":[],"tapConfigurations":[],"nicType":"Standard","allowPort25Out":false,"auxiliaryMode":"None","auxiliarySku":"None"},"type":"Microsoft.Network/networkInterfaces","location":"eastus","kind":"Regular"}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f33a51ce-1c6f-4eb0-a73a-44fe2db2539c?api-version=2023-11-01&t=639209926169261026&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=WFsaw3gDrM5910cKWJZTMYSOeRsUBzgOriftiumXL4gD9aHMkYDLU7E8iUcU6OFrJTrPZ_oKpBkEZCT4_OFECzDSJpKA7u_nt5eMM95_x1wxMgj8ckcWH_97tyTHe98bICuXSq2JjT8YWnC7wyFXNI0RVOOY6OTrsIzRgvgEEuwGy2W4YufdQwoMMKVi1BsrH7B8cN-YqgdZb2QHa9yPiUSiDlFDgfmXy1HmcdiUNweZ4IOi9LX4ughZSMigU6o7ioU6xFF2EZCpALHwu-2zE1HKEMrPQOgdEC1GIjd4qKsECnSsVe8vWlmamj3UKaVin2HBn0kEwkK06tUzfRLUWA&h=bQ6PyouJYEds08aeY8UUd_Q9E_g71iuFzsiW1vQMTro
+      cache-control:
+      - no-cache
+      content-length:
+      - '1608'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 9bfea853-30aa-42ed-b555-f5d650d21a07
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/321344a7-45b1-455c-98c6-e0e92ace5559
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.5,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 9BB4BA935DB34240B2A074EDBBF7B81D Ref B: SG2AA1070305031 Ref C: 2026-07-30T07:16:56Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nic create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --public-ip-address
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f33a51ce-1c6f-4eb0-a73a-44fe2db2539c?api-version=2023-11-01&t=639209926169261026&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=WFsaw3gDrM5910cKWJZTMYSOeRsUBzgOriftiumXL4gD9aHMkYDLU7E8iUcU6OFrJTrPZ_oKpBkEZCT4_OFECzDSJpKA7u_nt5eMM95_x1wxMgj8ckcWH_97tyTHe98bICuXSq2JjT8YWnC7wyFXNI0RVOOY6OTrsIzRgvgEEuwGy2W4YufdQwoMMKVi1BsrH7B8cN-YqgdZb2QHa9yPiUSiDlFDgfmXy1HmcdiUNweZ4IOi9LX4ughZSMigU6o7ioU6xFF2EZCpALHwu-2zE1HKEMrPQOgdEC1GIjd4qKsECnSsVe8vWlmamj3UKaVin2HBn0kEwkK06tUzfRLUWA&h=bQ6PyouJYEds08aeY8UUd_Q9E_g71iuFzsiW1vQMTro
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:16:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - c1ffbe87-06fe-4462-8f41-80b5e92d560a
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/9dce5dfe-71fd-4fb0-bfd4-c8bfc47858e8
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.3, etc
+      x-msedge-ref:
+      - 'Ref A: 879548FBFCBB414B83CF6D0097D7D206 Ref B: SG2AA1070304025 Ref C: 2026-07-30T07:16:57Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nic create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --public-ip-address
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1?api-version=2023-11-01
+  response:
+    body:
+      string: '{"name":"nic1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1","etag":"W/\"ca6cc1c1-7223-4ae0-9db6-ca7a694a1cc4\"","properties":{"provisioningState":"Succeeded","resourceGuid":"0cf38492-0216-4d08-ba57-0cee7fef1d55","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1","etag":"W/\"ca6cc1c1-7223-4ae0-9db6-ca7a694a1cc4\"","type":"Microsoft.Network/networkInterfaces/ipConfigurations","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"faktof3vrbrudnbs4fqlqtq2ub.bx.internal.cloudapp.net"},"vnetEncryptionSupported":false,"enableIPForwarding":false,"disableTcpStateTracking":false,"hostedWorkloads":[],"tapConfigurations":[],"nicType":"Standard","allowPort25Out":false,"auxiliaryMode":"None","auxiliarySku":"None"},"type":"Microsoft.Network/networkInterfaces","location":"eastus","kind":"Regular"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1610'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:00 GMT
+      etag:
+      - W/"ca6cc1c1-7223-4ae0-9db6-ca7a694a1cc4"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 6b9189d9-1d09-4d36-b088-d7dde5614f86
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.4,
+        etc
+      x-msedge-ref:
+      - 'Ref A: E1B5F9556EE7482FB3A17702A0B76BB7 Ref B: SG2AA1040513040 Ref C: 2026-07-30T07:17:00Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"1753dfdd-c88c-4897-9093-36a167a62a42\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '820'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:02 GMT
+      etag:
+      - W/"1753dfdd-c88c-4897-9093-36a167a62a42"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 20a888fb-c194-42ee-9dc9-d0b652bc3bd2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.4, etc
+      x-msedge-ref:
+      - 'Ref A: 4DAC486EEF7444FC9A074E7429D7C640 Ref B: SG2AA1070303023 Ref C: 2026-07-30T07:17:02Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1",
+      "location": "eastus", "properties": {"ddosSettings": {"ddosCustomPolicy": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1"},
+      "protectionMode": "VirtualNetworkInherited"}, "idleTimeoutInMinutes": 4, "ipAddress":
+      "52.188.14.35", "ipTags": [], "publicIPAddressVersion": "IPv4", "publicIPAllocationMethod":
+      "Static"}, "sku": {"name": "Standard", "tier": "Regional"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '626'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"0aa40f8e-e2a1-4cb1-bdcd-0efd1894f762\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited","ddosCustomPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5b81d7b8-ef6b-4703-9ffc-6210db19b890?api-version=2025-07-01&t=639209926243872992&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=BDfstrjNxdUtO7cUiI25oJEjaSl4Isa9rNePT9np7Cbxn_I0cytbAnazPJVnjDhAJcyahfLP9uPbCmun3S_IdVmjB-OVZYaYsRpweOlca-6eJTAuC-NrHUG-dXXu6v5J4fdqaE3_py9lSc6CfcYPWeHNiwCgTsBrBucRKdqnYoZS09TsfTXfk-icb2s8rX78en9HxrrgvEaA0tA936dkri040EB5tu3ZtGpHS1axQ-S-gJz9KdtCszJQ4CyhQFzQMZ0CaZwWK1DtTRDBAgeY0GEPWZXlHQTQ4wkEXi9Ykq5A9OrVIts2SKJpQynSJn3hTosMeGITUsaG-T3lWn0FOw&h=uvO86vDXuGuZc9dfxr48yDU2OcIIhPnUDoaMtwmWlBE
+      cache-control:
+      - no-cache
+      content-length:
+      - '996'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 105fcce4-3bf4-469f-97cf-c7899a376e35
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/c575db1e-242a-45c0-a7f8-0c5d09fd3c66
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.6,
+        etc
+      x-msedge-ref:
+      - 'Ref A: BF22547B18E54BC3BB1C189476E99AD1 Ref B: SG2AA1040518060 Ref C: 2026-07-30T07:17:03Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5b81d7b8-ef6b-4703-9ffc-6210db19b890?api-version=2025-07-01&t=639209926243872992&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=BDfstrjNxdUtO7cUiI25oJEjaSl4Isa9rNePT9np7Cbxn_I0cytbAnazPJVnjDhAJcyahfLP9uPbCmun3S_IdVmjB-OVZYaYsRpweOlca-6eJTAuC-NrHUG-dXXu6v5J4fdqaE3_py9lSc6CfcYPWeHNiwCgTsBrBucRKdqnYoZS09TsfTXfk-icb2s8rX78en9HxrrgvEaA0tA936dkri040EB5tu3ZtGpHS1axQ-S-gJz9KdtCszJQ4CyhQFzQMZ0CaZwWK1DtTRDBAgeY0GEPWZXlHQTQ4wkEXi9Ykq5A9OrVIts2SKJpQynSJn3hTosMeGITUsaG-T3lWn0FOw&h=uvO86vDXuGuZc9dfxr48yDU2OcIIhPnUDoaMtwmWlBE
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1997044c-2b73-4736-9ac8-df5b1146cbbc
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/b5bf041c-08c1-4c2e-a590-ef87eebc1a95
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.4, etc
+      x-msedge-ref:
+      - 'Ref A: CDDE810E0C554747ABD10CF0DA1D0B1A Ref B: SG2AA1070305040 Ref C: 2026-07-30T07:17:05Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"aa16f928-ed50-460c-9120-1ad25922f3bc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited","ddosCustomPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '997'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:06 GMT
+      etag:
+      - W/"aa16f928-ed50-460c-9120-1ad25922f3bc"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - ab458b78-cef6-46bf-a915-cda0f682189a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.4,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 9E96C2B8434B4381AFCAC0ADF61CD774 Ref B: SG2AA1070304040 Ref C: 2026-07-30T07:17:07Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"aa16f928-ed50-460c-9120-1ad25922f3bc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited","ddosCustomPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '997'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:08 GMT
+      etag:
+      - W/"aa16f928-ed50-460c-9120-1ad25922f3bc"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - aed94a5b-ea1d-491a-8f2d-046a8a30db24
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.4,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 8042E3AFFCD54270B81F7C899DD5811B Ref B: SG2AA1070304040 Ref C: 2026-07-30T07:17:08Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"aa16f928-ed50-460c-9120-1ad25922f3bc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited","ddosCustomPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '997'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:10 GMT
+      etag:
+      - W/"aa16f928-ed50-460c-9120-1ad25922f3bc"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - d00069f9-06ac-4575-8954-fbc810c25c9f
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.5,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 68A66D70556B4F2A806C3C2006A5F1D5 Ref B: SG2AA1040517029 Ref C: 2026-07-30T07:17:10Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1",
+      "location": "eastus", "properties": {"ddosSettings": {"ddosCustomPolicy": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2"},
+      "protectionMode": "VirtualNetworkInherited"}, "idleTimeoutInMinutes": 4, "ipAddress":
+      "52.188.14.35", "ipTags": [], "publicIPAddressVersion": "IPv4", "publicIPAllocationMethod":
+      "Static"}, "sku": {"name": "Standard", "tier": "Regional"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '626'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"7db8dc6a-0208-4d1e-aa87-9af61af1f611\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited","ddosCustomPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5a96e8b9-d83d-411c-ae60-eefabf2423a4?api-version=2025-07-01&t=639209926322450981&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=nhYYQETr1w5BUpgSkQm4tODOipa4TSc9_3UvatZvAF2JD2SlvXm7wqnHpL6La444f4Qho_NuIZkx2IK8k3Wh6Y3mg4qLGy7JQSqFYV4M7GIB5Og9bzW9Al3_Wa7vFrea_VgwXmwT5iMBqOzGjZvcDImNdWk6YXiGwTTFOtLw-Kx4cXM9WxmQJ8bxRDcaUmtrenb2qcCnb3HpLgrqXwL4EENBYEaS1rF6Xwmlk6q93yjAPyBPUMePw3wqAiHShbPKndR0oktaLDi3TgTU4a-swmAUFKj9yD7wQV3RVzOhO1JCan43n8t_KMo3LLYf70apjUp5cCIk8YIIxRDY-ZG40w&h=Iq_j-8SISXeyOsRgLhm4ZYHPeGDi4bI9JZ0T-Oe76I0
+      cache-control:
+      - no-cache
+      content-length:
+      - '996'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 65df93c1-0453-4f95-bf13-3f830c70b2c8
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/3c80a600-9911-4214-8680-e19c724bd920
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.7,
+        etc
+      x-msedge-ref:
+      - 'Ref A: EFE0E79CAE1D4BDC8DD2E4C66657446C Ref B: SG2AA1040515042 Ref C: 2026-07-30T07:17:11Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5a96e8b9-d83d-411c-ae60-eefabf2423a4?api-version=2025-07-01&t=639209926322450981&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=nhYYQETr1w5BUpgSkQm4tODOipa4TSc9_3UvatZvAF2JD2SlvXm7wqnHpL6La444f4Qho_NuIZkx2IK8k3Wh6Y3mg4qLGy7JQSqFYV4M7GIB5Og9bzW9Al3_Wa7vFrea_VgwXmwT5iMBqOzGjZvcDImNdWk6YXiGwTTFOtLw-Kx4cXM9WxmQJ8bxRDcaUmtrenb2qcCnb3HpLgrqXwL4EENBYEaS1rF6Xwmlk6q93yjAPyBPUMePw3wqAiHShbPKndR0oktaLDi3TgTU4a-swmAUFKj9yD7wQV3RVzOhO1JCan43n8t_KMo3LLYf70apjUp5cCIk8YIIxRDY-ZG40w&h=Iq_j-8SISXeyOsRgLhm4ZYHPeGDi4bI9JZ0T-Oe76I0
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 2aef53ac-a823-487e-a3a6-e6c1995407c6
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/5c282928-33f1-4334-917c-43516e81052c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.5,
+        etc
+      x-msedge-ref:
+      - 'Ref A: D2F00719EDC644ADA59B925C247D51B9 Ref B: SG2AA1070306036 Ref C: 2026-07-30T07:17:13Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"e0446112-ccd1-43a8-a60f-4c83eb873113\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited","ddosCustomPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '997'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:16 GMT
+      etag:
+      - W/"e0446112-ccd1-43a8-a60f-4c83eb873113"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 2ce7fadb-a273-4e48-ad27-c28f3db6dc2b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.4, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.5,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 3CA5C5C5F2234138A4AC144465560BFF Ref B: SG2AA1070301060 Ref C: 2026-07-30T07:17:15Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"e0446112-ccd1-43a8-a60f-4c83eb873113\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited","ddosCustomPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '997'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:17 GMT
+      etag:
+      - W/"e0446112-ccd1-43a8-a60f-4c83eb873113"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1237cc76-ab52-4837-8a24-f0c7c729a11c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.4, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.5,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 035D8E981CD144E686982EB426E57DF7 Ref B: SG2AA1070302036 Ref C: 2026-07-30T07:17:17Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1",
+      "location": "eastus", "properties": {"ddosSettings": {"protectionMode": "VirtualNetworkInherited"},
+      "idleTimeoutInMinutes": 4, "ipAddress": "52.188.14.35", "ipTags": [], "publicIPAddressVersion":
+      "IPv4", "publicIPAllocationMethod": "Static"}, "sku": {"name": "Standard", "tier":
+      "Regional"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '446'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"e8d3143c-1f63-427a-a82b-e0f2a5ea05e7\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/341f2c14-64a5-47a6-a3cc-671db5938511?api-version=2025-07-01&t=639209926392850152&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=f18HhieFqXGVcbWc4pRRlyxonLlFsYLWC_X6hsuEEte98NqONLGr4MtsN99Ues1EEsUFa8haLHASSUAp9dA2IJCYwt3iFu3FsqIs0J2tRY_eF7xmdT8dtDPMZ95wVyl0-84UCHYW9ErdL2MvILdo-w3TRN1DtW8AUxXqQW8j00ocyzO18xJrnvhPHaGbAP5DA-O225FqqOC9GB-Z80uDBj9WPdEDRjTjkG7298lEXK4kgz8qBZ7AF1Uw6C_Rqodl_9S93r6ocUzVTT0Q_eubad7OmWdjq6geHbn6YqTimfScbuj8dwcDHF4KiZW0jtmYDJ3YGelTdn54WMnlooflsA&h=m1ZxUhWKjXQe4okgeFjIgZ9-ziRjmhLxe3h5YytFE9Q
+      cache-control:
+      - no-cache
+      content-length:
+      - '819'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - d99b696f-0038-4163-9670-5a21a98e19d9
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/76de7d61-641e-48bb-81f6-22be0e4caba3
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.3, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.8,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 29EC7A90A02B4AC29B129FBC7CBEF3CA Ref B: SG2AA1070302040 Ref C: 2026-07-30T07:17:18Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/341f2c14-64a5-47a6-a3cc-671db5938511?api-version=2025-07-01&t=639209926392850152&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=f18HhieFqXGVcbWc4pRRlyxonLlFsYLWC_X6hsuEEte98NqONLGr4MtsN99Ues1EEsUFa8haLHASSUAp9dA2IJCYwt3iFu3FsqIs0J2tRY_eF7xmdT8dtDPMZ95wVyl0-84UCHYW9ErdL2MvILdo-w3TRN1DtW8AUxXqQW8j00ocyzO18xJrnvhPHaGbAP5DA-O225FqqOC9GB-Z80uDBj9WPdEDRjTjkG7298lEXK4kgz8qBZ7AF1Uw6C_Rqodl_9S93r6ocUzVTT0Q_eubad7OmWdjq6geHbn6YqTimfScbuj8dwcDHF4KiZW0jtmYDJ3YGelTdn54WMnlooflsA&h=m1ZxUhWKjXQe4okgeFjIgZ9-ziRjmhLxe3h5YytFE9Q
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 2ade018c-c77c-4c77-82bb-3125b3f6ff46
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/4cf9a6a1-1506-4e12-b8f7-0ee7fbf56945
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.6, etc
+      x-msedge-ref:
+      - 'Ref A: EDB3169FB2C04B3789749BAFBD2313E7 Ref B: SG2AA1070301023 Ref C: 2026-07-30T07:17:20Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --ddos-custom-policy
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"830e6936-fbd1-49e5-9cfc-630778f800ac\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"22997e5d-d0e1-45c0-8ace-58b835128625","ipAddress":"52.188.14.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '820'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:22 GMT
+      etag:
+      - W/"830e6936-fbd1-49e5-9cfc-630778f800ac"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - dd40b53a-8b1a-410c-b4cf-d8f675d3ae00
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.6, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.6,
+        etc
+      x-msedge-ref:
+      - 'Ref A: B5F056DF5ED24AB4996B0340E989D01F Ref B: SG2AA1040519031 Ref C: 2026-07-30T07:17:21Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nic delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/networkInterfaces/nic1?api-version=2023-11-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/7e49d30a-d66c-49be-9173-c2e8e872d763?api-version=2023-11-01&t=639209926439421490&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=NTyuU17zR8QfmeAqC1KZ0au-hIzO7nPHTuiSJsX810jybH_VyBOgJ1OGhacnxrbhmyZZDMtM0B8qejw9XrQO4x6OYeXct4EbXiYziech_5239ctS0MS1Gr-ZZudYam7-iiHFwjUttZK51zsq452dDcX1FHV3w2bFIV5yjOikHYHe5cGcEtVQa-jPhiVGZbotmcF1ZMiCtxyYoebj6N9cVs4bcYOAi5akCt4DiLEpRN_fA1bMiUBJ0ikJKRyNuZaQjYmwyybDyXLQcP_eAj5J2nKgfNlOrYLV7pK-Zv7o1AuIQ9z52_JGa_Ct0oCZvks_cp6aDl4edL9e_dbBqaYvnA&h=PClU-J-n1dDaCC7C0ak1JO7cvXyQeCAtganH0rTzTao
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 30 Jul 2026 07:17:23 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/7e49d30a-d66c-49be-9173-c2e8e872d763?api-version=2023-11-01&t=639209926439421490&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=3e3_aeTJEPgRCGMsTBELQVTdKBsbWNCo0FLdAtVeQdpw92z42Z-x5KVp2JqIQ_PhdKPnCsE377_8i9s4T7nQEyyvTy2AdTebrHSK8l7QD2hq3tgOvl2cTqiZFGvM6pE4q3tLucIj5UhjayBH-dA5I6sSpT9cY1ndn8MaUDs8gaO0HCxOG9xt6r8aSHfjlxzgdAsa8Rw4sRr8dsxI6efwyOwc3TRCneZbQg9YxhWtOxg6gTASY8ioqt3UCON3M8QwldlgtX2GqGjZPEMpijHGttfnoY6FzVkJGO0pbPdUv3ArXDBpqOJ_WijJvbuDyNPDxopA4n9yUrrQ-kTRLqTzIA&h=T7pFYOS6Zwg9Xc5EcFWvSBmoY1Guqdlfom32jeDXE4o
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 91a6bbcb-650c-4075-b9f4-2a0ca0018d70
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/8a886cde-8d58-48df-a482-93cc775f8024
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '199'
+      x-ms-ratelimit-remaining-subscription-global-deletes:
+      - '2999'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.9,
+        etc
+      x-msedge-ref:
+      - 'Ref A: CC105C6EE45F4D6A99DBB84CE02C72F0 Ref B: SG2AA1070302036 Ref C: 2026-07-30T07:17:23Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nic delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/7e49d30a-d66c-49be-9173-c2e8e872d763?api-version=2023-11-01&t=639209926439421490&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=NTyuU17zR8QfmeAqC1KZ0au-hIzO7nPHTuiSJsX810jybH_VyBOgJ1OGhacnxrbhmyZZDMtM0B8qejw9XrQO4x6OYeXct4EbXiYziech_5239ctS0MS1Gr-ZZudYam7-iiHFwjUttZK51zsq452dDcX1FHV3w2bFIV5yjOikHYHe5cGcEtVQa-jPhiVGZbotmcF1ZMiCtxyYoebj6N9cVs4bcYOAi5akCt4DiLEpRN_fA1bMiUBJ0ikJKRyNuZaQjYmwyybDyXLQcP_eAj5J2nKgfNlOrYLV7pK-Zv7o1AuIQ9z52_JGa_Ct0oCZvks_cp6aDl4edL9e_dbBqaYvnA&h=PClU-J-n1dDaCC7C0ak1JO7cvXyQeCAtganH0rTzTao
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 9f93105f-adb8-499f-8370-a4ce4c79a994
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/2de936f7-6fa2-41b1-be53-88f3dbb800e2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.6, etc
+      x-msedge-ref:
+      - 'Ref A: 8AE63C498B274908A3E96EE99A313564 Ref B: SG2AA1040520036 Ref C: 2026-07-30T07:17:25Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nic delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/7e49d30a-d66c-49be-9173-c2e8e872d763?api-version=2023-11-01&t=639209926439421490&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=3e3_aeTJEPgRCGMsTBELQVTdKBsbWNCo0FLdAtVeQdpw92z42Z-x5KVp2JqIQ_PhdKPnCsE377_8i9s4T7nQEyyvTy2AdTebrHSK8l7QD2hq3tgOvl2cTqiZFGvM6pE4q3tLucIj5UhjayBH-dA5I6sSpT9cY1ndn8MaUDs8gaO0HCxOG9xt6r8aSHfjlxzgdAsa8Rw4sRr8dsxI6efwyOwc3TRCneZbQg9YxhWtOxg6gTASY8ioqt3UCON3M8QwldlgtX2GqGjZPEMpijHGttfnoY6FzVkJGO0pbPdUv3ArXDBpqOJ_WijJvbuDyNPDxopA4n9yUrrQ-kTRLqTzIA&h=T7pFYOS6Zwg9Xc5EcFWvSBmoY1Guqdlfom32jeDXE4o
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/7e49d30a-d66c-49be-9173-c2e8e872d763?api-version=2023-11-01&t=639209926470547453&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=cmIP1MqGtgIuLLUQueTxDzhO_MQNXzOdVGGGRz0dCBuxaiPvDUQfCwFg3xUMFDg6xc-hxYohq2ORkTPvPOQ77rD2d08PkbZY8KDldZDq9j3Ol2kQo1nT9gRC_TP971iWLe6wPjMrwd8daXJMx_wTFKpzzrM2QnfPaPQn_NOg7aFlC7482ktWV92Rb3zLtd0AcdhzQVllHsZKwEcwqIZiMJ2J70VthA0xHiR3n2w-rT6_iMYQcLiq_G2-ct8zmSPDlBU67gm2xpyWfQRl0dp3TJD0v3uwFhjUlkgSZ1ROrNaoAP-PaCy58Vg9xSe8-xxOzjjAax9VKzfYZyCxVlnGrw&h=NZbukkp-qy4aurzwG03TXP-UKcAbJNExRV1Cf7V3gA8
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:26 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/7e49d30a-d66c-49be-9173-c2e8e872d763?api-version=2023-11-01&t=639209926470703274&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=joGuaQWZKybf3CQvaeLks-7E4OLbkeLr-2eEscgDPIH5P_FkfAq_anTEztmjgaGg5cmxDTyia1PGfZCJKQ--jd6acJCgVw50NrjcZHB1vqOykoikO0K3aXFSXiwGNUJjhqbDZchBE5n43p1trihUW4D5Nh7iEdvorK_-rxlIN223Q24cnd2Tfg22-p5AXW06hT8MZTTanA-W9V9svxgo09ap3SYr1KT7J72VJFHWJeq5ACsY-CUZib-jU4zMjshMvIswj5tFEw6a0y6kEMuVksrstAS8WN6OmPoQJXUeQeDfSafMH6SR0Pgorp0qNgtHekEJvw-ZRCnozDhFvFpn5w&h=kwlYd-y8qFd6XPsetoCPeKyvkHcEOiKPBe1zzxQKieE
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 91a6bbcb-650c-4075-b9f4-2a0ca0018d70
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/43baf0ec-e4c1-4f37-9b9d-366177d144b1
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.6, etc
+      x-msedge-ref:
+      - 'Ref A: 15613BC008C54C6EB9C084DA1A14310A Ref B: SG2AA1040518052 Ref C: 2026-07-30T07:17:26Z'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/dc5b7e6b-e443-4b1f-a6ed-afa0881999da?api-version=2025-07-01&t=639209926491882516&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=usw9_5O-0Vm5z6Tfj1aD-kDDcpiGS23ijm94hSf5wtqmHql2Lz8qmo6dMIXKK9asTCY0PejQSG8mCYXLVciPddpRD40jmBbwJfR9pDb29EijAFv1UuIJjJRiiT_egFJktpYgHfwStopYf35hUK5uiK_6EEcWOuw4d4npsp3tMD_HrHwAIB1O30xwMiTtmAytr-ACgSsPMVlYpX7VBSIV5a1I2hb8flXbvrQ1FjAWKXvqwP8tqce1GFfhCHQnKXWxxes2yYJ_7vh7ifliJAePKotrcbeFF3Jyqg8d7GoIdMhvKwlU_z5bEbg0UlxdYa3zbTOAkM3oGTbyytELi2btRA&h=c3pf0AWv2NYF9kGKbK9khb8M0ifXgfimOq2NUqzeQgA
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 30 Jul 2026 07:17:29 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/dc5b7e6b-e443-4b1f-a6ed-afa0881999da?api-version=2025-07-01&t=639209926491882516&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=bTyykY4XCgbM7VA1iO_UccaLDy5-MzVeuevbAfhKdSLMfhJuWzyPnYEhBUciwXW4vbM8JAvpjU6xWQ8kUQkjNss8b6Fi1gCNoRVOy3HvcioSuLmFGBf7dvPsvR7aTw36zHKjmfmIEiE3Qgv5kEf5CyhMU2SIesSIezq2MUlnv6Ru7c62THsFqJhSbTGsZ9RBOS6p8Jt4v5bQRk6ZgOX7bzQlgsBtYi00_4MjUYGmC5z0Xn3eRRsq4wrTX3Dc61UEjRTp7YYiBeFn3eV9w-qAleJCTHZ9vm8tA4u6RPdmyyesGB6CBxISLdJE_A7wJ2blLnnptr6j87Hu8JXGsgzgRg&h=Di-LojLh8DL-MHjqkOWg3cToCvHRneDoyNsUIMSVsNY
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b809cd14-bbb0-47b7-8745-2cc0102f55da
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/07a86d82-8112-4e13-a066-a3660a9115ce
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '199'
+      x-ms-ratelimit-remaining-subscription-global-deletes:
+      - '2999'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=1.0,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 77B8575FF6E04E39944FF7FDC9D05F47 Ref B: SG2AA1040516054 Ref C: 2026-07-30T07:17:28Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/dc5b7e6b-e443-4b1f-a6ed-afa0881999da?api-version=2025-07-01&t=639209926491882516&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=usw9_5O-0Vm5z6Tfj1aD-kDDcpiGS23ijm94hSf5wtqmHql2Lz8qmo6dMIXKK9asTCY0PejQSG8mCYXLVciPddpRD40jmBbwJfR9pDb29EijAFv1UuIJjJRiiT_egFJktpYgHfwStopYf35hUK5uiK_6EEcWOuw4d4npsp3tMD_HrHwAIB1O30xwMiTtmAytr-ACgSsPMVlYpX7VBSIV5a1I2hb8flXbvrQ1FjAWKXvqwP8tqce1GFfhCHQnKXWxxes2yYJ_7vh7ifliJAePKotrcbeFF3Jyqg8d7GoIdMhvKwlU_z5bEbg0UlxdYa3zbTOAkM3oGTbyytELi2btRA&h=c3pf0AWv2NYF9kGKbK9khb8M0ifXgfimOq2NUqzeQgA
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - ccf45d27-4114-42d2-8f1e-e3e07bab48d9
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/38ab4d33-f4be-4f8a-96f9-df8a756d9486
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.7, etc
+      x-msedge-ref:
+      - 'Ref A: 73A528EFE95B49199EC8B8F986E15D3A Ref B: SG2AA1070302029 Ref C: 2026-07-30T07:17:30Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/dc5b7e6b-e443-4b1f-a6ed-afa0881999da?api-version=2025-07-01&t=639209926491882516&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=bTyykY4XCgbM7VA1iO_UccaLDy5-MzVeuevbAfhKdSLMfhJuWzyPnYEhBUciwXW4vbM8JAvpjU6xWQ8kUQkjNss8b6Fi1gCNoRVOy3HvcioSuLmFGBf7dvPsvR7aTw36zHKjmfmIEiE3Qgv5kEf5CyhMU2SIesSIezq2MUlnv6Ru7c62THsFqJhSbTGsZ9RBOS6p8Jt4v5bQRk6ZgOX7bzQlgsBtYi00_4MjUYGmC5z0Xn3eRRsq4wrTX3Dc61UEjRTp7YYiBeFn3eV9w-qAleJCTHZ9vm8tA4u6RPdmyyesGB6CBxISLdJE_A7wJ2blLnnptr6j87Hu8JXGsgzgRg&h=Di-LojLh8DL-MHjqkOWg3cToCvHRneDoyNsUIMSVsNY
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/dc5b7e6b-e443-4b1f-a6ed-afa0881999da?api-version=2025-07-01&t=639209926527409471&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=dJNqCWQkMclutICM6cUcmnaJV9-i5fCANiW4CjS1dbQotvFk5t1yT2X1KPeJ9j6KuUWb_KRa84SjfhhYjMnsPHKIty6c3MBT3eNkI9q7AX1Fs7FJWHp-GM3XwARd7dcGZ3HSLzXDbw9p29vEvXp58Y6DFef9bbIqYGLMTqHUYoEJjUoYgEvdTAAthtnSz1QUxCPwOss9Hd9juWMu2vKH26WqLa7Tpxn-qzEqnnmUbbC_-h1JjHWQEhXzyxJwD4_xO3UgtkhsPgRX8OQBXcDj-3VuEyBu6-KDJ0-9-emjV5JE2OeAoAGzWbIBZK1sU_GHwFewC674jUIosnx_s_y3Pg&h=MW510VVOVwSjwjpK3rofhMjtTUppL_ZY2E5cNyHeTDg
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:32 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/dc5b7e6b-e443-4b1f-a6ed-afa0881999da?api-version=2025-07-01&t=639209926527409471&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=LWRTFpAU6rPQVRCJjSKSGoe5zwdO81jXdIdkmZ2hMkk5MQb5JuekgrAFhNhTCrsg8BefD85M6vwoNIQRiCATEa5vQ5v6buLqQNgyoK2qc2qd5EqV5sF0z-Jx9MNV_zlT_ZcvZjkCmrcG8AVDDwzxym_gCSms0_2-bYAw03KyyC2BV47Z0iNjRZLJgF0xoPsTeFGXDWDedwZCTCkJoEF-HQIY-N_CaA2fiXkyi3Lmkezgj6QyKpo50YQ27kfn8cNDu-SBwIelpxY3e8PXlh36P6urTpg95dL1t35TomPIjFYp4t2tj-W_4KmVAxC8znLgv4Rp77vekJjyckXKTtKzVQ&h=LQ2M2Ne2h77ocfono5FADGXs4ALwP3JeanM7e7paMGs
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b809cd14-bbb0-47b7-8745-2cc0102f55da
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/d71e283e-b5c2-42fa-8ebc-f115d1ce4a29
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.7, etc
+      x-msedge-ref:
+      - 'Ref A: C61055259B864ADFAE6335C3BF4BFCB4 Ref B: SG2AA1040519025 Ref C: 2026-07-30T07:17:32Z'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy1?api-version=2025-07-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/1e626baa-4d12-42f8-955b-e5e9d5a5202a?api-version=2025-07-01&t=639209926548255776&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=1_CS-0STWA71aWg-ydZb7LMZ2Ni_8KbTmkQ-nDb936xPnrb7GOtdnURlsBheMvR-8zV5NNR54fV7aiWO5hkFuby-iS8m9gb1J6_pIsZVjQ9kdG-z0nql7V7pr2izr2OS90lRHqJgQyrAPgSdnYqdB0VmkqfXVWaEQq15qG67MYVsTn5VUJgqHOsk-3K9OgFYtqCRRoCrEO_dN9PLAdQ-_uHLfMAzkYrG40FwpsD7R3z_g-LJbd16ly42I1VQn80Fxjaa7QUIt3b0LsRwEZlkrtNyYxaet95yI85DT2MntjmGChf6AFYx13vyPD8nh313QRiBvhmyo3CadD7UvPIk5Q&h=B4ouAwD65ynv4gtngLpE42lrMpP2jnbWFBiRZSSnYY0
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 30 Jul 2026 07:17:33 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/1e626baa-4d12-42f8-955b-e5e9d5a5202a?api-version=2025-07-01&t=639209926548255776&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=JmZrxb0JpfRa6FmynVq8Qv36yJlo8F1MffjX5WfgvewHJQsU6UYBVMiFFbGYsrKBcHXvz1yEW-B7_2tkQTDwGyMckKe-yl6bb5yOnsMbEedA8g4wIQhKPZUStFm1Q_pwaNpP1UAcoUeWn0-f3QLZSoDE3vIfulA4Py_O9y1Kubicc_6y-Ca3MSDKmVX5u3Osgr1uy4KEVS7DGfMP0TaS45ABrt0y2DQDTT_xhGgOmF41FJ4kifjBy6PwKgNSyfcH_jTKDeeaZ980u9M8g5Fp0FjpW5AoCyDf5fbooRLyoQjW0AO53WGesWVTQFKhsu6pu5Q1YYZ9lGef4CErEREE2A&h=nVgvcKRPIazpII5WEiYo1OpvfxEH2TUQkmXIBb5wjxk
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - cf88ccd6-2d6a-4ee8-adcf-2edf1b38b53c
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/199c4d81-0b13-49f7-bbbb-554d2257333b
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '199'
+      x-ms-ratelimit-remaining-subscription-global-deletes:
+      - '2999'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=1.1,
+        etc
+      x-msedge-ref:
+      - 'Ref A: FCE330BF9FE645D8A784531F7B7DF954 Ref B: SG2AA1040516040 Ref C: 2026-07-30T07:17:34Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/1e626baa-4d12-42f8-955b-e5e9d5a5202a?api-version=2025-07-01&t=639209926548255776&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=1_CS-0STWA71aWg-ydZb7LMZ2Ni_8KbTmkQ-nDb936xPnrb7GOtdnURlsBheMvR-8zV5NNR54fV7aiWO5hkFuby-iS8m9gb1J6_pIsZVjQ9kdG-z0nql7V7pr2izr2OS90lRHqJgQyrAPgSdnYqdB0VmkqfXVWaEQq15qG67MYVsTn5VUJgqHOsk-3K9OgFYtqCRRoCrEO_dN9PLAdQ-_uHLfMAzkYrG40FwpsD7R3z_g-LJbd16ly42I1VQn80Fxjaa7QUIt3b0LsRwEZlkrtNyYxaet95yI85DT2MntjmGChf6AFYx13vyPD8nh313QRiBvhmyo3CadD7UvPIk5Q&h=B4ouAwD65ynv4gtngLpE42lrMpP2jnbWFBiRZSSnYY0
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 6c771ec1-5377-42cd-83ca-c250606d6175
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/37be3d8a-8492-412c-9dd9-0870f45ece15
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.7,
+        etc
+      x-msedge-ref:
+      - 'Ref A: E40506B66AAB4E3693FCB7A2227F9669 Ref B: SG2AA1070303025 Ref C: 2026-07-30T07:17:35Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/1e626baa-4d12-42f8-955b-e5e9d5a5202a?api-version=2025-07-01&t=639209926548255776&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=JmZrxb0JpfRa6FmynVq8Qv36yJlo8F1MffjX5WfgvewHJQsU6UYBVMiFFbGYsrKBcHXvz1yEW-B7_2tkQTDwGyMckKe-yl6bb5yOnsMbEedA8g4wIQhKPZUStFm1Q_pwaNpP1UAcoUeWn0-f3QLZSoDE3vIfulA4Py_O9y1Kubicc_6y-Ca3MSDKmVX5u3Osgr1uy4KEVS7DGfMP0TaS45ABrt0y2DQDTT_xhGgOmF41FJ4kifjBy6PwKgNSyfcH_jTKDeeaZ980u9M8g5Fp0FjpW5AoCyDf5fbooRLyoQjW0AO53WGesWVTQFKhsu6pu5Q1YYZ9lGef4CErEREE2A&h=nVgvcKRPIazpII5WEiYo1OpvfxEH2TUQkmXIBb5wjxk
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/1e626baa-4d12-42f8-955b-e5e9d5a5202a?api-version=2025-07-01&t=639209926580127318&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=mCebZu2TDnp6X6bUd-qIF_ZF4PB39Df4Jiylj_xDAd1iY0meFzEQeldm5KaSSVimG0ENIR9HJiHYqksLjho8dfq1ClW_eQ7RyeTwIHWABos7VY3cBDEZFne5zRjM7VydZUHXSUAESslbQAyjwVzYHm9EwxDmAaebNkQfbQdIzXKzz1irCEMSdhBCW6i4Y-ijsjLQHe4bdEiO8TRtXrSsWfJmw9nSI3qVmBa9zNQgCbJDe_mnNzCBKofvLM4Vzy9OcFGIrdPpUnePszFcj2LnnyJSKkhR-DTEX62gdlc2KSNf0wYgZob3LxDz_kmwpL7DgHEXP-PwB5_evLoSiKwENA&h=e3DMsfOgKLPDH7-8hhGknL6tmIxbpTWCOIGEXdS8lIE
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:37 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/1e626baa-4d12-42f8-955b-e5e9d5a5202a?api-version=2025-07-01&t=639209926580127318&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=eNRZNOeD75t62OEX0DYIROFF7zpjHrEgYLrPn3M8ANkNTrIIbkyNMEjtts6t1qLOLgHNS-Ga-1rz-1JQ7LPaWC_u6PmetkbPt8d4g0Wv5kqOlhhZs2zIFWCriM3JDJN4VNbQVifsuUJ-2JdprqNyHtZkILFY-Rn3M-PXFRfrSnr59dZ3iV0sY8w9ukjDXS5bofMkUHlE-zv18zXOnpduwaJ0LCdv20rQm3EBqeMh3185GqI39AtmnQEHL4D1qZR_abKB4guHMvLkY61tDMZ4SfmnlbApmVnayg2g4xi1L5-T0RnfVGcjXWYbV7Wevc5O7d6mxP4DGNpzakV2M6Lw4A&h=bJnduZzMHqr2TNJdbOJ0B-eCD7gHH-iAgKCpsxPo9FY
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - cf88ccd6-2d6a-4ee8-adcf-2edf1b38b53c
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/35d125cf-5cf4-4dd2-ae6b-f10531a5f27d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.7, etc
+      x-msedge-ref:
+      - 'Ref A: 2926C5C18D064D169239C7F23A5684E2 Ref B: SG2AA1070301029 Ref C: 2026-07-30T07:17:37Z'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ddos_cuspol_pip000001/providers/Microsoft.Network/ddosCustomPolicies/policy2?api-version=2025-07-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9601db55-33b2-48b0-b355-2f9ae1c830b2?api-version=2025-07-01&t=639209926598934764&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=irLN-sI1SkW-Aspmne1A-eeLXFjU-nzzE6GEW6RCypz6jb2w-SfKmBWuORIiyRrA0JDmolcaNS4OS9Yx7RdDj4Vek01BH_fhTjYQWiSJB-Tinlc3u6qoBhjKjZrMPEMkfbWdB6JQGxiBEkUtOkivnHTAKCyNMql8hD7VtB3ECb2DSrXJ0jdQ_0EM5VTD3AKYGJGSON0gTOEns080nJgGiI2sJ_inbf8TTKWi8XsElbaAAtZeAWzxISsgyyQ2BUifBW5MXkXKJPKXVY6838k4Yej4JpIeyC5k-6k-Dq2w5a6wwSr21PqQIj-nOD_f2l0gPiOYrXDzJxEr4WRhTCq4ZQ&h=fBFb68SMYTIiDVKHGG2gazWXnZMnk0UC_mXt6A9Wqqs
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 30 Jul 2026 07:17:39 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/9601db55-33b2-48b0-b355-2f9ae1c830b2?api-version=2025-07-01&t=639209926598934764&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=a7jCE_s1-yOSCREyH3ccqsHtmkoi28m15nPCTnpyiy9GOMqRjcuDBNX7qRCTfz9cy2mxrc6ag7xMO7Jc2rBGWtGZQblxpMtPY_2m_e4n5ZUM30FxNsP6rqOKrZSuObXnDUo9cn2XMeku72PDX451CsOKRW-BCdhP11XOt_zdQDAL-54rPbI89sFTX4Fb5v-SGnhDZ3Mf-xrm5cQdMoSDNUu_7wubHUx0j2DNQwvzUdI3vluSSq35zNGtPLMvA8X8zte5JrviW0vQGZ-zzSlIFYnhlGbinJlaDsak5uxpULlPtRY8-paY86FNQUInH8lQuCG3PV3o-coWVKWd9gTpgA&h=0sxtSsAdmJlq9sL0XvRBKFJtW3qKW6ok6qZuUuiBKPU
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 91c72f92-5cf4-4355-8bb2-260fb5e4d2d8
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/eastus/1be1c4af-ca82-4e32-8c6a-f7cad5fe8aa2
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '199'
+      x-ms-ratelimit-remaining-subscription-global-deletes:
+      - '2999'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.3, subscriptionWriteRatePct=1.2,
+        etc
+      x-msedge-ref:
+      - 'Ref A: F9D2B332F6C74690AA6F2D4418E6ACB6 Ref B: SG2AA1040520025 Ref C: 2026-07-30T07:17:39Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9601db55-33b2-48b0-b355-2f9ae1c830b2?api-version=2025-07-01&t=639209926598934764&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=irLN-sI1SkW-Aspmne1A-eeLXFjU-nzzE6GEW6RCypz6jb2w-SfKmBWuORIiyRrA0JDmolcaNS4OS9Yx7RdDj4Vek01BH_fhTjYQWiSJB-Tinlc3u6qoBhjKjZrMPEMkfbWdB6JQGxiBEkUtOkivnHTAKCyNMql8hD7VtB3ECb2DSrXJ0jdQ_0EM5VTD3AKYGJGSON0gTOEns080nJgGiI2sJ_inbf8TTKWi8XsElbaAAtZeAWzxISsgyyQ2BUifBW5MXkXKJPKXVY6838k4Yej4JpIeyC5k-6k-Dq2w5a6wwSr21PqQIj-nOD_f2l0gPiOYrXDzJxEr4WRhTCq4ZQ&h=fBFb68SMYTIiDVKHGG2gazWXnZMnk0UC_mXt6A9Wqqs
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 78565c8d-d28f-4794-8eba-2ce273ec259e
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/2e616cec-2fcd-4185-bf33-8fd260f33842
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.7,
+        etc
+      x-msedge-ref:
+      - 'Ref A: B2872645A87D46889E2FFFEF844A27B7 Ref B: SG2AA1040519040 Ref C: 2026-07-30T07:17:41Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network ddos-custom-policy delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/9601db55-33b2-48b0-b355-2f9ae1c830b2?api-version=2025-07-01&t=639209926598934764&c=MIIHlDCCBnygAwIBAgIQZiYkoV_LM7Hwt06_u_DzJDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQxMDA4MTUzOVoXDTI2MTAwNTE0MTUzOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDealc9e2xWlYn0dX5zgxycoyRECfCn-ACb8WxKGmsKAA5yFa8bggPwuauZjSPSntq3xw99b6CFXZ6EM34WjxaWokZKYj8bbRT14WzrQHemPN5KUaI3SFtZidaSdEAzhm7Ha1a74SG8rDZU8qVqbaoCPQk9Iblv0LucrVV5BAMOwvi-5j-7X9vehxsheuxPwrVmGy_WrXI_3Qflmizp5BND_I3p4BIRjEcaQw_EBd3dhAC52EO5bT3FKSdM6N5xgpZvtjHjxRG2WG_8Gh07OrI0Ib0mnTB1_HNhiEw3_VzdnINXV0_Fsm7HMV-qCCkY5pyJIZjVX7L7FFY0PGqcqUKdAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSZIRQPs2If06iDFyiGbMnvIxenBzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzQ2L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNDYvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS80Ni9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAxSvsyw-aQGPuLg3sIv-zDLSqhHgP__v9DGyP7D16rJpNG1JcjpiXpbloqD9RW5Gc_hHWn5Kyr1pRABJrFa-jEt89-FiQdkToF-vvwJOXbryAgZYdS03uFzUGqARs3JMMqCHrVkx6hb9oOxh_3JdEemO_dbhApyOVTfloO4kIRsgJnHI_ImFt8xm3xa9ftB0ARfJAdN_1EHgB2NdOgTvaSljVOnQY6R40lh_Wl8-s3GIhHbNwQOECXegBxeVAUVN5nGxlD8TEqKc_mX-22kBMao71zBz3JWtCING4-QzwrWj9pxmanpqYqiVGf40ZbZZihRkte0KI9zvW53Y2Smcy7&s=a7jCE_s1-yOSCREyH3ccqsHtmkoi28m15nPCTnpyiy9GOMqRjcuDBNX7qRCTfz9cy2mxrc6ag7xMO7Jc2rBGWtGZQblxpMtPY_2m_e4n5ZUM30FxNsP6rqOKrZSuObXnDUo9cn2XMeku72PDX451CsOKRW-BCdhP11XOt_zdQDAL-54rPbI89sFTX4Fb5v-SGnhDZ3Mf-xrm5cQdMoSDNUu_7wubHUx0j2DNQwvzUdI3vluSSq35zNGtPLMvA8X8zte5JrviW0vQGZ-zzSlIFYnhlGbinJlaDsak5uxpULlPtRY8-paY86FNQUInH8lQuCG3PV3o-coWVKWd9gTpgA&h=0sxtSsAdmJlq9sL0XvRBKFJtW3qKW6ok6qZuUuiBKPU
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9601db55-33b2-48b0-b355-2f9ae1c830b2?api-version=2025-07-01&t=639209926632171416&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=X9THuKdpnVJAgI5wgkLY2YJESSZZJOEMBAhNpRG-LJjOT_Y5JqEHghuOViDbLfzqXZNl7eYLJnkUwd3amagzhq3pjDcXGtUbrse695aeMc4k61qUTvdHpJUPQs1um-NvwpQ_IGf-qNL7kPaXc2jRI3fdCrP684t13wjJNARU7a94eMEjGmY2fZXgRgtPWCkBnDgsr8JcTX-QgsTSWEiBpc-mRBXJq30PH27k1KuLexqq0gylH8KxpgmJ60QUyoUi35jPc4uu7nROhl0F4dwzk5EdSxlRaUvqOOojJ9sb0BfQ7feDZbtBJGUrBJrKAEZomEjHOYtiF38c1-i8XDCQrw&h=doctcqJ37I1SOV3Caup_qMReqcW1tnF8Q7JLgQJ-K5o
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 30 Jul 2026 07:17:42 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/9601db55-33b2-48b0-b355-2f9ae1c830b2?api-version=2025-07-01&t=639209926632171416&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=V6yuK4WT4IMB8jiJ1fa-Cb2UG9UP2Mj4lBD3zQDOpVeVM7HcdrjFTHOCp0g_yWSE5EPFnd9EWOC6yQEuasDmyb9hqXl_dbDC6DrYfxJVHDp8OQbGbaPOl25AqTQLgnG3RB6__pE1N79kDD-ahVTUdYb7FLlI_TEi3u9T1tyu5nPKYqUL7OCuDBptpTwW2i7i94fi0e301sZrya0nEJ-nx3CYtxw033DRrXPn6_STUxPlUY4mUv8Lo9XfoEpXUqSTx4lGEDspbfJ3FHrFZ6ETRMmw_GfuHCYC0NcfZ3FyttDj_RrG55Gkkt0BDJffkZqRa_Iuf2mQC09eTQfBFkMThQ&h=hNBAWoQmNJQAXko5kLA5VpxV3vpDouPzjaAJLQG8Rbo
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 91c72f92-5cf4-4355-8bb2-260fb5e4d2d8
+      x-ms-operation-identifier:
+      - tenantId=4f00b3b6-2940-4f2c-b037-94637c180d30,objectId=016c741f-3499-47a6-bdb0-6ef338078ddf/southeastasia/a17cb2cb-a29d-4274-b54a-b53813abdef4
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.8,
+        etc
+      x-msedge-ref:
+      - 'Ref A: E9DB86E2E83743EBB4EDBE71F4858B84 Ref B: SG2AA1040516060 Ref C: 2026-07-30T07:17:42Z'
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_manage_appgw_private_endpoint.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_manage_appgw_private_endpoint.yaml
@@ -63,7 +63,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.45.0 (PIP) (AAZ) azsdk-python-core/1.24.0 Python/3.8.10 (Windows-10-10.0.19045-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2022-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"public_ip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint000001/providers/Microsoft.Network/publicIPAddresses/public_ip\",\r\n
@@ -171,7 +171,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.45.0 (PIP) (AAZ) azsdk-python-core/1.24.0 Python/3.8.10 (Windows-10-10.0.19045-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2022-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"public_ip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint000001/providers/Microsoft.Network/publicIPAddresses/public_ip\",\r\n

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_manage_appgw_private_endpoint_without_standard.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_manage_appgw_private_endpoint_without_standard.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.5 (Windows-10-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint_without_standard000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint_without_standard000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"public_ip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint_without_standard000001/providers/Microsoft.Network/publicIPAddresses/public_ip\",\r\n
@@ -175,7 +175,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.5 (Windows-10-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint_without_standard000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint_without_standard000001/providers/Microsoft.Network/publicIPAddresses/public_ip?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"public_ip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_manage_appgw_private_endpoint_without_standard000001/providers/Microsoft.Network/publicIPAddresses/public_ip\",\r\n

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_basic.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_basic.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"d9c8d207-233d-443b-b9c7-c82988b63e1a\"","location":"eastus2","zones":["2"],"properties":{"provisioningState":"Updating","resourceGuid":"f9107558-ba5b-4a19-82ed-4047f111df7d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -126,7 +126,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"c0e7aaf0-6ab4-4b6d-b690-53a5cf895516\"","location":"eastus2","zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"f9107558-ba5b-4a19-82ed-4047f111df7d","ipAddress":"20.55.211.86","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_pipv6_param_formats.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_pipv6_param_formats.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pipv4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4","etag":"W/\"f24c7110-37db-40e9-b4ff-06a35735a244\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"0b7c6d21-52f4-450c-8d1b-ab457c19f0a2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pipv4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4","etag":"W/\"d7193c01-244d-458d-9e80-6ea18f2832fb\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"0b7c6d21-52f4-450c-8d1b-ab457c19f0a2","ipAddress":"172.175.224.109","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -232,7 +232,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pipv6-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1","etag":"W/\"3bc39bed-0982-4742-af31-26fe49050259\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"b9e0636c-b951-4ac8-bfcc-f5e02c5bad4a","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -388,7 +388,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pipv6-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1","etag":"W/\"344d3614-3769-4559-a495-0994475bf5f5\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"b9e0636c-b951-4ac8-bfcc-f5e02c5bad4a","ipAddress":"2603:1030:403:4::","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -444,7 +444,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pipv6-2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2","etag":"W/\"e66eb8b5-ba63-4484-bf66-54d1eabccdd5\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"0971a9b1-f37a-4ddd-9346-bc3904cd1bb5","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -600,7 +600,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pipv6-2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2","etag":"W/\"feeaae70-72e4-420b-89a3-9ef8ed4a46ba\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"0971a9b1-f37a-4ddd-9346-bc3904cd1bb5","ipAddress":"2603:1030:403:40::2","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_active_active_cross_premise_connection.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_active_active_cross_premise_connection.yaml
@@ -325,7 +325,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gwip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip1","etag":"W/\"fe002327-7556-4b65-be53-19113da48211\"","location":"westus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"6e93dcfa-9853-4f38-9f9b-2d316b538242","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -431,7 +431,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gwip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip1","etag":"W/\"0810ccc2-02a0-4765-95a4-ae973a50a6ba\"","location":"westus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"6e93dcfa-9853-4f38-9f9b-2d316b538242","ipAddress":"40.90.218.148","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -532,7 +532,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gwip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip2","etag":"W/\"c02b035a-4e49-4b28-911a-6201ca3bbe4f\"","location":"westus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"3435e808-5005-41f9-b47c-85f05ab0f4ee","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -638,7 +638,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gwip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection000001/providers/Microsoft.Network/publicIPAddresses/gwip2","etag":"W/\"914f0de3-70ea-40c4-9d4b-c6beca4470e4\"","location":"westus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"3435e808-5005-41f9-b47c-85f05ab0f4ee","ipAddress":"172.179.29.62","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_active_active_vnet_connection.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_active_active_vnet_connection.yaml
@@ -596,7 +596,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw1ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip1","etag":"W/\"460e4716-104d-401e-92aa-6ddfff09f7a7\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"a4ee5fa8-f875-4ca6-a043-4dcccd064973","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -694,7 +694,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw1ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip1","etag":"W/\"99a663f5-e5b1-40d4-bd0a-a98149cb5e53\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"a4ee5fa8-f875-4ca6-a043-4dcccd064973","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -790,7 +790,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw1ip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip2","etag":"W/\"21028937-74ec-480f-a520-cd8ba74276a7\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"d2280106-9e35-4975-b71b-aa60f384988b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -892,7 +892,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw1ip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw1ip2","etag":"W/\"ee15c5cf-8c55-4c73-a7f7-9c326ba8909a\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"d2280106-9e35-4975-b71b-aa60f384988b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -1271,7 +1271,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw2ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip1","etag":"W/\"5afc9c82-9833-4a14-babb-821f8e8ab2e8\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"80f1971a-2b96-4570-9c71-6b30e676f2ea","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -1373,7 +1373,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw2ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip1","etag":"W/\"eb5f061b-2607-42ad-9ca7-ddf588fe16bc\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"80f1971a-2b96-4570-9c71-6b30e676f2ea","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -1473,7 +1473,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw2ip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip2","etag":"W/\"7daf77c4-fbe0-456b-b5f6-ee7dd9f51ca5\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"bb054fec-56cc-4779-bd0e-3623c0fa0eb8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -1575,7 +1575,7 @@ interactions:
       - AZURECLI/2.53.0 (AAZ) azsdk-python-core/1.26.0 Python/3.10.13 (Linux-5.15.0-1047-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gw2ip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection000001/providers/Microsoft.Network/publicIPAddresses/gw2ip2","etag":"W/\"982179f4-719a-4dd7-b613-0cef60eb54a8\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"bb054fec-56cc-4779-bd0e-3623c0fa0eb8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_auth_cert.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_auth_cert.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_auth_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_auth_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"error":{"code":"SubscriptionNotRegisteredForFeature","message":"Subscription

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_frontend_ip_private.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_frontend_ip_private.yaml
@@ -64,7 +64,7 @@ interactions:
       - AZURECLI/2.45.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_private000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_private000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"myip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_private000001/providers/Microsoft.Network/publicIPAddresses/myip1\",\r\n
@@ -173,7 +173,7 @@ interactions:
       - AZURECLI/2.45.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
         VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_private000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_private000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"myip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_private000001/providers/Microsoft.Network/publicIPAddresses/myip1\",\r\n

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_frontend_ip_public.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_frontend_ip_public.yaml
@@ -416,7 +416,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.60.0 azsdk-python-core/1.28.0 Python/3.9.5 (Windows-10-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip1","etag":"W/\"fee052e2-e207-4e1e-a169-ba5d61f9b8c4\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"a9d1f28c-ee8e-418c-bbb6-619ecb57b5c9","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -514,7 +514,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.60.0 azsdk-python-core/1.28.0 Python/3.9.5 (Windows-10-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip1","etag":"W/\"e798c7d1-0980-4ff9-b3f8-b212e9b0b97d\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"a9d1f28c-ee8e-418c-bbb6-619ecb57b5c9","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -611,7 +611,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.60.0 azsdk-python-core/1.28.0 Python/3.9.5 (Windows-10-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip2","etag":"W/\"fc9e0235-9a88-45ee-8f9b-d331af5f4b83\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"d95ef278-2fc1-491b-8f5f-a97c74ea2dd2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -709,7 +709,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.60.0 azsdk-python-core/1.28.0 Python/3.9.5 (Windows-10-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public000001/providers/Microsoft.Network/publicIPAddresses/myip2","etag":"W/\"5714a6c7-6dc7-481a-9c35-1beecda16838\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"d95ef278-2fc1-491b-8f5f-a97c74ea2dd2","ipAddress":"13.91.121.19","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_http_listener_with_multi_host_names.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_http_listener_with_multi_host_names.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_listener000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_listener000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_listener000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"9963c395-a27b-49f4-bab6-e62663d4b288\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"18256f9e-ac9d-4ead-a60d-162f718e05c4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_listener000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_listener000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_listener000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"91ca0267-ac3c-4529-8713-00a3961f2382\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"18256f9e-ac9d-4ead-a60d-162f718e05c4","ipAddress":"172.184.158.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_http_listener_with_waf_policy.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_http_listener_with_waf_policy.yaml
@@ -387,7 +387,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_ag_http_listener_with_waf_policy000001/providers/Microsoft.Network/publicIPAddresses/ip-1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_ag_http_listener_with_waf_policy000001/providers/Microsoft.Network/publicIPAddresses/ip-1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_ag_http_listener_with_waf_policy000001/providers/Microsoft.Network/publicIPAddresses/ip-1","etag":"W/\"34cf7907-e489-405b-a564-988fbf9389f3\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"3389c6cb-a5ad-4c37-8e31-017dc9b5c470","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -493,7 +493,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_ag_http_listener_with_waf_policy000001/providers/Microsoft.Network/publicIPAddresses/ip-1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_ag_http_listener_with_waf_policy000001/providers/Microsoft.Network/publicIPAddresses/ip-1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_ag_http_listener_with_waf_policy000001/providers/Microsoft.Network/publicIPAddresses/ip-1","etag":"W/\"635afa2d-ba18-4039-83f3-f6a9b0e24d85\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"3389c6cb-a5ad-4c37-8e31-017dc9b5c470","ipAddress":"172.185.152.24","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_http_settings.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_http_settings.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settings000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settings000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settings000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"4269bfca-1eb7-4392-9c78-901cf1e33b0e\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"1ba89c65-3aba-4144-b229-aa8068828b50","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settings000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settings000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settings000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"9863b3dd-21fc-4330-9a29-3e3c25190a62\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"1ba89c65-3aba-4144-b229-aa8068828b50","ipAddress":"57.154.189.229","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_listener.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_listener.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"9c254d18-a314-41cf-98ce-d1923fdc197d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"03ea18c0-6112-414f-a708-a1674eb7accb","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"b61272ab-1f50-4f94-91fd-c7aefaff1cd6\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"03ea18c0-6112-414f-a708-a1674eb7accb","ipAddress":"20.253.220.183","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_listener_with_host_names.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_listener_with_host_names.yaml
@@ -630,7 +630,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener_with_host_names000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener_with_host_names000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener_with_host_names000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"b83da1ec-1616-4a02-abb4-f4ac77cf4be8\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"1f7ec16c-2d12-4c20-b0a8-8f2f2945cf6f","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -736,7 +736,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener_with_host_names000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener_with_host_names000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_listener_with_host_names000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"30034879-af92-4caa-abf4-710321544ff6\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"1f7ec16c-2d12-4c20-b0a8-8f2f2945cf6f","ipAddress":"172.185.18.242","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_probe.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_probe.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gateway_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip","etag":"W/\"c38641b9-ab47-47bb-960d-5b3ef2b2a319\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"8a509e58-2861-477e-ad4f-6bcf1d477d36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gateway_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip","etag":"W/\"d6a2b193-854b-4440-810d-062442c78f71\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8a509e58-2861-477e-ad4f-6bcf1d477d36","ipAddress":"52.234.35.212","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_probe_with_host_name_from_settings.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_probe_with_host_name_from_settings.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe_with_host_name_from_settings000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe_with_host_name_from_settings000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gateway_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe_with_host_name_from_settings000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip","etag":"W/\"a688fb27-9b2b-4933-92f5-dc2b0da4e0d5\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"ccc85167-190a-4212-9441-c2d5feda59e9","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe_with_host_name_from_settings000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe_with_host_name_from_settings000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"gateway_ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe_with_host_name_from_settings000001/providers/Microsoft.Network/publicIPAddresses/gateway_ip","etag":"W/\"974d80cd-de66-4294-891a-368a098e76f1\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ccc85167-190a-4212-9441-c2d5feda59e9","ipAddress":"20.245.192.150","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_root_cert.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_root_cert.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_root_cert000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_root_cert000001/providers/Microsoft.Network/publicIPAddresses/myip1?api-version=2025-07-01
   response:
     body:
       string: '{"error":{"code":"SubscriptionNotRegisteredForFeature","message":"Subscription

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_routing_rule.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_routing_rule.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_routing_rule000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_routing_rule000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_routing_rule000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"cfc6e359-30e9-4d9d-b5c1-f5c9c176bf6d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"9c34df29-6069-4e0f-b6aa-1f41027da391","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_routing_rule000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_routing_rule000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_routing_rule000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"d1daf2bc-8187-4e72-8408-3f7e7913d60a\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"9c34df29-6069-4e0f-b6aa-1f41027da391","ipAddress":"172.185.52.253","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_rule.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_rule.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"a18dc82c-4846-430d-94ab-0be9dc8ebea8\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"0c86c5ed-d1cb-440f-b771-0858563be316","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rule000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"7c762234-942b-4df8-aa99-8e40be6a296c\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"0c86c5ed-d1cb-440f-b771-0858563be316","ipAddress":"172.184.106.186","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_settings.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_settings.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_settings000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_settings000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_settings000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"186e501e-b2df-463b-8c06-cdfd2a32af8d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"7400652c-7647-4b30-a681-5a21c19f6e28","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_settings000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_settings000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testPublicIp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_settings000001/providers/Microsoft.Network/publicIPAddresses/testPublicIp","etag":"W/\"8360be73-4628-4a3b-8799-92563c534e75\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"7400652c-7647-4b30-a681-5a21c19f6e28","ipAddress":"20.43.245.251","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_url_path_map.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_url_path_map.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"8dc2b9b5-1416-434e-89b5-c4478c48c268\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"c7b2ef60-0efe-4a47-90f6-4e7b79c377ed","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"f20e29fc-cdd3-4be9-a63b-2b4d58ba8cc1\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"c7b2ef60-0efe-4a47-90f6-4e7b79c377ed","ipAddress":"20.245.207.156","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_url_path_map_edge_case.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_url_path_map_edge_case.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map_edge_case000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map_edge_case000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map_edge_case000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"aa7ee74d-5c23-4b26-bc58-9c592846662c\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"04dbbac4-b4b8-4796-b966-32fd0861d625","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map_edge_case000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map_edge_case000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_url_path_map_edge_case000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"953c3964-b63c-4c62-8301-f7e84a6bc3e2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"04dbbac4-b4b8-4796-b966-32fd0861d625","ipAddress":"52.234.126.74","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_zone.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ag_zone.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"2baf9978-b6ab-43c2-a527-31b16558969b\"","location":"westus2","zones":["1","3","2"],"properties":{"provisioningState":"Updating","resourceGuid":"61e2daa8-c766-4d2f-8a39-effaf83324a4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"9dba297e-6e54-43bb-a055-fb14e6b81731\"","location":"westus2","zones":["1","3","2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"61e2daa8-c766-4d2f-8a39-effaf83324a4","ipAddress":"172.179.103.29","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ags_enable_l4_client_ip_preservation.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ags_enable_l4_client_ip_preservation.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ags_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ags_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ags_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002","etag":"W/\"35227873-1d9d-45fc-af4f-cb62aae49123\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"1ecc65e1-01af-4d0f-a5a7-20733f11bbeb","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ags_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ags_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ags_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002","etag":"W/\"75aee331-cf7d-4240-b5d7-9f0f64efc821\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"1ecc65e1-01af-4d0f-a5a7-20733f11bbeb","ipAddress":"20.253.230.90","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ags_enable_probe_proxy_protocol_header.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_ags_enable_probe_proxy_protocol_header.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_agp_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_agp_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_agp_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002","etag":"W/\"6124ee50-5dfc-42c2-95eb-2d62b7d520f1\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"5ab96cdf-ed8f-4e22-a57f-b3a4a343b4e0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.80.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_agp_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_agp_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_agp_new_prop000001/providers/Microsoft.Network/publicIPAddresses/public000002","etag":"W/\"140dd7bf-9409-482a-8350-a1aeb15c185f\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"5ab96cdf-ed8f-4e22-a57f-b3a4a343b4e0","ipAddress":"20.66.91.70","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_rewrite_rulesets.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_rewrite_rulesets.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"6848785b-503a-4ae3-abd3-d5a23f9321e4\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"795d161d-c40b-4a90-916c-b1cfc855821f","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"52cbf0d5-fd04-45dd-9522-4df19cb04022\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"795d161d-c40b-4a90-916c-b1cfc855821f","ipAddress":"13.88.112.205","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_ssl_cert_managed_hsm.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_ssl_cert_managed_hsm.yaml
@@ -3585,7 +3585,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_cert_hsm000001/providers/Microsoft.Network/publicIPAddresses/pip-hsm-test?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_cert_hsm000001/providers/Microsoft.Network/publicIPAddresses/pip-hsm-test?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip-hsm-test","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_cert_hsm000001/providers/Microsoft.Network/publicIPAddresses/pip-hsm-test","etag":"W/\"19f0a41c-5569-4199-9995-f7ee9b9b288f\"","location":"uksouth","properties":{"provisioningState":"Updating","resourceGuid":"978bc55e-2957-4864-b0dc-162f70a5e460","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -3691,7 +3691,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_cert_hsm000001/providers/Microsoft.Network/publicIPAddresses/pip-hsm-test?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_cert_hsm000001/providers/Microsoft.Network/publicIPAddresses/pip-hsm-test?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip-hsm-test","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_cert_hsm000001/providers/Microsoft.Network/publicIPAddresses/pip-hsm-test","etag":"W/\"645e6330-2901-4906-881c-a5370088fb16\"","location":"uksouth","properties":{"provisioningState":"Succeeded","resourceGuid":"978bc55e-2957-4864-b0dc-162f70a5e460","ipAddress":"51.143.171.205","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_waf_policy_with_application_gateway.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_waf_policy_with_application_gateway.yaml
@@ -1851,7 +1851,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"b5241a3b-7176-4192-899f-224b47b88ffb\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"6f2471ee-b18c-4537-9d6c-031508fcc2c5","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1957,7 +1957,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"be863d5a-e534-4747-881a-26eaa92b56bf\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6f2471ee-b18c-4537-9d6c-031508fcc2c5","ipAddress":"20.165.186.88","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -2059,7 +2059,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip2","etag":"W/\"f79f0800-0a49-433e-94be-dc40f7f0a040\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"6a86c69a-0d8b-4f06-866e-c11674665a70","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -2165,7 +2165,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_app_gateway_waf_policy_000001/providers/Microsoft.Network/publicIPAddresses/pip2","etag":"W/\"f3bb4486-bef4-4f0e-a552-7c8e02e5eefa\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a86c69a-0d8b-4f06-866e-c11674665a70","ipAddress":"20.165.132.249","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_cert_name.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_cert_name.yaml
@@ -631,7 +631,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_cert_name_000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_cert_name_000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_cert_name_000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"8729dbc2-25f3-4fd2-9dff-b1eb1afcf214\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"0baae443-578f-4712-a012-1e6859b69686","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -737,7 +737,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.79.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_cert_name_000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_cert_name_000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_cert_name_000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"1426e688-a0ed-4735-8463-93f1f8805551\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"0baae443-578f-4712-a012-1e6859b69686","ipAddress":"20.66.112.159","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_defaults.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_defaults.yaml
@@ -488,7 +488,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"8fce709d-1bb3-4321-83d1-fa1ab06ce44f\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"71948eec-16c3-42ea-b74e-465a315c8839","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -594,7 +594,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"61569339-b879-4ddf-98b5-92fba132a2c6\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"71948eec-16c3-42ea-b74e-465a315c8839","ipAddress":"13.91.222.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_private_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_private_ip.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip000001/providers/Microsoft.Network/publicIPAddresses/pip-ag3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip000001/providers/Microsoft.Network/publicIPAddresses/pip-ag3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip-ag3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip000001/providers/Microsoft.Network/publicIPAddresses/pip-ag3","etag":"W/\"7fac37b6-bf06-4acd-9e6c-39d073759192\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"a55117de-f4fe-4a91-b625-ade7462ab560","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip000001/providers/Microsoft.Network/publicIPAddresses/pip-ag3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip000001/providers/Microsoft.Network/publicIPAddresses/pip-ag3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip-ag3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip000001/providers/Microsoft.Network/publicIPAddresses/pip-ag3","etag":"W/\"580413ef-1013-4677-bf28-813516bc6385\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"a55117de-f4fe-4a91-b625-ade7462ab560","ipAddress":"20.245.190.177","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_ssl_profile.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_ssl_profile.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_profile000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_profile000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_profile000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"87082148-0599-4958-a906-0483c53a589e\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"22ff31c9-3a29-4500-ac38-06930d58c170","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_profile000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_profile000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_ssl_profile000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"0d4597f8-5620-4d64-aea3-ec17c669aa5c\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"22ff31c9-3a29-4500-ac38-06930d58c170","ipAddress":"20.253.169.77","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_trusted_client_cert.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_trusted_client_cert.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_trusted_client_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_trusted_client_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_trusted_client_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"be4894d6-24b4-41b6-9d46-773a3ff0831e\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"37d532fd-9d80-4b3c-8492-dfa6817d4a34","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_trusted_client_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_trusted_client_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_trusted_client_cert000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"7d6101d4-1226-40b4-9928-10db9869248b\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"37d532fd-9d80-4b3c-8492-dfa6817d4a34","ipAddress":"172.184.104.126","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_waf_v2_sku.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_with_waf_v2_sku.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.75.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic_with_waf_v2_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic_with_waf_v2_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic_with_waf_v2_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"4f4db712-2bdc-42d9-a328-d7c667875695\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"8e9a1a74-ca5d-4631-8595-23ef761c69b8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.75.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic_with_waf_v2_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic_with_waf_v2_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basic_with_waf_v2_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"6d928c69-3834-4890-8021-0d835c220f72\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8e9a1a74-ca5d-4631-8595-23ef761c69b8","ipAddress":"172.184.132.17","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_appgw_creation_with_public_and_private_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_appgw_creation_with_public_and_private_ip.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_appgw_creation_with_public_and_private_ip000001/providers/Microsoft.Network/publicIPAddresses/publicIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_appgw_creation_with_public_and_private_ip000001/providers/Microsoft.Network/publicIPAddresses/publicIP?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_appgw_creation_with_public_and_private_ip000001/providers/Microsoft.Network/publicIPAddresses/publicIP","etag":"W/\"d9b5bed1-c9c7-4eb8-8857-2983de68dfc0\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"2e6b4a2a-e40a-4175-b782-6a3d2fe7fdb3","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_appgw_creation_with_public_and_private_ip000001/providers/Microsoft.Network/publicIPAddresses/publicIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_appgw_creation_with_public_and_private_ip000001/providers/Microsoft.Network/publicIPAddresses/publicIP?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_appgw_creation_with_public_and_private_ip000001/providers/Microsoft.Network/publicIPAddresses/publicIP","etag":"W/\"bca1541a-4c6f-42c7-912c-305f4a91b06a\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"2e6b4a2a-e40a-4175-b782-6a3d2fe7fdb3","ipAddress":"52.225.18.61","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_application_gateway_http_settings_validate_flags.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_application_gateway_http_settings_validate_flags.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ag000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ag000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ag000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"37d83b4f-b870-4557-9d70-536c370b6447\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"61778c5b-ea5f-448c-8034-5d69d666e4d7","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ag000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ag000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_ag000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"6cc2ae14-abe1-4a6a-bba2-313bf3ce628c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"61778c5b-ea5f-448c-8034-5d69d666e4d7","ipAddress":"13.68.249.110","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_cross_region_lb.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_cross_region_lb.yaml
@@ -612,7 +612,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/PublicIPcross-region-lb2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/PublicIPcross-region-lb2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"PublicIPcross-region-lb2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/PublicIPcross-region-lb2","etag":"W/\"88f1e975-e2be-48c5-83b7-2ce4f7675002\"","location":"westus","tags":{"foo":"doo"},"properties":{"provisioningState":"Succeeded","resourceGuid":"cd2c72cc-2d84-4525-85d5-bc9978d9ea25","ipAddress":"68.220.42.118","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/loadBalancers/cross-region-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -715,7 +715,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4","etag":"W/\"b69fa83e-559e-4d5b-8503-6481141dcc7c\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"8cd562fe-3e30-4f79-9cad-4af06bfc8c4b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -826,7 +826,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cr_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4","etag":"W/\"9ca8dcc5-53bf-4b1f-a117-dfa5c020e7b6\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8cd562fe-3e30-4f79-9cad-4af06bfc8c4b","ipAddress":"68.220.42.130","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_cross_region_load_balancer_ip_config.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_cross_region_load_balancer_ip_config.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1","etag":"W/\"947039e2-46e2-41fb-8c4f-4c4efdc55966\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"fcbe4252-0568-45c6-bf79-a56ff0472391","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1","etag":"W/\"04e6811e-e16a-4724-aecb-0db6e40e0c79\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fcbe4252-0568-45c6-bf79-a56ff0472391","ipAddress":"68.220.40.189","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -273,7 +273,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2","etag":"W/\"db427f50-8866-4c4e-b4ec-eed758e8427e\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"7dd93b80-2138-473c-aa1a-916b46b472e5","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -379,7 +379,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2","etag":"W/\"72eba29b-2e64-44c7-8a3b-14847e9beab8\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"7dd93b80-2138-473c-aa1a-916b46b472e5","ipAddress":"68.220.40.193","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -480,7 +480,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3","etag":"W/\"8e8cf0a7-2a04-4000-84c5-d594fd79377a\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"2dd26684-3c09-4e9b-a395-8dccbfbf011e","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -586,7 +586,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cross_region_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3","etag":"W/\"f15621c7-8339-405b-be74-6555492b09f5\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"2dd26684-3c09-4e9b-a395-8dccbfbf011e","ipAddress":"68.220.40.200","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb.yaml
@@ -609,7 +609,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/PublicIPlb2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/PublicIPlb2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"PublicIPlb2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/PublicIPlb2","etag":"W/\"ff1c7231-3235-43c4-ab93-2eda0921e8f9\"","location":"eastus2","tags":{"foo":"doo"},"properties":{"provisioningState":"Succeeded","resourceGuid":"277a4512-5806-4823-9fe7-47f264d466cb","ipAddress":"52.252.58.115","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/LoadBalancerFrontEnd"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1275,7 +1275,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4","etag":"W/\"51f729e8-46cd-4822-b3b2-e69f1d3adeb5\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"ceb98122-bc40-4f94-822a-172b3d0427ec","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1386,7 +1386,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer000001/providers/Microsoft.Network/publicIPAddresses/publicip4","etag":"W/\"3e62d1a4-deb7-4f65-b118-dbcdb6d03f29\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"ceb98122-bc40-4f94-822a-172b3d0427ec","ipAddress":"20.97.172.81","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_front_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_front_ip.yaml
@@ -755,7 +755,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_lb_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_lb_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_lb_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1","etag":"W/\"d5bedda1-a399-4b95-bebc-ac63a9ef28b2\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"c00f3105-c712-488b-94ce-61eecb114cb3","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -861,7 +861,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_lb_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_lb_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_lb_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1","etag":"W/\"14f23ed5-3eb0-438a-9eec-41b065b9bcb0\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"c00f3105-c712-488b-94ce-61eecb114cb3","ipAddress":"20.253.213.209","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_sku.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_sku.yaml
@@ -848,7 +848,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"ea4ed508-c9c2-4ff1-b50d-f7a5af014e03\"","location":"eastus2","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"6bd8e1fa-4743-405c-bcc4-f7e061643a5c","ipAddress":"20.49.41.138","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/LoadBalancerFrontEnd"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_with_cross_subscription_id.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_with_cross_subscription_id.yaml
@@ -837,7 +837,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_with_cross_subscription_id_000002/providers/Microsoft.Network/publicIPAddresses/publicip000007?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_with_cross_subscription_id_000002/providers/Microsoft.Network/publicIPAddresses/publicip000007?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip000007","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_with_cross_subscription_id_000002/providers/Microsoft.Network/publicIPAddresses/publicip000007","etag":"W/\"0239d626-8330-4924-bf5b-a574f6f8d76b\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"96d8bf03-95d6-4900-a950-e91c86dc7a8b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -943,7 +943,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_with_cross_subscription_id_000002/providers/Microsoft.Network/publicIPAddresses/publicip000007?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_with_cross_subscription_id_000002/providers/Microsoft.Network/publicIPAddresses/publicip000007?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip000007","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_with_cross_subscription_id_000002/providers/Microsoft.Network/publicIPAddresses/publicip000007","etag":"W/\"13632190-efbb-4756-8e0b-3ff60e8fc2cf\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"96d8bf03-95d6-4900-a950-e91c86dc7a8b","ipAddress":"135.18.49.196","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_zone.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_lb_zone.yaml
@@ -362,7 +362,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"dabb7ee5-9a50-4c1f-848e-bbcef8ff3a54\"","location":"eastus2","tags":{},"zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"81963e40-e166-4c39-a595-a1771a05986f","ipAddress":"40.67.128.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/LoadBalancerFrontEnd"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1427,7 +1427,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"3edf5ad1-1311-4e9e-b1a7-7c0e09de47f3\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"68fd65aa-5ef0-4a11-8a58-e224e4e6f2c5","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1533,7 +1533,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"c530a8a8-b6b5-4ecb-98f7-97858153ccc4\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"68fd65aa-5ef0-4a11-8a58-e224e4e6f2c5","ipAddress":"2603:1030:b00:13::4c8","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_load_balancer_ip_config.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_load_balancer_ip_config.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1","etag":"W/\"4a203536-9c72-446a-a1dd-35a8e0375c04\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"745b7381-045a-4261-a7e0-1bdd61c50f6b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip1","etag":"W/\"629ec969-d8ad-4171-8364-7c6027a91b3e\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"745b7381-045a-4261-a7e0-1bdd61c50f6b","ipAddress":"20.245.137.137","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -273,7 +273,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2","etag":"W/\"321967fa-cbd7-40af-b623-e60074a332b0\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"3362fc39-3a1b-496a-bb3f-ae051c5adb84","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -379,7 +379,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip2","etag":"W/\"4e53156d-1cfc-44ed-906a-2b34457aa9db\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"3362fc39-3a1b-496a-bb3f-ae051c5adb84","ipAddress":"20.66.8.72","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -480,7 +480,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3","etag":"W/\"5f7a1a44-cc91-4bb8-b935-9066358d8de5\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"489d6dcd-fd80-4996-b735-f82d3dd96c7b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -586,7 +586,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_load_balancer_ip_config000001/providers/Microsoft.Network/publicIPAddresses/publicip3","etag":"W/\"e9418876-9c1d-4805-ba0c-41f4a099b661\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"489d6dcd-fd80-4996-b735-f82d3dd96c7b","ipAddress":"40.86.174.43","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_multi_id_show.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_multi_id_show.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"50b07b43-552c-4dea-8723-033cec882724\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"0a0c5d11-f9c7-4ef8-ba26-a10abe871c59","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"92b750ec-0290-4025-acf1-155b0f557259\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"0a0c5d11-f9c7-4ef8-ba26-a10abe871c59","ipAddress":"104.42.231.80","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -275,7 +275,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2","etag":"W/\"49fd0fb3-2f1c-42d6-84c4-b0118510a677\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"ba4a8681-2c65-47f7-adab-4d8564fc3db5","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -381,7 +381,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2","etag":"W/\"e5d7440d-7cc1-4cba-80c8-70ebc5d1efa0\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ba4a8681-2c65-47f7-adab-4d8564fc3db5","ipAddress":"52.159.233.182","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -431,7 +431,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"92b750ec-0290-4025-acf1-155b0f557259\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"0a0c5d11-f9c7-4ef8-ba26-a10abe871c59","ipAddress":"104.42.231.80","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -481,7 +481,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip2","etag":"W/\"e5d7440d-7cc1-4cba-80c8-70ebc5d1efa0\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ba4a8681-2c65-47f7-adab-4d8564fc3db5","ipAddress":"52.159.233.182","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -531,7 +531,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_multi_id000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"92b750ec-0290-4025-acf1-155b0f557259\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"0a0c5d11-f9c7-4ef8-ba26-a10abe871c59","ipAddress":"104.42.231.80","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_nic.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_nic.yaml
@@ -1112,7 +1112,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1","etag":"W/\"ace460c7-fc1b-437a-8b8d-5d8fcc77802e\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"7de4b7aa-bae4-46fa-808f-dfe8fad3a931","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1216,7 +1216,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1","etag":"W/\"d821d500-4b66-4bae-a1b9-8f9977622867\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"7de4b7aa-bae4-46fa-808f-dfe8fad3a931","ipAddress":"172.203.40.48","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1265,7 +1265,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario000001/providers/Microsoft.Network/publicIPAddresses/publicip1","etag":"W/\"d821d500-4b66-4bae-a1b9-8f9977622867\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"7de4b7aa-bae4-46fa-808f-dfe8fad3a931","ipAddress":"172.203.40.48","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_nic_front_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_nic_front_ip.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip","etag":"W/\"531f3b0b-a431-4bd9-9b98-d4b64940a01c\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"eff94653-193e-43a5-851a-26dab8f79c7a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -216,7 +216,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip","etag":"W/\"b52943d3-7349-4f9b-8c55-50124109cc76\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"eff94653-193e-43a5-851a-26dab8f79c7a","ipAddress":"52.225.169.222","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -317,7 +317,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1","etag":"W/\"678959ef-f4e9-4159-9fe3-3b981a6a1129\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"f33aeaa7-8afa-47c1-9109-c9656f96f78a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -419,7 +419,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_nic_front_ip000001/providers/Microsoft.Network/publicIPAddresses/public-ip1","etag":"W/\"f86bb2a6-191f-4380-bad3-29adeadd6991\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"f33aeaa7-8afa-47c1-9109-c9656f96f78a","ipAddress":"40.89.91.3","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_nic_subresources.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_nic_subresources.yaml
@@ -1134,7 +1134,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2","etag":"W/\"83c77bd6-cc64-4bfd-b754-b80664074f78\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"efdb57e3-d8c4-458e-8e79-7f4b8f227da0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1240,7 +1240,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2","etag":"W/\"7ae463a1-da35-4345-8ee4-2d6ac1bba0f7\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"efdb57e3-d8c4-458e-8e79-7f4b8f227da0","ipAddress":"20.245.253.100","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1290,7 +1290,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"publicip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresource000001/providers/Microsoft.Network/publicIPAddresses/publicip2","etag":"W/\"7ae463a1-da35-4345-8ee4-2d6ac1bba0f7\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"efdb57e3-d8c4-458e-8e79-7f4b8f227da0","ipAddress":"20.245.253.100","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipdns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns","etag":"W/\"5d0d8bcd-d430-45c8-b064-0c6f9db46ce4\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"e721d06a-660a-4945-8bac-966a543a08a8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"woot1","domainNameLabelScope":"TenantReuse","fqdn":"woot1.cvcha2gjbtgteafb.eastus2euap.sysgen.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -169,7 +169,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipdns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns","etag":"W/\"3cea0dc5-4c8f-44d8-ac3d-e4d5e01951db\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"e721d06a-660a-4945-8bac-966a543a08a8","ipAddress":"40.74.157.129","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"woot1","domainNameLabelScope":"TenantReuse","fqdn":"woot1.cvcha2gjbtgteafb.eastus2euap.sysgen.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -270,7 +270,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipnodns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns","etag":"W/\"6814bddd-9335-4fca-8bf4-4cf1f3351ef8\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"9d489052-ef4f-485c-9942-f302ad6129f0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -372,7 +372,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipnodns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns","etag":"W/\"c8d8104a-4dd5-4dc1-93dd-83bdccdece37\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"9d489052-ef4f-485c-9942-f302ad6129f0","ipAddress":"40.89.80.30","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -429,7 +429,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"331a0c24-668f-44a8-ab77-dbb0408fcdea\"","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"04ec42b2-090d-43ea-bb46-627ca62d6732","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"RoutingPreference","tag":"Internet"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -579,7 +579,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"320c424f-2f94-49bb-a229-20acb8293c55\"","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"04ec42b2-090d-43ea-bb46-627ca62d6732","ipAddress":"20.157.64.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"RoutingPreference","tag":"Internet"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -629,7 +629,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipnodns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns","etag":"W/\"c8d8104a-4dd5-4dc1-93dd-83bdccdece37\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"9d489052-ef4f-485c-9942-f302ad6129f0","ipAddress":"40.89.80.30","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -688,7 +688,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipnodns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns","etag":"W/\"a6cfc939-4a10-4dde-a169-1964fb1d1e35\"","location":"eastus2euap","tags":{"foo":"doo"},"properties":{"provisioningState":"Updating","resourceGuid":"9d489052-ef4f-485c-9942-f302ad6129f0","ipAddress":"40.89.80.30","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":10,"dnsSettings":{"domainNameLabel":"wowza2","fqdn":"wowza2.eastus2euap.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -790,7 +790,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipnodns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns","etag":"W/\"986f373c-445f-4c5c-a0b7-5d480f88953e\"","location":"eastus2euap","tags":{"foo":"doo"},"properties":{"provisioningState":"Succeeded","resourceGuid":"9d489052-ef4f-485c-9942-f302ad6129f0","ipAddress":"40.89.80.30","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":10,"dnsSettings":{"domainNameLabel":"wowza2","fqdn":"wowza2.eastus2euap.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -840,7 +840,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses?api-version=2025-07-01
   response:
     body:
       string: '{"value":[{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"320c424f-2f94-49bb-a229-20acb8293c55\"","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"04ec42b2-090d-43ea-bb46-627ca62d6732","ipAddress":"20.157.64.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"RoutingPreference","tag":"Internet"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}},{"name":"pubipdns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns","etag":"W/\"3cea0dc5-4c8f-44d8-ac3d-e4d5e01951db\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"e721d06a-660a-4945-8bac-966a543a08a8","ipAddress":"40.74.157.129","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"woot1","domainNameLabelScope":"TenantReuse","fqdn":"woot1.cvcha2gjbtgteafb.eastus2euap.sysgen.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}},{"name":"pubipnodns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns","etag":"W/\"986f373c-445f-4c5c-a0b7-5d480f88953e\"","location":"eastus2euap","tags":{"foo":"doo"},"properties":{"provisioningState":"Succeeded","resourceGuid":"9d489052-ef4f-485c-9942-f302ad6129f0","ipAddress":"40.89.80.30","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":10,"dnsSettings":{"domainNameLabel":"wowza2","fqdn":"wowza2.eastus2euap.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}]}'
@@ -889,7 +889,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipdns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns","etag":"W/\"3cea0dc5-4c8f-44d8-ac3d-e4d5e01951db\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"e721d06a-660a-4945-8bac-966a543a08a8","ipAddress":"40.74.157.129","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"woot1","domainNameLabelScope":"TenantReuse","fqdn":"woot1.cvcha2gjbtgteafb.eastus2euap.sysgen.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -941,7 +941,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipdns?api-version=2025-07-01
   response:
     body:
       string: ''
@@ -1095,7 +1095,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses?api-version=2025-07-01
   response:
     body:
       string: '{"value":[{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"320c424f-2f94-49bb-a229-20acb8293c55\"","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"04ec42b2-090d-43ea-bb46-627ca62d6732","ipAddress":"20.157.64.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"RoutingPreference","tag":"Internet"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}},{"name":"pubipnodns","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubipnodns","etag":"W/\"986f373c-445f-4c5c-a0b7-5d480f88953e\"","location":"eastus2euap","tags":{"foo":"doo"},"properties":{"provisioningState":"Succeeded","resourceGuid":"9d489052-ef4f-485c-9942-f302ad6129f0","ipAddress":"40.89.80.30","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":10,"dnsSettings":{"domainNameLabel":"wowza2","fqdn":"wowza2.eastus2euap.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}]}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_ddos_settings.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_ddos_settings.yaml
@@ -263,7 +263,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipddos","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos","etag":"W/\"4c0ab840-3943-413c-bd75-89ba53f5aebc\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"a81f19d8-cc7c-4f87-8dc4-40c479271df4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"Enabled","ddosProtectionPlan":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/ddosProtectionPlans/ddos1"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -367,7 +367,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipddos","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos","etag":"W/\"f1be5ac3-7616-4d89-917a-bc561759dc87\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"a81f19d8-cc7c-4f87-8dc4-40c479271df4","ipAddress":"172.200.42.195","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"Enabled","ddosProtectionPlan":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/ddosProtectionPlans/ddos1"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1301,7 +1301,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipddos","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos","etag":"W/\"1e4381c7-17e0-4f48-aaf6-897e5c1bc4e7\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"a81f19d8-cc7c-4f87-8dc4-40c479271df4","ipAddress":"172.200.42.195","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/applicationGateways/testag/frontendIPConfigurations/appGatewayFrontendIP"},"ddosSettings":{"protectionMode":"Enabled","ddosProtectionPlan":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/ddosProtectionPlans/ddos1"}}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1358,7 +1358,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipddos","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos","etag":"W/\"c0e740b0-76f4-4926-98b3-ed94657dc32e\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"a81f19d8-cc7c-4f87-8dc4-40c479271df4","ipAddress":"172.200.42.195","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/applicationGateways/testag/frontendIPConfigurations/appGatewayFrontendIP"},"ddosSettings":{"protectionMode":"Disabled"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1462,7 +1462,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubipddos","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos","etag":"W/\"a224d3e6-c490-435f-93fc-d49392d642d4\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"a81f19d8-cc7c-4f87-8dc4-40c479271df4","ipAddress":"172.200.42.195","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/applicationGateways/testag/frontendIPConfigurations/appGatewayFrontendIP"},"ddosSettings":{"protectionMode":"Disabled"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -2176,7 +2176,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses/pubipddos?api-version=2025-07-01
   response:
     body:
       string: ''
@@ -2336,7 +2336,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_ddos_settings000001/providers/Microsoft.Network/publicIPAddresses?api-version=2025-07-01
   response:
     body:
       string: '{"value":[]}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_edge_zone.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_edge_zone.yaml
@@ -63,7 +63,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.50.0 (AAZ) azsdk-python-core/1.26.0 Python/3.9.5 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_public_ip_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_public_ip_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_public_ip_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"11956cb6-eb9c-4171-9302-5154bd0e8766\"","location":"eastus2euap","extendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"properties":{"provisioningState":"Updating","resourceGuid":"80e703b0-b354-4ade-b576-a5e06a0b4cf0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -604,7 +604,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.50.0 (AAZ) azsdk-python-core/1.26.0 Python/3.9.5 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_public_ip_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_public_ip_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_public_ip_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"6968fa6b-e15c-4b4f-b043-2c5b1a61232c\"","location":"eastus2euap","extendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"properties":{"provisioningState":"Succeeded","resourceGuid":"80e703b0-b354-4ade-b576-a5e06a0b4cf0","ipAddress":"198.180.97.41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_prefix.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_prefix.yaml
@@ -1155,7 +1155,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"d0418062-2c07-408a-ad06-b3d746c26259\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"cc84e158-5718-4691-8474-0eb7c44d8907","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"publicIPPrefix":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPPrefixes/prefix1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1261,7 +1261,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"da38c279-780c-414c-8ad3-7134d64babfc\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"cc84e158-5718-4691-8474-0eb7c44d8907","ipAddress":"104.209.149.252","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"publicIPPrefix":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPPrefixes/prefix1"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1620,7 +1620,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip-000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000003","etag":"W/\"de75b5ee-9d69-4b23-b422-05605f4cf76a\"","location":"eastus2","zones":["1","3","2"],"properties":{"provisioningState":"Updating","resourceGuid":"f065bf54-5981-49d3-869e-c999a9f1e093","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"publicIPPrefix":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPPrefixes/public-ip-prefix-000002"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1726,7 +1726,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip-000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000003","etag":"W/\"3dd39eb5-438b-4b9f-a4e6-8a8092f71dbd\"","location":"eastus2","zones":["1","3","2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"f065bf54-5981-49d3-869e-c999a9f1e093","ipAddress":"2603:1030:403:16::dc","publicIPAddressVersion":"IPv6","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"publicIPPrefix":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix000001/providers/Microsoft.Network/publicIPPrefixes/public-ip-prefix-000002"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_prefix_with_ip_address.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_prefix_with_ip_address.yaml
@@ -625,7 +625,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"a3f03116-b99a-45ec-961d-6763ffde5d80\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"d09dd276-0f1d-44db-ae05-c46b4f4f4755","ipAddress":"20.55.230.224","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"publicIPPrefix":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPPrefixes/public_ip_prefix_0"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -731,7 +731,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"facccf39-ccb6-4ed1-9cff-65a48b2997a1\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d09dd276-0f1d-44db-ae05-c46b4f4f4755","ipAddress":"20.55.230.224","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"publicIPPrefix":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_public_ip_prefix_with_ip_address000001/providers/Microsoft.Network/publicIPPrefixes/public_ip_prefix_0"},"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_sku.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_sku.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"4aedb5e2-b353-4e1c-b268-1e97c6129bc9\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"f830ff54-49c4-4ee7-9e0a-62a369ca59e3","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -127,7 +127,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"cd273678-72e3-4e94-b4b3-c48054bedffc\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"f830ff54-49c4-4ee7-9e0a-62a369ca59e3","ipAddress":"135.119.144.96","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -177,7 +177,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"cd273678-72e3-4e94-b4b3-c48054bedffc\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"f830ff54-49c4-4ee7-9e0a-62a369ca59e3","ipAddress":"135.119.144.96","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -233,7 +233,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"add1542e-ecdc-4c88-80a9-3cd99c9d1f7a\"","location":"eastus2","tags":{"foo":"doo"},"properties":{"provisioningState":"Updating","resourceGuid":"49a26759-9d27-4e98-96e0-e7de3f312760","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -339,7 +339,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"5dc8d1f8-a54e-4825-a531-8650da35a010\"","location":"eastus2","tags":{"foo":"doo"},"properties":{"provisioningState":"Succeeded","resourceGuid":"49a26759-9d27-4e98-96e0-e7de3f312760","ipAddress":"128.24.88.239","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -389,7 +389,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"5dc8d1f8-a54e-4825-a531-8650da35a010\"","location":"eastus2","tags":{"foo":"doo"},"properties":{"provisioningState":"Succeeded","resourceGuid":"49a26759-9d27-4e98-96e0-e7de3f312760","ipAddress":"128.24.88.239","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -445,7 +445,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"17998457-579e-467f-9529-936f8979111d\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"d7e4a4c8-9aee-4d49-baba-b912858c1707","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -551,7 +551,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"89781128-b383-4217-af02-c2aafb396da9\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d7e4a4c8-9aee-4d49-baba-b912858c1707","ipAddress":"20.41.28.95","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -601,7 +601,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"89781128-b383-4217-af02-c2aafb396da9\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d7e4a4c8-9aee-4d49-baba-b912858c1707","ipAddress":"20.41.28.95","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Global"}}'
@@ -703,7 +703,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip4","etag":"W/\"30715c15-e3fb-45f7-8236-2c876990a951\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"9d149700-f405-493e-a538-d0638f733812","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -859,7 +859,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.77.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_lb_sku000001/providers/Microsoft.Network/publicIPAddresses/pubip4","etag":"W/\"fb4647a6-eab2-4fbf-9d53-f34715c096fb\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"9d149700-f405-493e-a538-d0638f733812","ipAddress":"172.185.224.0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"StandardV2","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_zone.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_public_ip_zone.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_zone000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_zone000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_zone000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"c888b9ac-0319-41aa-bc8f-096eb9636807\"","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"1e11d2c0-2b36-4d8c-9338-d645c14bc814","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_zone000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_zone000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_public_ip_zone000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"5f88ad98-8d51-4b88-ac99-c386b4e6ef9d\"","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"1e11d2c0-2b36-4d8c-9338-d645c14bc814","ipAddress":"130.213.180.159","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_subnet_endpoint_service.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_subnet_endpoint_service.yaml
@@ -114,7 +114,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.64.0 azsdk-python-core/1.28.0 Python/3.12.6 (Windows-11-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip1","etag":"W/\"14b75418-8f8d-44e4-a537-f205998365b4\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"f0b8c08e-327c-44eb-8718-58b93371c904","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -264,7 +264,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.64.0 azsdk-python-core/1.28.0 Python/3.12.6 (Windows-11-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip1","etag":"W/\"00c20d94-9945-4d5f-91a7-18b6f431d418\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"f0b8c08e-327c-44eb-8718-58b93371c904","ipAddress":"52.179.175.105","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -365,7 +365,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.64.0 azsdk-python-core/1.28.0 Python/3.12.6 (Windows-11-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip2","etag":"W/\"7b1e9e66-f574-446b-9fc7-cf1edf2c7d92\"","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"fefbbaa1-37bd-40c3-83ed-bb74891574fc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -515,7 +515,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.64.0 azsdk-python-core/1.28.0 Python/3.12.6 (Windows-11-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"testip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_endpoint_service_test000001/providers/Microsoft.Network/publicIPAddresses/testip2","etag":"W/\"e8bfb97a-4e36-40a1-802e-6dd705a5d50c\"","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"fefbbaa1-37bd-40c3-83ed-bb74891574fc","ipAddress":"172.210.169.176","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_traffic_manager_subnet_routing.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_traffic_manager_subnet_routing.yaml
@@ -123,7 +123,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_traffic_manager_subnet000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_traffic_manager_subnet000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_traffic_manager_subnet000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"0b22d84e-1d63-477a-81d2-1bc93ec381ea\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"85674d68-f2c3-4277-b8cf-a7c4de701ab1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"testpip000003","fqdn":"testpip000003.westus.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -279,7 +279,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_traffic_manager_subnet000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_traffic_manager_subnet000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_traffic_manager_subnet000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"12198fb6-f4b4-4b69-9810-22038a02f032\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"85674d68-f2c3-4277-b8cf-a7c4de701ab1","ipAddress":"20.253.205.97","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"testpip000003","fqdn":"testpip000003.westus.cloudapp.azure.com"},"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_virtual_hub_router_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_virtual_hub_router_scenario.yaml
@@ -531,7 +531,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.68.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_virtual_hub_router000001/providers/Microsoft.Network/publicIPAddresses/vhrip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_virtual_hub_router000001/providers/Microsoft.Network/publicIPAddresses/vhrip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vhrip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_virtual_hub_router000001/providers/Microsoft.Network/publicIPAddresses/vhrip1","etag":"W/\"7f635ab1-30c9-460d-b72c-eabcd2e0665a\"","location":"centraluseuap","properties":{"provisioningState":"Updating","resourceGuid":"533b4e52-2ee6-4722-a98b-37c961b178e6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -633,7 +633,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.68.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_virtual_hub_router000001/providers/Microsoft.Network/publicIPAddresses/vhrip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_virtual_hub_router000001/providers/Microsoft.Network/publicIPAddresses/vhrip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vhrip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_virtual_hub_router000001/providers/Microsoft.Network/publicIPAddresses/vhrip1","etag":"W/\"d4e58ea7-b5a0-4bfd-800b-643c5f7cc5e5\"","location":"centraluseuap","properties":{"provisioningState":"Succeeded","resourceGuid":"533b4e52-2ee6-4722-a98b-37c961b178e6","ipAddress":"52.158.191.252","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_allow_traffic.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_allow_traffic.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_allow_traffic000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_allow_traffic000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_allow_traffic000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"ddafe471-1424-4ea9-ad5c-bf1f0e5b7026\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"08f59eb1-c7af-4a3c-bbaf-8e10ed74299b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_allow_traffic000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_allow_traffic000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_allow_traffic000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"99402512-70b8-405b-bf7a-95334960b5bf\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"08f59eb1-c7af-4a3c-bbaf-8e10ed74299b","ipAddress":"52.159.149.120","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_edge_zone.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_edge_zone.yaml
@@ -62,7 +62,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.50.0 (AAZ) azsdk-python-core/1.26.0 Python/3.9.5 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"1b0c3efa-c335-4c33-a3ed-67fe72ca4e02\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"717e479e-05d5-43ec-adcb-bf4e744b0117","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -162,7 +162,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.50.0 (AAZ) azsdk-python-core/1.26.0 Python/3.9.5 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_edge_zone000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"77555665-f3b0-4eb1-af4d-c325aad17af8\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"717e479e-05d5-43ec-adcb-bf4e744b0117","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_expressroute_with_public_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_expressroute_with_public_ip.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_pip000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_pip000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_pip000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"869544a9-3e95-4e9b-a38c-afc5e33bcae1\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"becdedba-01a9-43e4-955c-5e4b42db0f47","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_pip000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_pip000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_pip000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"aace8c68-4439-4ef8-ade1-29cafb76661f\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"becdedba-01a9-43e4-955c-5e4b42db0f47","ipAddress":"20.184.132.40","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_get_routes_and_resiliency_information.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_get_routes_and_resiliency_information.yaml
@@ -322,7 +322,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.76.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gw_routes_resiliency_info000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gw_routes_resiliency_info000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gw_routes_resiliency_info000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"e407e92f-6b68-4ffc-94ec-a592e3479bb2\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"e944b692-608b-45fa-a052-eb683de87024","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -428,7 +428,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.76.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gw_routes_resiliency_info000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gw_routes_resiliency_info000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gw_routes_resiliency_info000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"454ec479-7719-4a39-8ae4-a9624275ef64\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"e944b692-608b-45fa-a052-eb683de87024","ipAddress":"135.18.44.80","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_ipsec.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_ipsec.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"cdd0b54a-3df8-4200-842a-05389d0c8b92\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"e60a417d-a1bb-4aeb-b627-8e9de4f91009","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"1f64a87a-5ccb-4b44-86bf-1e337cdd31dc\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"e60a417d-a1bb-4aeb-b627-8e9de4f91009","ipAddress":"172.185.19.92","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_migration.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_migration.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_migration000001/providers/Microsoft.Network/publicIPAddresses/public_ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_migration000001/providers/Microsoft.Network/publicIPAddresses/public_ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public_ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_migration000001/providers/Microsoft.Network/publicIPAddresses/public_ip1","etag":"W/\"62582bce-916c-4e13-8adc-b9d64617d9b6\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"d861827a-ab41-4763-abd6-2a39ecd35806","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_migration000001/providers/Microsoft.Network/publicIPAddresses/public_ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_migration000001/providers/Microsoft.Network/publicIPAddresses/public_ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public_ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_gateway_migration000001/providers/Microsoft.Network/publicIPAddresses/public_ip1","etag":"W/\"730f1a27-4226-451c-827e-99e506217dc1\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"d861827a-ab41-4763-abd6-2a39ecd35806","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_multi_auth.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_multi_auth.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"3cae41ac-6684-44b1-bbc9-12d118423c1a\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"4f23bf9a-57e5-481d-9653-d406fba2918b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"a1f58101-959d-45ef-8516-28086368f67b\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"4f23bf9a-57e5-481d-9653-d406fba2918b","ipAddress":"20.66.10.35","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_multi_auth1.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_multi_auth1.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth1000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth1000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth1000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"56e41834-3015-4526-a31d-ad7ac077dc63\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"47ab2315-9d84-4178-824c-3e07699cfed1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth1000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth1000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_multi_auth1000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"d9240d32-37e3-489d-92bb-26019762e1d3\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"47ab2315-9d84-4178-824c-3e07699cfed1","ipAddress":"13.93.221.4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_nat_rule.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_nat_rule.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"ab4b69a0-e36b-43f7-829d-024a5c0c7483\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"ac2088ed-48e1-4ba8-aa1e-09651a671c04","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"9d6e305e-e8bb-4e91-a292-8bf15b77885c\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ac2088ed-48e1-4ba8-aa1e-09651a671c04","ipAddress":"52.137.188.199","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1739,7 +1739,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"5a981c46-08fb-4615-8902-be0254dbffa9\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"d37217c3-66ac-47e6-bce0-aa0a389a7de4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1845,7 +1845,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"ec422390-bc03-4182-8d6d-122c762724f9\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"d37217c3-66ac-47e6-bce0-aa0a389a7de4","ipAddress":"40.112.238.179","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_nat_rule_sub_cmd.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_nat_rule_sub_cmd.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"4efd9471-af00-4d92-9088-c6a3038e44e9\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"ebdd86fe-5b07-43a5-8ac1-aaa96ec435d4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"fbd1c594-8f53-44e8-ae9a-df8b0c5cc610\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ebdd86fe-5b07-43a5-8ac1-aaa96ec435d4","ipAddress":"20.57.194.58","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_with_enable_private_ip_address.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_gateway_with_enable_private_ip_address.yaml
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.64.0 azsdk-python-core/1.28.0 Python/3.12.6 (Windows-11-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_enable_private_ip_address000001/providers/Microsoft.Network/publicIPAddresses/ip-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_enable_private_ip_address000001/providers/Microsoft.Network/publicIPAddresses/ip-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_enable_private_ip_address000001/providers/Microsoft.Network/publicIPAddresses/ip-000002","etag":"W/\"20e259e1-2170-432f-b47a-fb334315882b\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"48414039-9bd9-44f4-a295-bcbd3f945b0c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -532,7 +532,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.64.0 azsdk-python-core/1.28.0 Python/3.12.6 (Windows-11-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_enable_private_ip_address000001/providers/Microsoft.Network/publicIPAddresses/ip-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_enable_private_ip_address000001/providers/Microsoft.Network/publicIPAddresses/ip-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vnet_gateway_with_enable_private_ip_address000001/providers/Microsoft.Network/publicIPAddresses/ip-000002","etag":"W/\"7861456b-c80e-43b4-b2cf-af8311d185aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"48414039-9bd9-44f4-a295-bcbd3f945b0c","ipAddress":"52.170.218.223","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering.yaml
@@ -581,7 +581,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"6fdd1b45-9c65-4a09-b7a8-a2e9a749582d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"e7eab004-f7f9-4928-b236-a0c3623edcc7","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -687,7 +687,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"2fb3392a-707d-49c4-9c66-b0fd10fd2d34\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"e7eab004-f7f9-4928-b236-a0c3623edcc7","ipAddress":"20.253.252.2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -737,7 +737,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"2fb3392a-707d-49c4-9c66-b0fd10fd2d34\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"e7eab004-f7f9-4928-b236-a0c3623edcc7","ipAddress":"20.253.252.2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering_sync.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering_sync.yaml
@@ -581,7 +581,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"ad0c3a46-2707-42b4-8fab-dc05ce91380a\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"9b3d209f-1758-4bd1-9308-2ab369f36cdf","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -687,7 +687,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"7119784a-1ea6-4da9-8af8-9bfba7ccb3d8\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"9b3d209f-1758-4bd1-9308-2ab369f36cdf","ipAddress":"172.184.98.127","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -737,7 +737,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1","etag":"W/\"7119784a-1ea6-4da9-8af8-9bfba7ccb3d8\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"9b3d209f-1758-4bd1-9308-2ab369f36cdf","ipAddress":"172.184.98.127","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_connection_ipsec.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_connection_ipsec.yaml
@@ -966,7 +966,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_connection_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_connection_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_connection_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"6279b1a1-96f2-4b36-bbdc-f97f691b830e\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"acf6c92f-d839-4ec4-93c0-1d7a563c873c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -1072,7 +1072,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_connection_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_connection_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_connection_ipsec000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"c5e14e2d-73b6-42d7-b6d2-6ee14a87c97e\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"acf6c92f-d839-4ec4-93c0-1d7a563c873c","ipAddress":"20.245.192.160","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_connection_nat_rule.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_connection_nat_rule.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vpn_connection_nat_rule000001/providers/Microsoft.Network/publicIPAddresses/ip-name?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vpn_connection_nat_rule000001/providers/Microsoft.Network/publicIPAddresses/ip-name?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip-name","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vpn_connection_nat_rule000001/providers/Microsoft.Network/publicIPAddresses/ip-name","etag":"W/\"5a4baba1-18bb-481f-bfbe-882d67df9317\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"a4a357c3-2ee0-40aa-85c9-0e6570296370","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vpn_connection_nat_rule000001/providers/Microsoft.Network/publicIPAddresses/ip-name?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vpn_connection_nat_rule000001/providers/Microsoft.Network/publicIPAddresses/ip-name?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip-name","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_network_vpn_connection_nat_rule000001/providers/Microsoft.Network/publicIPAddresses/ip-name","etag":"W/\"8fa595c9-044d-4e2c-8e35-c869d7f2eefd\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"a4a357c3-2ee0-40aa-85c9-0e6570296370","ipAddress":"20.59.124.60","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"20e20083-9f6c-44f2-b1f6-cbb75632ed9f\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"f4c1366b-653c-47e0-9821-f85c8d075efd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"5f7bc31c-9253-4b93-aa50-2b02da505c48\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"f4c1366b-653c-47e0-9821-f85c8d075efd","ipAddress":"20.57.195.105","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -273,7 +273,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"318a0f96-baac-445d-a8bb-1a82bad50361\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"505fdd00-3212-4797-bfc4-6ac741fc04dd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -379,7 +379,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"4e9f84c3-d9d2-4570-be1a-143ee6c55d0a\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"505fdd00-3212-4797-bfc4-6ac741fc04dd","ipAddress":"13.93.224.199","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -480,7 +480,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"0c3a4849-00d9-4237-ae6e-a788a7967dc9\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"3562d0de-43f1-4dc1-ac35-812c2d59c4eb","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -586,7 +586,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"527ad4e4-f342-441f-9c62-753184156ab1\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"3562d0de-43f1-4dc1-ac35-812c2d59c4eb","ipAddress":"20.184.128.151","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_aad.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_aad.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_aad_000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_aad_000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_aad_000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"c20b524e-c6a3-4c35-985e-b93707e6c9e6\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"d6df3f34-acb0-443b-97ab-1fe7d68ea55b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_aad_000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_aad_000001/providers/Microsoft.Network/publicIPAddresses/ip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_aad_000001/providers/Microsoft.Network/publicIPAddresses/ip","etag":"W/\"40b292ae-e5df-4f1c-aa9f-c09ccbf2613b\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"d6df3f34-acb0-443b-97ab-1fe7d68ea55b","ipAddress":"13.64.76.68","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_disconnect_connects.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_disconnect_connects.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"5001215f-33ef-4bff-87de-86bfadcf4183\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"467ad5de-fe3b-49ed-9d97-96ca00c61f80","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"2775f231-1224-4821-ac0b-1b3bf0e87763\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"467ad5de-fe3b-49ed-9d97-96ca00c61f80","ipAddress":"52.225.80.39","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -273,7 +273,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"1bd6a60d-61bd-4c24-9f97-a9bfc153bbe5\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"b08eeda1-5828-4a1b-b2ad-8176e7fda6eb","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -379,7 +379,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_disconnect_connects_000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"c293f21c-03b6-4851-9e26-b93569eac778\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"b08eeda1-5828-4a1b-b2ad-8176e7fda6eb","ipAddress":"20.57.201.76","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_package_capture.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_package_capture.yaml
@@ -312,7 +312,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_package_capture000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_package_capture000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_package_capture000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"9615a8e9-ea42-49d3-a4d6-ff8e1c2b4934\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"3758fb0a-c8ef-4a40-b90d-4ab97ec12928","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -418,7 +418,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_package_capture000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_package_capture000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_package_capture000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"19852818-c481-4516-b74f-b758027f0fca\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"3758fb0a-c8ef-4a40-b90d-4ab97ec12928","ipAddress":"40.75.137.50","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_sku.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_vpn_gateway_sku.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_sku_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_sku_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_sku_000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"de6bc6d0-5473-4205-a737-7895a25f4582\"","location":"westus3","properties":{"provisioningState":"Updating","resourceGuid":"36bae8bc-9ee5-44a6-9fcb-987db8da41f8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_sku_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_sku_000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_gateway_sku_000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"0f11da68-396d-4268-876f-67eb08a429f1\"","location":"westus3","properties":{"provisioningState":"Succeeded","resourceGuid":"36bae8bc-9ee5-44a6-9fcb-987db8da41f8","ipAddress":"4.242.133.22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_watcher_troubleshooting.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_watcher_troubleshooting.yaml
@@ -515,7 +515,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nw_troubleshooting000001/providers/Microsoft.Network/publicIPAddresses/vgw1-pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nw_troubleshooting000001/providers/Microsoft.Network/publicIPAddresses/vgw1-pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vgw1-pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nw_troubleshooting000001/providers/Microsoft.Network/publicIPAddresses/vgw1-pip","etag":"W/\"85915531-ee14-458e-b968-386105ba9a9f\"","location":"westcentralus","properties":{"provisioningState":"Updating","resourceGuid":"65db9583-25de-43a0-8df7-537b8f0c0588","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -621,7 +621,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nw_troubleshooting000001/providers/Microsoft.Network/publicIPAddresses/vgw1-pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nw_troubleshooting000001/providers/Microsoft.Network/publicIPAddresses/vgw1-pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vgw1-pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nw_troubleshooting000001/providers/Microsoft.Network/publicIPAddresses/vgw1-pip","etag":"W/\"31ace843-5f38-4798-8a16-e27575c3a813\"","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"65db9583-25de-43a0-8df7-537b8f0c0588","ipAddress":"20.165.145.76","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_zoned_public_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_zoned_public_ip.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"b844ba63-bd69-4393-b682-33af2404acdc\"","location":"centralus","zones":["2"],"properties":{"provisioningState":"Updating","resourceGuid":"642f77e9-cefc-4a2f-b9e2-0f02e9d4465b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -126,7 +126,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"9b373202-aa0a-4bb7-bf3d-dfdd84f59b6e\"","location":"centralus","zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"642f77e9-cefc-4a2f-b9e2-0f02e9d4465b","ipAddress":"20.98.152.132","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_zoned_public_ip000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"9b373202-aa0a-4bb7-bf3d-dfdd84f59b6e\"","location":"centralus","zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"642f77e9-cefc-4a2f-b9e2-0f02e9d4465b","ipAddress":"20.98.152.132","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_link_ip_config.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_link_ip_config.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_private_link_ip_config_000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_private_link_ip_config_000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_private_link_ip_config_000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002","etag":"W/\"9e111fe6-7b1c-414d-9a8b-cdf238ed7ce6\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"77a0cf1b-f120-4c00-b6ba-df18ed07e22b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_private_link_ip_config_000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_private_link_ip_config_000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002?api-version=2025-07-01
   response:
     body:
       string: '{"name":"public-ip-000002","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_private_link_ip_config_000001/providers/Microsoft.Network/publicIPAddresses/public-ip-000002","etag":"W/\"c2dd62d5-d335-44b2-a6dc-b8ef95b6b814\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"77a0cf1b-f120-4c00-b6ba-df18ed07e22b","ipAddress":"52.159.249.5","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_subnet_detach_nat_gateway.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_subnet_detach_nat_gateway.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.76.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"538f26a1-0524-49e6-b96f-5aaca8f22994\"","location":"eastus2","zones":["2"],"properties":{"provisioningState":"Updating","resourceGuid":"74ed68d2-5b77-4a81-8c7f-b3ec80705446","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -126,7 +126,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.76.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip","etag":"W/\"485d7ff5-c34d-4fd0-b763-5074a79ce44b\"","location":"eastus2","zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"74ed68d2-5b77-4a81-8c7f-b3ec80705446","ipAddress":"20.186.115.27","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vnet_gateway_managed_identity.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vnet_gateway_managed_identity.yaml
@@ -529,7 +529,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gateway_mi000001/providers/Microsoft.Network/publicIPAddresses/myGWpip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gateway_mi000001/providers/Microsoft.Network/publicIPAddresses/myGWpip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myGWpip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gateway_mi000001/providers/Microsoft.Network/publicIPAddresses/myGWpip","etag":"W/\"7ab25ff1-e007-4492-ad09-aac7e9ead470\"","location":"eastus","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"50d267b9-a29d-4358-9c6a-a179442e76fa","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -635,7 +635,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gateway_mi000001/providers/Microsoft.Network/publicIPAddresses/myGWpip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gateway_mi000001/providers/Microsoft.Network/publicIPAddresses/myGWpip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myGWpip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vnet_gateway_mi000001/providers/Microsoft.Network/publicIPAddresses/myGWpip","etag":"W/\"2ed9400f-53f4-491d-8948-c614d33cc414\"","location":"eastus","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"50d267b9-a29d-4358-9c6a-a179442e76fa","ipAddress":"172.171.186.123","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vpn_client_package.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vpn_client_package.yaml
@@ -324,7 +324,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.82.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_package000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_package000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_package000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"6f847048-09f0-49f7-8524-d6ada2f0d6e4\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"11edc699-0baa-4bfd-bd71-32c504c20e45","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -430,7 +430,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.82.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_package000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_package000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_package000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"7d4d98d9-8006-4510-bb4b-b2718896667e\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"11edc699-0baa-4bfd-bd71-32c504c20e45","ipAddress":"172.185.173.232","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vpn_connection_authentication.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vpn_connection_authentication.yaml
@@ -743,7 +743,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.82.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_auth000001/providers/Microsoft.Network/publicIPAddresses/myGatewayIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_auth000001/providers/Microsoft.Network/publicIPAddresses/myGatewayIP?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myGatewayIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_auth000001/providers/Microsoft.Network/publicIPAddresses/myGatewayIP","etag":"W/\"081c159d-95f9-41da-aca5-69945c868366\"","location":"eastus","properties":{"provisioningState":"Updating","resourceGuid":"7c945aa3-950b-451b-9559-d48a914d85a4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -849,7 +849,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.82.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_auth000001/providers/Microsoft.Network/publicIPAddresses/myGatewayIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_auth000001/providers/Microsoft.Network/publicIPAddresses/myGatewayIP?api-version=2025-07-01
   response:
     body:
       string: '{"name":"myGatewayIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_auth000001/providers/Microsoft.Network/publicIPAddresses/myGatewayIP","etag":"W/\"c977a008-6e9d-4a47-bbd8-154e2090c670\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"7c945aa3-950b-451b-9559-d48a914d85a4","ipAddress":"74.235.209.206","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vpn_connection_aux.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_vpn_connection_aux.yaml
@@ -792,7 +792,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_aux_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_aux_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_aux_000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"c71e6a3e-12f1-4ecf-a95c-c41665d04c86\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"129d3e37-5a35-4d77-83b5-437551ad20a9","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -894,7 +894,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_aux_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2022-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_aux_000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_vpn_connection_aux_000001/providers/Microsoft.Network/publicIPAddresses/pip1","etag":"W/\"fa2cd6f8-fa59-4d79-b6d6-0dfebeca12ee\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"129d3e37-5a35-4d77-83b5-437551ad20a9","ipAddress":"40.78.56.190","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -9845,6 +9845,68 @@ class DdosCustomPolicyScenarioTest(ScenarioTest):
 
         self.cmd('network ddos-custom-policy delete -g {rg} -n {policy_name} -y')
 
+    @ResourceGroupPreparer(name_prefix='test_ddos_cuspol_pip', location='eastus')
+    def test_ddos_custom_policy_attach_to_public_ip(self, resource_group):
+        self.kwargs.update({
+            'policy_name': 'policy1',
+            'policy_name2': 'policy2',
+            'pip_name': 'pip1',
+        })
+
+        dcp = self.cmd('network ddos-custom-policy create -g {rg} -n {policy_name} '
+                       '--detection-rule-name rule1 --detection-mode TrafficThreshold '
+                       '--traffic-type Tcp --packets-per-second 1000000', checks=[
+            self.check('name', '{policy_name}'),
+        ]).get_output_in_json()
+        self.kwargs['dcp_id'] = dcp['id']
+
+        dcp2 = self.cmd('network ddos-custom-policy create -g {rg} -n {policy_name2} '
+                        '--detection-rule-name rule1 --detection-mode TrafficThreshold '
+                        '--traffic-type Tcp --packets-per-second 2000000', checks=[
+            self.check('name', '{policy_name2}'),
+        ]).get_output_in_json()
+        self.kwargs['dcp_id2'] = dcp2['id']
+
+        # A DDoS custom policy can only be attached to an instance-level public IP,
+        # i.e. a public IP associated with a NIC's IP configuration. Create the public
+        # IP and associate it with a NIC to make it eligible.
+        self.cmd('network public-ip create -g {rg} -n {pip_name} --sku Standard '
+                 '--allocation-method Static', checks=[
+            self.check('publicIp.name', '{pip_name}'),
+            self.check('publicIp.provisioningState', 'Succeeded'),
+        ])
+
+        self.cmd('network vnet create -g {rg} -n vnet1 --subnet-name subnet1')
+        self.cmd('network nic create -g {rg} -n nic1 --vnet-name vnet1 --subnet subnet1 '
+                 '--public-ip-address {pip_name}')
+
+        # Attach the DDoS custom policy to the (now instance-level) public IP
+        self.cmd('network public-ip update -g {rg} -n {pip_name} '
+                 '--ddos-custom-policy id={dcp_id}', checks=[
+            self.check('ddosSettings.ddosCustomPolicy.id', '{dcp_id}'),
+        ])
+
+        self.cmd('network public-ip show -g {rg} -n {pip_name}', checks=[
+            self.check('ddosSettings.ddosCustomPolicy.id', '{dcp_id}'),
+        ])
+
+        # Replace the attached policy on the existing public IP
+        self.cmd('network public-ip update -g {rg} -n {pip_name} '
+                 '--ddos-custom-policy id={dcp_id2}', checks=[
+            self.check('ddosSettings.ddosCustomPolicy.id', '{dcp_id2}'),
+        ])
+
+        # Remove the policy from the public IP
+        self.cmd('network public-ip update -g {rg} -n {pip_name} '
+                 '--ddos-custom-policy null', checks=[
+            self.check('ddosSettings.ddosCustomPolicy', None),
+        ])
+
+        self.cmd('network nic delete -g {rg} -n nic1')
+        self.cmd('network public-ip delete -g {rg} -n {pip_name}')
+        self.cmd('network ddos-custom-policy delete -g {rg} -n {policy_name} -y')
+        self.cmd('network ddos-custom-policy delete -g {rg} -n {policy_name2} -y')
+
 
 class NetworkPrivateEndpointScenarioTest(ScenarioTest):
     @ResourceGroupPreparer(name_prefix='test_network_private_endpoint_ip_version_type', location='eastus2euap')

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_tag_update_by_patch.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_tag_update_by_patch.yaml
@@ -4981,7 +4981,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.72.0 azsdk-python-core/1.31.0 Python/3.11.2 (Linux-5.15.167.4-microsoft-standard-WSL2-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.Network/publicIPAddresses/cli_ip000004?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.Network/publicIPAddresses/cli_ip000004?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cli_ip000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.Network/publicIPAddresses/cli_ip000004","etag":"W/\"6545fe77-172c-4914-bfba-b41c1f3b7b37\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"f0960bbe-1375-4dda-b9ac-6f0d23b4103e","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -5087,7 +5087,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.72.0 azsdk-python-core/1.31.0 Python/3.11.2 (Linux-5.15.167.4-microsoft-standard-WSL2-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.Network/publicIPAddresses/cli_ip000004?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.Network/publicIPAddresses/cli_ip000004?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cli_ip000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.Network/publicIPAddresses/cli_ip000004","etag":"W/\"763cb332-0037-4875-9944-f0082f733ca0\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"f0960bbe-1375-4dda-b9ac-6f0d23b4103e","ipAddress":"40.83.193.12","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_create_disk_from_diff_gallery_image_version.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_create_disk_from_diff_gallery_image_version.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_disk_from_diff_gallery_image_version_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_disk_from_diff_gallery_image_version_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_disk_from_diff_gallery_image_version_000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"4fd9df4f-7c5e-445c-b055-b999522f5898\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"6fd24d79-0aa7-49bc-a175-7669871bd851","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_disk_from_diff_gallery_image_version_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_disk_from_diff_gallery_image_version_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_disk_from_diff_gallery_image_version_000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"cbb7887a-cee5-4742-ba08-aab1d119ce97\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"6fd24d79-0aa7-49bc-a175-7669871bd851","ipAddress":"20.66.40.128","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_create_vm_with_shared_gallery_image.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_create_vm_with_shared_gallery_image.yaml
@@ -501,7 +501,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"a249203f-d162-4a44-9502-8b7421ef2c6e\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"65a51394-0a14-44b0-8a5b-3dedcec0817c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -607,7 +607,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"38fa20ed-7fb1-4396-b2ea-143c0657552a\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"65a51394-0a14-44b0-8a5b-3dedcec0817c","ipAddress":"68.220.56.160","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_disk_controller_type.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_disk_controller_type.yaml
@@ -303,7 +303,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"8ccd6ba8-8154-4fa7-bef6-5236f70bbb53\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"a44c83e7-c944-4b70-9c58-958a280e3a0e","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -409,7 +409,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"8fc15412-0ebe-4e6c-a2c9-b7e5c008249b\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"a44c83e7-c944-4b70-9c58-958a280e3a0e","ipAddress":"20.252.223.139","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -6099,7 +6099,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"b2fd317c-fb34-4238-ad9f-4494a73247ed\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"c032207e-0a48-4cf3-976f-1c89ddb52ed8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -6205,7 +6205,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"21ac2f64-4bcb-443e-ab02-4b665b7c63bc\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"c032207e-0a48-4cf3-976f-1c89ddb52ed8","ipAddress":"40.89.84.225","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -10695,7 +10695,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"b5694c2c-a575-4b9e-9ccc-2fcaff949009\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"56d20b56-5029-440a-b895-b66eb749e03d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -10801,7 +10801,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"cd35f538-d715-477b-8a7a-8b0c6e10aab1\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"56d20b56-5029-440a-b895-b66eb749e03d","ipAddress":"20.252.172.184","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -16355,7 +16355,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip4","etag":"W/\"61ddcf93-359f-440b-b10d-23ea6b25b3a0\"","location":"eastus2euap","properties":{"provisioningState":"Updating","resourceGuid":"3f3098e5-47b6-4c3f-8b96-a3b2d24e5fa7","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -16461,7 +16461,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_disk_controller_type000001/providers/Microsoft.Network/publicIPAddresses/pubip4","etag":"W/\"6db85dc3-7bf6-4019-ad4b-77f6dbc9101d\"","location":"eastus2euap","properties":{"provisioningState":"Succeeded","resourceGuid":"3f3098e5-47b6-4c3f-8b96-a3b2d24e5fa7","ipAddress":"20.252.171.125","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_image_version_create_for_diff_source.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_image_version_create_for_diff_source.yaml
@@ -502,7 +502,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_image_version_create_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_image_version_create_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_image_version_create_000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"9363939d-b9da-49bc-8710-28ea20bde2a5\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"05e4db44-ea48-4001-848f-0b216aa3f077","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -608,7 +608,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_image_version_create_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_image_version_create_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_image_version_create_000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"3210ee42-5055-4a50-b1a7-12c5a24d728e\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"05e4db44-ea48-4001-848f-0b216aa3f077","ipAddress":"172.184.162.234","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_shared_gallery.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_shared_gallery.yaml
@@ -555,7 +555,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"f34911b3-e3a8-4faa-9f00-146580e5df18\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"dd6fb338-9fd4-44e2-8f7a-ce14b02c1423","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -661,7 +661,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"9920faf4-4e79-4580-b2e7-fec35a2a3016\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"dd6fb338-9fd4-44e2-8f7a-ce14b02c1423","ipAddress":"172.184.113.96","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_snapshot_create_with_source_blob_uri.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_snapshot_create_with_source_blob_uri.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_snapshot_create_with_source_blob_uri000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_snapshot_create_with_source_blob_uri000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_snapshot_create_with_source_blob_uri000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"5e7c95fa-077f-4d2b-8aee-515a75dcb017\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"653c9c4e-65e7-4f1c-b51d-5a834b8ccd10","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_snapshot_create_with_source_blob_uri000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_snapshot_create_with_source_blob_uri000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_snapshot_create_with_source_blob_uri000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"6b885f40-83b3-432f-9e00-476fcfabef71\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"653c9c4e-65e7-4f1c-b51d-5a834b8ccd10","ipAddress":"57.154.184.123","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_capture_zone_resilient_image.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_capture_zone_resilient_image.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_generalize_vm000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_generalize_vm000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_generalize_vm000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"f0f544fa-2dac-4b8d-a43f-0d013cedb9d4\"","location":"francecentral","properties":{"provisioningState":"Updating","resourceGuid":"c6bbbabe-7d5f-4082-8477-a0663120db1e","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_generalize_vm000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_generalize_vm000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_generalize_vm000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"86deaa1d-4bad-41ae-a4a7-566d2ac08738\"","location":"francecentral","properties":{"provisioningState":"Succeeded","resourceGuid":"c6bbbabe-7d5f-4082-8477-a0663120db1e","ipAddress":"40.89.164.80","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_by_attach_os_and_data_disks.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_by_attach_os_and_data_disks.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"d4554f0c-58c8-479e-8ae2-1b15754d8ddb\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"df22eb57-0098-4dd7-87ab-2652cdd57749","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"ac2e2ca7-4a26-42ec-acc8-cf49f71480c8\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"df22eb57-0098-4dd7-87ab-2652cdd57749","ipAddress":"20.253.193.34","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -7280,7 +7280,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"7fdc22cb-ef7e-4d0a-acbf-fd98445e77d5\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"eacd7daa-d0bf-40bc-9a71-bb37f38b04a0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -7386,7 +7386,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"6f4bf806-f10f-4495-a282-ba93af9d2ad7\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"eacd7daa-d0bf-40bc-9a71-bb37f38b04a0","ipAddress":"20.245.208.180","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_custom_ip.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_custom_ip.yaml
@@ -4277,7 +4277,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_ip000001/providers/Microsoft.Network/publicIPAddresses/vrfvmzPublicIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_ip000001/providers/Microsoft.Network/publicIPAddresses/vrfvmzPublicIP?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vrfvmzPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_ip000001/providers/Microsoft.Network/publicIPAddresses/vrfvmzPublicIP","etag":"W/\"86f722ae-0558-4e25-a143-d50dcfda27b3\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b6b889d2-cff5-4593-a065-d435a492dee1","ipAddress":"52.241.248.49","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"vrfmyvm00110011z","fqdn":"vrfmyvm00110011z.westus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_ip000001/providers/Microsoft.Network/networkInterfaces/vrfvmzVMNic/ipConfigurations/ipconfigvrfvmz"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_data_disk_delete_option.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_data_disk_delete_option.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"71efbf04-957a-43a0-89ab-b10bf5055b48\"","location":"northeurope","properties":{"provisioningState":"Updating","resourceGuid":"c821673f-b4cb-4761-9a27-7f43021aeed7","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -177,7 +177,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"f2f458d8-cd66-40a9-aa86-ace2b39be1f4\"","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"c821673f-b4cb-4761-9a27-7f43021aeed7","ipAddress":"65.52.231.67","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -9254,7 +9254,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"8dfca9c6-8c61-49e4-8b1e-2c52bbdccf6d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"da226515-44b9-4a69-a052-0021c26c8572","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -9360,7 +9360,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"e9e14c38-e284-417d-8f0a-18a23db52de4\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"da226515-44b9-4a69-a052-0021c26c8572","ipAddress":"52.160.93.20","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -17067,7 +17067,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"4d7b8292-0775-4b0f-8131-84d8d1aeb870\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"1c09316e-8ca3-4be5-aa08-ce4caa8d5868","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -17173,7 +17173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"a7a7ca1b-a74f-4910-9484-b76f3fb94272\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"1c09316e-8ca3-4be5-aa08-ce4caa8d5868","ipAddress":"52.159.233.136","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_existing_ids_options.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_existing_ids_options.yaml
@@ -365,7 +365,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing_ids000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing_ids000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vrfpubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing_ids000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip","etag":"W/\"0471aa1c-8fca-4d04-ab75-ed7de542b6bc\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"ab55a343-6943-4390-aeaf-d05eb403ea08","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -476,7 +476,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing_ids000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing_ids000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vrfpubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing_ids000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip","etag":"W/\"10d35e7a-9beb-45cc-b012-aa3a90a32c99\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ab55a343-6943-4390-aeaf-d05eb403ea08","ipAddress":"104.40.8.53","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_existing_nic.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_existing_nic.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.63.0 azsdk-python-core/1.28.0 Python/3.10.11 (Windows-10-10.0.22631-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_existing_nic000001/providers/Microsoft.Network/publicIPAddresses/my-pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_existing_nic000001/providers/Microsoft.Network/publicIPAddresses/my-pip?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"my-pip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_existing_nic000001/providers/Microsoft.Network/publicIPAddresses/my-pip\"\
@@ -177,7 +177,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.63.0 azsdk-python-core/1.28.0 Python/3.10.11 (Windows-10-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_existing_nic000001/providers/Microsoft.Network/publicIPAddresses/my-pip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_existing_nic000001/providers/Microsoft.Network/publicIPAddresses/my-pip?api-version=2025-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"my-pip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_existing_nic000001/providers/Microsoft.Network/publicIPAddresses/my-pip\"\

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_existing_options.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_existing_options.yaml
@@ -365,7 +365,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vrfpubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip","etag":"W/\"33a5979f-dd95-4992-9ec4-079cb854964d\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"feb1d403-448b-4976-833b-c33212278e5e","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -476,7 +476,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vrfpubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip","etag":"W/\"51d040bd-4c8a-448b-993f-b8d1bed3ac57\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"feb1d403-448b-4976-833b-c33212278e5e","ipAddress":"20.245.106.198","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_from_unmanaged_disk.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_from_unmanaged_disk.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"d0b0708a-f714-4bee-a254-4d37f974dd75\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"c4f3446d-4344-48f5-828a-edc5a20207af","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"58ec24c3-247b-4f6e-8374-7fa60c58c7a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"c4f3446d-4344-48f5-828a-edc5a20207af","ipAddress":"13.91.97.146","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -6737,7 +6737,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"d0aa361f-1b2a-46ae-9ab1-ca7c9c39618b\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"a46e9c4d-7ed5-492c-9639-65f18af3fdd4","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -6843,7 +6843,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_from_unmanaged_disk000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"129857fa-c9e0-48f3-991e-4bb5bde10e5b\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"a46e9c4d-7ed5-492c-9639-65f18af3fdd4","ipAddress":"57.154.184.109","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_none_options.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_none_options.yaml
@@ -4214,7 +4214,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_none_options000001/providers/Microsoft.Network/publicIPAddresses/nooptvmPublicIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_none_options000001/providers/Microsoft.Network/publicIPAddresses/nooptvmPublicIP?api-version=2025-07-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/publicIPAddresses/nooptvmPublicIP''

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_state_modifications.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_state_modifications.yaml
@@ -9089,7 +9089,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod000001/providers/Microsoft.Network/publicIPAddresses/mypubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod000001/providers/Microsoft.Network/publicIPAddresses/mypubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"mypubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod000001/providers/Microsoft.Network/publicIPAddresses/mypubip","etag":"W/\"df7efff6-d77b-41e6-9eb8-f7471bc1fdbe\"","location":"westus","tags":{"firsttag":"1","secondtag":"2","thirdtag":""},"properties":{"provisioningState":"Succeeded","resourceGuid":"d919cd20-7109-4594-bfa4-c75cd75e02d6","ipAddress":"52.241.3.230","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod000001/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic/ipConfigurations/ipconfigvm-state-mod"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_custom_image.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_custom_image.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"25b38f53-1b4d-47c0-b949-6a4438bcbf42\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"286742fe-cb24-48d6-81bf-d9a400776dd6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip1","etag":"W/\"daff058d-9710-4af0-988c-333c99125e35\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"286742fe-cb24-48d6-81bf-d9a400776dd6","ipAddress":"20.66.88.22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -7007,7 +7007,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"ff17ea22-4e51-46ea-ab08-f49a5b1e8021\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"b4f9c73d-1673-4e18-9d3b-5aeb0363afe0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -7113,7 +7113,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip2","etag":"W/\"a46ace8b-dbe9-411a-a450-32f45cbdb4a1\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"b4f9c73d-1673-4e18-9d3b-5aeb0363afe0","ipAddress":"20.245.224.79","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -13470,7 +13470,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"ffc65bd3-fb3f-4d61-bbc0-0a24debeb2a2\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"e9c4efc7-8559-4cd2-b6d2-c888c6dd903c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -13576,7 +13576,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip3?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip3","etag":"W/\"42ed0cbc-a3f5-444a-9a86-e740cd92f826\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"e9c4efc7-8559-4cd2-b6d2-c888c6dd903c","ipAddress":"52.241.7.136","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -18008,7 +18008,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip4","etag":"W/\"77f874e1-f8bb-40b7-b525-3953f5a91d39\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"79ac4da2-3c33-4d4a-ad59-3729a697eca0","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -18114,7 +18114,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip4?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip4","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip4","etag":"W/\"346d202a-12ca-4212-91f1-ff8106cf0971\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"79ac4da2-3c33-4d4a-ad59-3729a697eca0","ipAddress":"20.66.72.60","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -20504,7 +20504,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip5?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip5?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip5","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip5","etag":"W/\"8a80d470-ac49-48f5-be64-5179847185ae\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"f23b6f1e-cdd7-47b2-abe2-8c0ad29659b6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -20610,7 +20610,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip5?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip5?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip5","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip5","etag":"W/\"fd8b6362-e220-4eb8-b9dc-38f7f8bcc801\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"f23b6f1e-cdd7-47b2-abe2-8c0ad29659b6","ipAddress":"40.125.43.216","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -24824,7 +24824,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip6?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip6?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip6","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip6","etag":"W/\"834409e3-f300-457a-a37a-dc2320ca33ce\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"85b45b11-4e3a-43c8-9098-27bb7e0a32a5","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -24930,7 +24930,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip6?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip6?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip6","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip6","etag":"W/\"e9b41f3c-0acc-4cf7-bdf5-f63011dbb4c8\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"85b45b11-4e3a-43c8-9098-27bb7e0a32a5","ipAddress":"13.93.203.116","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -29162,7 +29162,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip7?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip7?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip7","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip7","etag":"W/\"e6fa1085-8b84-4df2-8f34-8993dae07e7e\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"aead4e33-59bf-4e0a-b612-56433b56c3ae","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -29268,7 +29268,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip7?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip7?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip7","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image000001/providers/Microsoft.Network/publicIPAddresses/pubip7","etag":"W/\"e2d74724-e47d-435d-a404-80431216c189\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"aead4e33-59bf-4e0a-b612-56433b56c3ae","ipAddress":"172.184.184.61","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_custom_image_name_conflict.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_custom_image_name_conflict.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image_conflict000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image_conflict000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image_conflict000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"ce14ec62-f267-476b-b2c8-a08e5f413de2\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"f28f2c47-6eae-46cb-845e-5580dadf94ab","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image_conflict000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image_conflict000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_image_conflict000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"840866e5-4bce-4413-8496-d3a6b92474cc\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28f2c47-6eae-46cb-845e-5580dadf94ab","ipAddress":"52.137.189.73","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_extended_location.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_extended_location.yaml
@@ -1165,7 +1165,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.30.1 Python/3.10.11 (Windows-10-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_extended_location_000001/providers/Microsoft.Network/publicIPAddresses/vmPublicIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_extended_location_000001/providers/Microsoft.Network/publicIPAddresses/vmPublicIP?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vmPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_extended_location_000001/providers/Microsoft.Network/publicIPAddresses/vmPublicIP","etag":"W/\"49b71176-99b1-472e-88df-7f86d88aa579\"","location":"westus","tags":{},"extendedLocation":{"type":"EdgeZone","name":"microsoftlosangeles1"},"properties":{"provisioningState":"Succeeded","resourceGuid":"b91ff335-cb3c-473b-b7f1-b88fd52c2fc8","ipAddress":"20.59.64.40","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_extended_location_000001/providers/Microsoft.Network/networkInterfaces/vmVMNic/ipConfigurations/ipconfigvm"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_reimage.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_reimage.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_reimage_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_reimage_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_reimage_000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"27f8d2ed-9e1d-4836-880a-d26ec4f335ad\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"3dea3fb9-9fe8-4ae0-b01d-5e97ed1def81","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_reimage_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_reimage_000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_reimage_000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"591dc449-4c6f-4be1-9b68-4f4c2b6dd1be\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"3dea3fb9-9fe8-4ae0-b01d-5e97ed1def81","ipAddress":"20.245.225.251","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_windows_license_type.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_windows_license_type.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_windows_license_type000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_windows_license_type000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_windows_license_type000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"15434c93-6a82-4afa-b20a-d101533bff06\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"97262cd8-8333-435f-a194-2c792c1daf28","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.12.9 (Linux-6.8.0-1021-azure-x86_64-with-glibc2.36)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_windows_license_type000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_windows_license_type000001/providers/Microsoft.Network/publicIPAddresses/pubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"pubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_windows_license_type000001/providers/Microsoft.Network/publicIPAddresses/pubip","etag":"W/\"825c89b3-dfc9-4c23-9408-2c10a3ebbaf6\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"97262cd8-8333-435f-a194-2c792c1daf28","ipAddress":"104.209.1.61","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[{"ipTagType":"FirstPartyUsage","tag":"/NonProd"}],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_create_none_options.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_create_none_options.yaml
@@ -1171,7 +1171,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.71.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_none000001/providers/Microsoft.Network/publicIPAddresses/vmss1PublicIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_none000001/providers/Microsoft.Network/publicIPAddresses/vmss1PublicIP?api-version=2025-07-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/publicIPAddresses/vmss1PublicIP''

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_create_options.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_create_options.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_options000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_options000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vrfpubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_options000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip","etag":"W/\"818f8b67-8fea-4fc2-bee5-dd9711c2c90f\"","location":"westus","properties":{"provisioningState":"Updating","resourceGuid":"68a169b4-4a17-4842-99a3-6fbc1d16279c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_options000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_options000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vrfpubip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_options000001/providers/Microsoft.Network/publicIPAddresses/vrfpubip","etag":"W/\"8bc5eb01-5693-487c-9c17-312a4100aa0b\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"68a169b4-4a17-4842-99a3-6fbc1d16279c","ipAddress":"20.245.83.172","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_extended_location.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_extended_location.yaml
@@ -786,7 +786,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.59.0 azsdk-python-core/1.30.1 Python/3.10.11 (Windows-10-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extended_location_000001/providers/Microsoft.Network/publicIPAddresses/vmssLBPublicIP?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extended_location_000001/providers/Microsoft.Network/publicIPAddresses/vmssLBPublicIP?api-version=2025-07-01
   response:
     body:
       string: '{"name":"vmssLBPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extended_location_000001/providers/Microsoft.Network/publicIPAddresses/vmssLBPublicIP","etag":"W/\"33e5899d-f476-44fe-aff1-1d20b673aa1c\"","location":"westus","tags":{},"extendedLocation":{"type":"EdgeZone","name":"microsoftlosangeles1"},"properties":{"provisioningState":"Succeeded","resourceGuid":"5e05d6f7-8d51-4298-a3f7-0ebafedfd652","ipAddress":"20.59.64.39","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extended_location_000001/providers/Microsoft.Network/loadBalancers/vmssLB/frontendIPConfigurations/loadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_single_placement_group_default_to_std_lb.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_single_placement_group_default_to_std_lb.yaml
@@ -640,7 +640,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.56.0 (AAZ) azsdk-python-core/1.28.0 Python/3.9.5 (Windows-10-10.0.22631-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses?api-version=2025-07-01
   response:
     body:
       string: '{"value":[{"name":"vmss123LBPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss123LBPublicIP","etag":"W/\"140c570d-cb3e-464c-8441-cb6a7166aea9\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"7f4567e4-0c45-4a9f-89b3-db286fb20d3e","ipAddress":"13.88.43.81","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss123LB/frontendIPConfigurations/loadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}]}'


### PR DESCRIPTION
**Related command**
`az network public-ip create`
`az network public-ip update`

**Description**
Implements Azure CLI request #33811 (follow-up to #33383, which added DDoS custom policy CRUD and LB frontend-ip linkage in #33413).

This PR adds a new `--ddos-custom-policy` argument to `az network public-ip create` and `az network public-ip update`, letting users associate a DDoS custom policy with a public IP by name or resource ID. 

aaz https://github.com/Azure/aaz/pull/1052


**Testing Guide**
`azdev test test_ddos_custom_policy_attach_to_public_ip`

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
