### PR TITLE
[Core] Enable native authentication broker on macOS, Linux, and WSL

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -5,6 +5,8 @@
 
 import os
 import os.path
+import platform
+import sys
 from copy import deepcopy
 from enum import Enum
 
@@ -12,7 +14,7 @@ from azure.cli.core._session import ACCOUNT
 from azure.cli.core.azclierror import AuthenticationError
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
 from azure.cli.core.auth.credential_adaptor import CredentialAdaptor
-from azure.cli.core.util import in_cloud_console, can_launch_browser, is_github_codespaces
+from azure.cli.core.util import in_cloud_console, can_launch_browser, is_github_codespaces, is_wsl
 from knack.log import get_logger
 from knack.util import CLIError
 
@@ -60,6 +62,20 @@ _USER_ASSIGNED_IDENTITY = 'userAssignedIdentity'
 _ASSIGNED_IDENTITY_INFO = 'assignedIdentityInfo'
 
 _AZ_LOGIN_MESSAGE = "Please run 'az login' to setup account."
+
+
+def _is_linux_broker_available():
+    if platform.machine().lower() not in ('amd64', 'x86_64'):
+        return False
+
+    from ctypes.util import find_library
+    required_libraries = ('secret-1', 'webkit2gtk-4.1')
+    missing_libraries = [library for library in required_libraries if not find_library(library)]
+    if missing_libraries:
+        logger.debug("Native authentication broker is unavailable; missing libraries: %s",
+                     ', '.join(missing_libraries))
+        return False
+    return True
 
 
 def load_subscriptions(cli_ctx, all_clouds=False, refresh=False):
