### PR TITLE
[Packaging] Add Debian Trixie support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1007,6 +1007,12 @@ jobs:
           distro: bookworm
           arch: ${{ arch.value }}
           pool: ${{ arch.pool }}
+        Trixie ${{ arch.name }}:
+          # 13
+          deb_system: debian
+          distro: trixie
+          arch: ${{ arch.value }}
+          pool: ${{ arch.pool }}
   steps:
   - bash: ./scripts/ci/install_docker.sh
     displayName: Install Docker
@@ -1062,6 +1068,11 @@ jobs:
         Bookworm ${{ arch.name }}:
           deb_system: debian
           distro: bookworm
+          arch: ${{ arch.value }}
+          pool: ${{ arch.pool }}
+        Trixie ${{ arch.name }}:
+          deb_system: debian
+          distro: trixie
           arch: ${{ arch.value }}
           pool: ${{ arch.pool }}
   pool:


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Related command

N/A — packaging/CI change only, no CLI command changes.

## Description

Adds Debian Trixie (13) to the `BuildDebPackages`/`TestDebPackages` matrix in `azure-pipelines.yml`, mirroring the existing Bookworm entries added in #26690.

`packages.microsoft.com/repos/azure-cli/dists/` currently only goes up to `bookworm`, so anyone on Debian 13 installing via the documented apt-repo method hits a missing `Release` file (#32069). This PR adds the CI build/test matrix entry needed to produce a `trixie` `.deb`, the same way #26690 added Bookworm support after Debian 12's release.

Note: merging this adds `trixie` to what CI builds/tests, but actually publishing it to `packages.microsoft.com/repos/azure-cli/dists/trixie/` is a separate internal release step outside this repo — flagging that step needs to happen too for #32069 to be fully resolved.

Fixes #32069

## History Notes

- Add Debian Trixie (13) to the CI build/test matrix, following the Bookworm precedent from #26690.

## PR information

- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.
- [ ] This PR has modified CHANGELOG.md to reflect the applicable changes. (N/A — packaging/CI only, no user-facing CLI change)
- [x] I have read the [Submitting Changes](https://github.com/Azure/azure-cli/blob/dev/CONTRIBUTING.md#submitting-changes) section of CONTRIBUTING.md.
- [ ] I have added tests for the changes made. (N/A — CI matrix entry, covered by the existing TestDebPackages job itself)
- [ ] I have verified that this change works when installed from the appropriate package for various environments (Cloud Shell, MSI, Homebrew, apt-get, YUM/DNF, Docker, etc.) (Blocked on Microsoft's internal publish pipeline being updated for trixie — see note above.)