### PR TITLE
[MySql] Fix grammar in MySQL import help text

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_help.py
@@ -223,7 +223,7 @@ long-summary: >
 
     To Migrate an external MySQL server to Azure MySQL Flexible server whose backup is stored on an Azure Blob Container.
 
-    To Migrate a Azure MySQL single server to Azure MySQL Flexible server. For more information for network configuration, see
+    To Migrate an Azure MySQL single server to Azure MySQL Flexible server. For more information for network configuration, see
 
     - Migrate Azure Database for MySQL - Single Server to Flexible Server using Azure Database for MySQL Import CLI
 


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary
- Corrects "a Azure" to "an Azure" in the `az mysql flexible-server import create` long-summary help text.

Fixes #27760

## Test plan
- [ ] Confirm help text renders with "an Azure" in `az mysql flexible-server import create -h`
- [ ] Confirm no other changes in the diff