@@ -973,10 +989,27 @@ def _create_identity_instance(cli_ctx, authority, tenant_id=None, client_id=None
     # EXPERIMENTAL: Use core.use_msal_http_cache=False to turn off MSAL HTTP cache.
     use_msal_http_cache = cli_ctx.config.getboolean('core', 'use_msal_http_cache', fallback=True)
 
-    # On Windows, use core.enable_broker_on_windows=false to disable broker (WAM) for authentication.
-    enable_broker_on_windows = cli_ctx.config.getboolean('core', 'enable_broker_on_windows', fallback=True)
+    broker_options = {
+        'enable_broker_on_windows': False,
+        'enable_broker_on_mac': False,
+        'enable_broker_on_linux': False,
+        'enable_broker_on_wsl': False,
+    }
+    if sys.platform == 'win32':
+        broker_option = 'enable_broker_on_windows'
+    elif sys.platform == 'darwin':
+        broker_option = 'enable_broker_on_mac'
+    elif sys.platform == 'linux' and _is_linux_broker_available():
+        broker_option = 'enable_broker_on_wsl' if is_wsl() else 'enable_broker_on_linux'
+    else:
+        broker_option = None
+
+    if broker_option:
+        # Use core.enable_broker_on_<platform>=false to disable the native authentication broker.
+        broker_options[broker_option] = cli_ctx.config.getboolean('core', broker_option, fallback=True)
+
     from .telemetry import set_broker_info
-    set_broker_info(enable_broker_on_windows)
+    set_broker_info(**broker_options)
 
     # PREVIEW: In Azure Stack environment, use core.instance_discovery=false to disable MSAL's instance discovery.
     instance_discovery = cli_ctx.config.getboolean('core', 'instance_discovery', True)
@@ -984,5 +1017,5 @@ def _create_identity_instance(cli_ctx, authority, tenant_id=None, client_id=None
     return Identity(authority, tenant_id=tenant_id, client_id=client_id,
                     encrypt=encrypt,
                     use_msal_http_cache=use_msal_http_cache,
-                    enable_broker_on_windows=enable_broker_on_windows,
+                    **broker_options,
                     instance_discovery=instance_discovery)

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -58,7 +58,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     _service_principal_store_instance = None
 
     def __init__(self, authority, tenant_id=None, client_id=None, encrypt=False, use_msal_http_cache=True,
-                 enable_broker_on_windows=None, instance_discovery=None):
+                 enable_broker_on_windows=None, enable_broker_on_mac=None, enable_broker_on_linux=None,
+                 enable_broker_on_wsl=None, instance_discovery=None):
         """
         :param authority: Authentication authority endpoint. For example,
             - AAD: https://login.microsoftonline.com
@@ -74,6 +75,9 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         self._encrypt = encrypt
         self._use_msal_http_cache = use_msal_http_cache
         self._enable_broker_on_windows = enable_broker_on_windows
+        self._enable_broker_on_mac = enable_broker_on_mac
+        self._enable_broker_on_linux = enable_broker_on_linux
+        self._enable_broker_on_wsl = enable_broker_on_wsl
         self._instance_discovery = instance_discovery
 
         # Build the authority in MSAL style
@@ -111,9 +115,12 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     @property
     def _msal_public_app_kwargs(self):
         """kwargs for creating PublicClientApplication."""
-        # enable_broker_on_windows can only be used on PublicClientApplication.
+        # Broker options can only be used on PublicClientApplication.
         return {**self._msal_app_kwargs,
                 "enable_broker_on_windows": self._enable_broker_on_windows,
+                "enable_broker_on_mac": self._enable_broker_on_mac,
+                "enable_broker_on_linux": self._enable_broker_on_linux,
+                "enable_broker_on_wsl": self._enable_broker_on_wsl,
                 "enable_pii_log": True}
 
     @property

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -45,6 +45,25 @@ with open(TEST_CERT) as f:
 
 class TestIdentity(unittest.TestCase):
 
+    def test_msal_public_app_kwargs_include_all_broker_options(self):
+        identity = Identity(
+            'https://login.microsoftonline.com',
+            enable_broker_on_windows=True,
+            enable_broker_on_mac=False,
+            enable_broker_on_linux=True,
+            enable_broker_on_wsl=False)
+
+        with mock.patch.object(Identity, '_msal_app_kwargs', new_callable=mock.PropertyMock,
+                               return_value={'base_option': 'value'}):
+            assert identity._msal_public_app_kwargs == {
+                'base_option': 'value',
+                'enable_broker_on_windows': True,
+                'enable_broker_on_mac': False,
+                'enable_broker_on_linux': True,
+                'enable_broker_on_wsl': False,
+                'enable_pii_log': True,
+            }
+
     @mock.patch("azure.cli.core.auth.identity.ServicePrincipalStore.save_entry")
     @mock.patch("msal.application.ConfidentialClientApplication.acquire_token_for_client")
     @mock.patch("msal.application.ConfidentialClientApplication.__init__", return_value=None)

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -77,6 +77,9 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.user_agent = None
         # authentication-related
         self.enable_broker_on_windows = None
+        self.enable_broker_on_mac = None
+        self.enable_broker_on_linux = None
+        self.enable_broker_on_wsl = None
         self.msal_telemetry = None
         self.login_experience_v2 = None
         self.agentic_session = False
@@ -238,6 +241,9 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'SecretNames', ','.join(self.secret_names or []))
         # authentication-related
         set_custom_properties(result, 'EnableBrokerOnWindows', str(self.enable_broker_on_windows))
+        set_custom_properties(result, 'EnableBrokerOnMac', str(self.enable_broker_on_mac))
+        set_custom_properties(result, 'EnableBrokerOnLinux', str(self.enable_broker_on_linux))
+        set_custom_properties(result, 'EnableBrokerOnWSL', str(self.enable_broker_on_wsl))
         set_custom_properties(result, 'MsalTelemetry', self.msal_telemetry)
         set_custom_properties(result, 'LoginExperienceV2', str(self.login_experience_v2))
         set_custom_properties(result, 'AgenticSession', str(self.agentic_session))
@@ -485,9 +491,11 @@ def set_region_identified(region_input, region_identified):
 
 # region authentication-related
 @decorators.suppress_all_exceptions()
-def set_broker_info(enable_broker_on_windows):
-    # Log the value of `enable_broker_on_windows`
+def set_broker_info(enable_broker_on_windows, enable_broker_on_mac, enable_broker_on_linux, enable_broker_on_wsl):
     _session.enable_broker_on_windows = enable_broker_on_windows
+    _session.enable_broker_on_mac = enable_broker_on_mac
+    _session.enable_broker_on_linux = enable_broker_on_linux
+    _session.enable_broker_on_wsl = enable_broker_on_wsl
 
 
 @decorators.suppress_all_exceptions()

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from unittest import mock
 
 from azure.cli.core._profile import (Profile, SubscriptionFinder, _attach_token_tenant,
-                                      _transform_subscription_for_multiapi,
+                                      _create_identity_instance, _transform_subscription_for_multiapi,
                                       _TENANT_LEVEL_ACCOUNT_NAME)
 from azure.cli.core.azclierror import AuthenticationError
 from azure.cli.core.auth.util import AccessToken
@@ -105,6 +105,47 @@ class ManagedIdentityCredentialStub:
 
 
 class TestProfile(unittest.TestCase):
+
+    @mock.patch('azure.cli.core.util.should_encrypt_token_cache', return_value=False)
+    @mock.patch('azure.cli.core.telemetry.set_broker_info')
+    @mock.patch('azure.cli.core.auth.identity.Identity')
+    def test_create_identity_instance_enables_broker_for_current_platform(
+            self, identity_mock, set_broker_info_mock, _):
+        cases = [
+            ('win32', False, True, 'enable_broker_on_windows'),
+            ('darwin', False, True, 'enable_broker_on_mac'),
+            ('linux', False, True, 'enable_broker_on_linux'),
+            ('linux', True, True, 'enable_broker_on_wsl'),
+            ('linux', False, False, None),
+            ('linux', True, False, None),
+        ]
+
+        cli_ctx = mock.MagicMock()
+        cli_ctx.config.getboolean.side_effect = lambda _section, _option, fallback=None: fallback
+
+        for platform_name, running_in_wsl, linux_broker_available, enabled_option in cases:
+            with self.subTest(platform=platform_name, running_in_wsl=running_in_wsl), \
+                    mock.patch('azure.cli.core._profile.sys.platform', platform_name), \
+                    mock.patch('azure.cli.core._profile.is_wsl', return_value=running_in_wsl), \
+                    mock.patch('azure.cli.core._profile._is_linux_broker_available',
+                               return_value=linux_broker_available):
+                identity_mock.reset_mock()
+                set_broker_info_mock.reset_mock()
+
+                _create_identity_instance(cli_ctx, 'https://login.microsoftonline.com')
+
+                expected_broker_options = {
+                    'enable_broker_on_windows': False,
+                    'enable_broker_on_mac': False,
+                    'enable_broker_on_linux': False,
+                    'enable_broker_on_wsl': False,
+                }
+                if enabled_option:
+                    expected_broker_options[enabled_option] = True
+                identity_kwargs = identity_mock.call_args.kwargs
+                for option, expected_value in expected_broker_options.items():
+                    assert identity_kwargs[option] is expected_value
+                set_broker_info_mock.assert_called_once_with(**expected_broker_options)
 
     @classmethod
     def setUpClass(cls):

--- a/src/azure-cli-core/azure/cli/core/tests/test_telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_telemetry.py
@@ -8,6 +8,22 @@ from unittest import mock
 
 
 class TestCoreTelemetry(unittest.TestCase):
+    def test_set_broker_info(self):
+        from azure.cli.core import telemetry
+
+        session = mock.MagicMock()
+        with mock.patch.object(telemetry, '_session', session):
+            telemetry.set_broker_info(
+                enable_broker_on_windows=True,
+                enable_broker_on_mac=False,
+                enable_broker_on_linux=True,
+                enable_broker_on_wsl=False)
+
+        self.assertTrue(session.enable_broker_on_windows)
+        self.assertFalse(session.enable_broker_on_mac)
+        self.assertTrue(session.enable_broker_on_linux)
+        self.assertFalse(session.enable_broker_on_wsl)
+
     def test_suppress_all_exceptions(self):
         self._impl(Exception, 'fallback')
         self._impl(Exception, None)
@@ -79,4 +95,3 @@ class TestCoreTelemetry(unittest.TestCase):
         self.assertEqual(session.command, "")
         self.assertEqual(session.parameters, ["--version"])
         self.assertIsNone(session.raw_command)
-

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -57,7 +57,10 @@ DEPENDENCIES = [
     'microsoft-security-utilities-secret-masker~=1.0.0b4',
     'msal-extensions==1.3.1',
     'msal[broker]==1.36.0; sys_platform == "win32"',
-    'msal==1.36.0; sys_platform != "win32"',
+    'msal[broker]==1.36.0; sys_platform == "darwin"',
+    'msal[broker]==1.36.0; sys_platform == "linux" and platform_machine == "x86_64"',
+    'msal==1.36.0; sys_platform == "linux" and platform_machine != "x86_64"',
+    'msal==1.36.0; sys_platform != "win32" and sys_platform != "darwin" and sys_platform != "linux"',
     'packaging>=20.9',
     # pkginfo>=1.12.0 reads the spec-defined wheel METADATA / unpacked .dist-info
     # layout produced by modern wheel/setuptools (no metadata.json). Required so

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -12,8 +12,8 @@ type: command
 short-summary: Log in to Azure.
 long-summary: >-
     By default, this command logs in with a user account.
-    Azure CLI uses Web Account Manager (WAM) on Windows, and browser-based login on Linux and macOS by default.
-    If WAM or a web browser is not available, Azure CLI will fall back to device code login.
+    Azure CLI uses the native authentication broker on Windows, macOS, Linux, and WSL when available,
+    and browser-based login otherwise. If neither is available, Azure CLI will fall back to device code login.
 
 
     [WARNING] Authentication with username and password in the command line is strongly discouraged.

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -111,7 +111,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.14.0
 msal-extensions==1.3.1
-msal==1.36.0
+msal[broker]==1.36.0
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0
@@ -123,6 +123,7 @@ psutil==6.1.0
 pycomposefile==0.0.34
 PyGithub==1.55
 PyJWT==2.13.0
+pymsalruntime==0.20.6
 PyNaCl==1.6.2
 pyOpenSSL==26.0.0
 PySocks==1.7.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -112,7 +112,8 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.14.0
 msal-extensions==1.3.1
-msal==1.36.0
+msal[broker]==1.36.0; platform_machine == "x86_64"
+msal==1.36.0; platform_machine != "x86_64"
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0
@@ -124,6 +125,7 @@ psutil==6.1.0
 pycomposefile==0.0.34
 PyGithub==1.55
 PyJWT==2.13.0
+pymsalruntime==0.20.6; platform_machine == "x86_64"
 PyNaCl==1.6.2
 pyOpenSSL==26.0.0
 PySocks==1.7.1


### PR DESCRIPTION

**Related command**

`az login`

**Description**

Azure CLI currently enables MSAL's native Web Account Manager broker on Windows, but uses browser authentication by default on macOS, Linux, and WSL. MSAL 1.36 supports native brokers on all four platforms.

Fixes: #33842

This change:

- enables the matching MSAL broker option for Windows, macOS, standalone Linux, or WSL;
- keeps the existing `core.enable_broker_on_windows` behavior and adds equivalent per-platform opt-out settings;
- installs `msal[broker]` and `pymsalruntime` for macOS and supported Linux systems;
- keeps regular MSAL on Linux ARM64 because `pymsalruntime` does not currently publish Linux ARM64 wheels; https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/949
- checks for `libsecret-1` and `libwebkit2gtk-4.1` before enabling the Linux/WSL broker, preserving browser and device-code fallback when native prerequisites are unavailable;
- passes broker options only to `PublicClientApplication`, leaving service-principal and managed-identity authentication unchanged;
- adds per-platform broker telemetry and updates `az login` help.

The following settings disable broker authentication for their respective platforms:

```console
az config set core.enable_broker_on_mac=false
az config set core.enable_broker_on_linux=false
az config set core.enable_broker_on_wsl=false
```

**Testing Guide**

Automated validation:

- 68 identity and profile tests passed.
- 5 core telemetry tests passed.
- Focused broker option propagation and platform-routing tests passed.
- Dependency markers were evaluated for Linux x86_64 and ARM64.

WSL validation:

- Ubuntu 24.04 with `libsecret-1`, `libwebkit2gtk-4.1`, and `pymsalruntime` initialized the native WSL broker and completed broker account discovery.

Manual WSL verification:

```console
sudo apt install libsecret-1-0 libwebkit2gtk-4.1-0
az account clear
az login
az account show
```

Verify the opt-out path:

```console
az config set core.enable_broker_on_wsl=false
az account clear
az login
```

**History Notes**


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
