### PR TITLE
[AKS] `az aks create`: Skip SSH key configuration for Automatic SKU clusters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -408,7 +408,7 @@ def load_arguments(self, _):
         c.argument('edge_zone', edge_zone_type)
         c.argument('admin_username', options_list=['--admin-username', '-u'], default='azureuser')
         c.argument('generate_ssh_keys', action='store_true', validator=validate_create_parameters)
-        c.argument('ssh_key_value', required=False, type=file_type, default=None,
+        c.argument('ssh_key_value', required=False, type=file_type, default=os.path.join('~', '.ssh', 'id_rsa.pub'),
                    completer=FilesCompleter(), validator=validate_ssh_key)
         c.argument('no_ssh_key', options_list=['--no-ssh-key', '-x'])
         c.argument('dns_service_ip')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -408,7 +408,7 @@ def load_arguments(self, _):
         c.argument('edge_zone', edge_zone_type)
         c.argument('admin_username', options_list=['--admin-username', '-u'], default='azureuser')
         c.argument('generate_ssh_keys', action='store_true', validator=validate_create_parameters)
-        c.argument('ssh_key_value', required=False, type=file_type, default=os.path.join('~', '.ssh', 'id_rsa.pub'),
+        c.argument('ssh_key_value', required=False, type=file_type, default=None,
                    completer=FilesCompleter(), validator=validate_ssh_key)
         c.argument('no_ssh_key', options_list=['--no-ssh-key', '-x'])
         c.argument('dns_service_ip')

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -45,17 +45,10 @@ def validate_ssh_key(namespace):
     if hasattr(namespace, 'no_ssh_key') and namespace.no_ssh_key:
         return
     # Automatic SKU clusters use a fully managed system node pool that rejects any SSH key
-    # configuration. Skip reading/generating an SSH key so users don't need --no-ssh-key.
+    # configuration. Do not generate/read a key; if the user explicitly asked for one, error.
     if getattr(namespace, 'sku', None) is not None and \
             namespace.sku.lower() == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
-        # ssh_key_value defaults to "~/.ssh/id_rsa.pub" (expanded to an absolute path by
-        # the arg's file_type); only treat a non-default value as an explicit user request.
-        default_ssh_key_value = os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub"))
-        explicit_ssh_key = (
-            namespace.ssh_key_value and
-            os.path.expanduser(namespace.ssh_key_value) != default_ssh_key_value
-        )
-        if namespace.generate_ssh_keys or explicit_ssh_key:
+        if namespace.generate_ssh_keys or namespace.ssh_key_value:
             raise MutuallyExclusiveArgumentError(
                 'SSH key configuration is not supported for the Automatic SKU. '
                 'Do not specify "--ssh-key-value" or "--generate-ssh-keys" when using "--sku automatic".'

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -10,6 +10,7 @@ from math import isclose, isnan
 
 from azure.mgmt.containerservice.models import KubernetesSupportPlan
 from azure.cli.command_modules.acs._consts import (
+    CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC,
     CONST_MANAGED_CLUSTER_SKU_TIER_FREE,
     CONST_MANAGED_CLUSTER_SKU_TIER_STANDARD,
     CONST_MANAGED_CLUSTER_SKU_TIER_PREMIUM,
@@ -42,6 +43,23 @@ logger = get_logger(__name__)
 
 def validate_ssh_key(namespace):
     if hasattr(namespace, 'no_ssh_key') and namespace.no_ssh_key:
+        return
+    # Automatic SKU clusters use a fully managed system node pool that rejects any SSH key
+    # configuration. Skip reading/generating an SSH key so users don't need --no-ssh-key.
+    if getattr(namespace, 'sku', None) is not None and \
+            namespace.sku.lower() == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+        # ssh_key_value defaults to "~/.ssh/id_rsa.pub" (expanded to an absolute path by
+        # the arg's file_type); only treat a non-default value as an explicit user request.
+        default_ssh_key_value = os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub"))
+        explicit_ssh_key = (
+            namespace.ssh_key_value and
+            os.path.expanduser(namespace.ssh_key_value) != default_ssh_key_value
+        )
+        if namespace.generate_ssh_keys or explicit_ssh_key:
+            raise MutuallyExclusiveArgumentError(
+                'SSH key configuration is not supported for the Automatic SKU. '
+                'Do not specify "--ssh-key-value" or "--generate-ssh-keys" when using "--sku automatic".'
+            )
         return
     string_or_file = (namespace.ssh_key_value or
                       os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa.pub'))

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -45,10 +45,17 @@ def validate_ssh_key(namespace):
     if hasattr(namespace, 'no_ssh_key') and namespace.no_ssh_key:
         return
     # Automatic SKU clusters use a fully managed system node pool that rejects any SSH key
-    # configuration. Do not generate/read a key; if the user explicitly asked for one, error.
+    # configuration. Skip reading/generating an SSH key so users don't need --no-ssh-key.
     if getattr(namespace, 'sku', None) is not None and \
             namespace.sku.lower() == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
-        if namespace.generate_ssh_keys or namespace.ssh_key_value:
+        # ssh_key_value defaults to "~/.ssh/id_rsa.pub" (expanded to an absolute path by
+        # the arg's file_type); only treat a non-default value as an explicit user request.
+        default_ssh_key_value = os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub"))
+        explicit_ssh_key = (
+            namespace.ssh_key_value and
+            os.path.expanduser(namespace.ssh_key_value) != default_ssh_key_value
+        )
+        if namespace.generate_ssh_keys or explicit_ssh_key:
             raise MutuallyExclusiveArgumentError(
                 'SSH key configuration is not supported for the Automatic SKU. '
                 'Do not specify "--ssh-key-value" or "--generate-ssh-keys" when using "--sku automatic".'

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -6649,7 +6649,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
 
         # Automatic SKU clusters use a fully managed system node pool that rejects any SSH
         # key configuration, so never attach a linux profile for them.
-        if self.context.get_sku_name() == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+        if (self.context.get_sku_name() or "").lower() == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
             return mc
 
         ssh_key_value, no_ssh_key = self.context.get_ssh_key_value_and_no_ssh_key()

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -6647,6 +6647,11 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         """
         self._ensure_mc(mc)
 
+        # Automatic SKU clusters use a fully managed system node pool that rejects any SSH
+        # key configuration, so never attach a linux profile for them.
+        if self.context.get_sku_name() == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+            return mc
+
         ssh_key_value, no_ssh_key = self.context.get_ssh_key_value_and_no_ssh_key()
         if not no_ssh_key:
             ssh_config = self.models.ContainerServiceSshConfiguration(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -7160,6 +7160,26 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         ground_truth_mc_2 = self.models.ManagedCluster(location="test_location")
         self.assertEqual(dec_mc_2, ground_truth_mc_2)
 
+    def test_set_up_linux_profile_automatic_sku_skips_ssh_key(self):
+        dec_1 = AKSManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "sku": "automatic",
+                "admin_username": "azureuser",
+                "no_ssh_key": False,
+                "ssh_key_value": "unused-for-managed-system-pool",
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_1 = self.models.ManagedCluster(location="test_location")
+        dec_1.context.attach_mc(mc_1)
+
+        dec_mc_1 = dec_1.set_up_linux_profile(mc_1)
+
+        self.assertIs(dec_mc_1, mc_1)
+        self.assertIsNone(dec_mc_1.linux_profile)
+
     def test_set_up_windows_profile(self):
         # default value in `aks_create`
         dec_1 = AKSManagedClusterCreateDecorator(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -1986,5 +1986,65 @@ class TestArtifactStreaming(unittest.TestCase):
         )
 
 
+class TestValidateSshKey(unittest.TestCase):
+    def _default_key(self):
+        import os
+        return os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub"))
+
+    def test_skip_for_automatic_sku(self):
+        # Default ssh_key_value (expanded like the CLI does) should be treated as
+        # "not explicitly provided" and skipped without error.
+        default_key = self._default_key()
+        namespace = SimpleNamespace(
+            no_ssh_key=False,
+            generate_ssh_keys=False,
+            ssh_key_value=default_key,
+            sku="automatic",
+        )
+        validators.validate_ssh_key(namespace)
+        self.assertEqual(namespace.ssh_key_value, default_key)
+
+    def test_skip_for_automatic_sku_case_insensitive(self):
+        default_key = self._default_key()
+        namespace = SimpleNamespace(
+            no_ssh_key=False,
+            generate_ssh_keys=False,
+            ssh_key_value=default_key,
+            sku="Automatic",
+        )
+        validators.validate_ssh_key(namespace)
+        self.assertEqual(namespace.ssh_key_value, default_key)
+
+    def test_automatic_sku_with_generate_ssh_keys_errors(self):
+        namespace = SimpleNamespace(
+            no_ssh_key=False,
+            generate_ssh_keys=True,
+            ssh_key_value=self._default_key(),
+            sku="automatic",
+        )
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            validators.validate_ssh_key(namespace)
+
+    def test_automatic_sku_with_explicit_ssh_key_value_errors(self):
+        namespace = SimpleNamespace(
+            no_ssh_key=False,
+            generate_ssh_keys=False,
+            ssh_key_value="ssh-rsa AAAAB3NzaC1yc2Euser@host",
+            sku="automatic",
+        )
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            validators.validate_ssh_key(namespace)
+
+    def test_no_ssh_key_still_skips(self):
+        namespace = SimpleNamespace(
+            no_ssh_key=True,
+            generate_ssh_keys=False,
+            ssh_key_value=None,
+            sku="base",
+        )
+        validators.validate_ssh_key(namespace)
+        self.assertIsNone(namespace.ssh_key_value)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -1987,39 +1987,33 @@ class TestArtifactStreaming(unittest.TestCase):
 
 
 class TestValidateSshKey(unittest.TestCase):
-    def _default_key(self):
-        import os
-        return os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub"))
-
     def test_skip_for_automatic_sku(self):
-        # Default ssh_key_value (expanded like the CLI does) should be treated as
-        # "not explicitly provided" and skipped without error.
-        default_key = self._default_key()
+        # When --ssh-key-value is not provided (default None), Automatic SKU skips SSH
+        # handling without error.
         namespace = SimpleNamespace(
             no_ssh_key=False,
             generate_ssh_keys=False,
-            ssh_key_value=default_key,
+            ssh_key_value=None,
             sku="automatic",
         )
         validators.validate_ssh_key(namespace)
-        self.assertEqual(namespace.ssh_key_value, default_key)
+        self.assertIsNone(namespace.ssh_key_value)
 
     def test_skip_for_automatic_sku_case_insensitive(self):
-        default_key = self._default_key()
         namespace = SimpleNamespace(
             no_ssh_key=False,
             generate_ssh_keys=False,
-            ssh_key_value=default_key,
+            ssh_key_value=None,
             sku="Automatic",
         )
         validators.validate_ssh_key(namespace)
-        self.assertEqual(namespace.ssh_key_value, default_key)
+        self.assertIsNone(namespace.ssh_key_value)
 
     def test_automatic_sku_with_generate_ssh_keys_errors(self):
         namespace = SimpleNamespace(
             no_ssh_key=False,
             generate_ssh_keys=True,
-            ssh_key_value=self._default_key(),
+            ssh_key_value=None,
             sku="automatic",
         )
         with self.assertRaises(MutuallyExclusiveArgumentError):
@@ -2030,6 +2024,19 @@ class TestValidateSshKey(unittest.TestCase):
             no_ssh_key=False,
             generate_ssh_keys=False,
             ssh_key_value="ssh-rsa AAAAB3NzaC1yc2Euser@host",
+            sku="automatic",
+        )
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            validators.validate_ssh_key(namespace)
+
+    def test_automatic_sku_with_default_path_ssh_key_value_errors(self):
+        # Even the default key path counts as an explicit --ssh-key-value now that the
+        # arg default is None.
+        import os
+        namespace = SimpleNamespace(
+            no_ssh_key=False,
+            generate_ssh_keys=False,
+            ssh_key_value=os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub")),
             sku="automatic",
         )
         with self.assertRaises(MutuallyExclusiveArgumentError):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -1987,33 +1987,39 @@ class TestArtifactStreaming(unittest.TestCase):
 
 
 class TestValidateSshKey(unittest.TestCase):
+    def _default_key(self):
+        import os
+        return os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub"))
+
     def test_skip_for_automatic_sku(self):
-        # When --ssh-key-value is not provided (default None), Automatic SKU skips SSH
-        # handling without error.
+        # Default ssh_key_value (expanded like the CLI does) should be treated as
+        # "not explicitly provided" and skipped without error.
+        default_key = self._default_key()
         namespace = SimpleNamespace(
             no_ssh_key=False,
             generate_ssh_keys=False,
-            ssh_key_value=None,
+            ssh_key_value=default_key,
             sku="automatic",
         )
         validators.validate_ssh_key(namespace)
-        self.assertIsNone(namespace.ssh_key_value)
+        self.assertEqual(namespace.ssh_key_value, default_key)
 
     def test_skip_for_automatic_sku_case_insensitive(self):
+        default_key = self._default_key()
         namespace = SimpleNamespace(
             no_ssh_key=False,
             generate_ssh_keys=False,
-            ssh_key_value=None,
+            ssh_key_value=default_key,
             sku="Automatic",
         )
         validators.validate_ssh_key(namespace)
-        self.assertIsNone(namespace.ssh_key_value)
+        self.assertEqual(namespace.ssh_key_value, default_key)
 
     def test_automatic_sku_with_generate_ssh_keys_errors(self):
         namespace = SimpleNamespace(
             no_ssh_key=False,
             generate_ssh_keys=True,
-            ssh_key_value=None,
+            ssh_key_value=self._default_key(),
             sku="automatic",
         )
         with self.assertRaises(MutuallyExclusiveArgumentError):
@@ -2024,19 +2030,6 @@ class TestValidateSshKey(unittest.TestCase):
             no_ssh_key=False,
             generate_ssh_keys=False,
             ssh_key_value="ssh-rsa AAAAB3NzaC1yc2Euser@host",
-            sku="automatic",
-        )
-        with self.assertRaises(MutuallyExclusiveArgumentError):
-            validators.validate_ssh_key(namespace)
-
-    def test_automatic_sku_with_default_path_ssh_key_value_errors(self):
-        # Even the default key path counts as an explicit --ssh-key-value now that the
-        # arg default is None.
-        import os
-        namespace = SimpleNamespace(
-            no_ssh_key=False,
-            generate_ssh_keys=False,
-            ssh_key_value=os.path.expanduser(os.path.join("~", ".ssh", "id_rsa.pub")),
             sku="automatic",
         )
         with self.assertRaises(MutuallyExclusiveArgumentError):


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
`az aks create ...`


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Following the [AKS Automatic quickstart](https://learn.microsoft.com/en-us/azure/aks/automatic/quick-automatic-managed-network?pivots=azure-cli), running az aks create --sku automatic fails with a server-side error:

(BadRequest) Managed cluster 'Automatic' SKU with managed system node pools enabled should not include SSH key configuration. Remove SSH key configuration and retry the request.

Automatic clusters use a fully managed system node pool that rejects any SSH key, so users were forced to manually add --no-ssh-key as a workaround. The CLI would also silently generate an SSH key pair on disk.

Fix: Make the CLI SSH-key-aware of the Automatic SKU:

**Testing Guide**
<!--Example commands with explanations.-->

(1) --sku automatic --ssh-key-value ~/.ssh/id_rsa.pub (default) |  ✅ Skip ssh key — no SSH error, proceeds to RG check
(2) --sku automatic --ssh-key-value "<real key>" (non-default) | ❌ Errors with message the Automatic don't support ssh key.
(3) --sku automatic (nothing) | ✅ don't generate ssh key
(4) --sku base | ✅ Proceeds — non-automatic unchanged



**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
