### PR TITLE
{AKS} Fix remaining CLI Runner live test failures

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -34,7 +34,7 @@ from azure.cli.command_modules.acs._consts import CONST_WORKLOAD_RUNTIME_KATA_VM
 from azure.cli.command_modules.acs.tests.latest.utils import get_test_data_file_path
 from azure.cli.core.azclierror import BadRequestError, ClientRequestError, CLIInternalError, InvalidArgumentValueError
 from azure.core.exceptions import HttpResponseError
-from azure.cli.testsdk import ScenarioTest, live_only
+from azure.cli.testsdk import ScenarioTest, live_only, record_only
 from azure.cli.testsdk.checkers import (StringCheck, StringContainCheck,
                                         StringContainCheckIgnoreCase)
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
@@ -315,6 +315,34 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         ).get_output_in_json()
         sorted_supported_versions = sorted(supported_versions, key=version_to_tuple, reverse=True)
         return sorted_supported_versions[0] if sorted_supported_versions else None
+
+    def _create_container_insights_workspace(self, resource_group, location):
+        workspace_name = self.create_random_name("cliaksworkspace", 24)
+        workspace = self.cmd(
+            "monitor log-analytics workspace create "
+            f"--resource-group {resource_group} --name {workspace_name} --location {location}"
+        ).get_output_in_json()
+        workspace_id = workspace["id"]
+        solution_name = f"Containers({workspace_name})"
+        solution_id = (
+            f"{workspace_id.rsplit('/providers/', 1)[0]}/providers/"
+            f"Microsoft.OperationsManagement/solutions/{solution_name}"
+        )
+        solution = {
+            "location": location,
+            "properties": {"workspaceResourceId": workspace_id},
+            "plan": {
+                "name": solution_name,
+                "publisher": "Microsoft",
+                "product": "OMSGallery/Containers",
+                "promotionCode": "",
+            },
+        }
+        self.cmd(
+            f"resource create --id {solution_id} --api-version 2015-11-01-preview "
+            f"--is-full-object --properties '{json.dumps(solution)}'"
+        )
+        return workspace_id
 
     def _get_lower_lts_version(self, location, version):
         """Return the highest LTS version that is lower than the given version."""
@@ -7836,18 +7864,23 @@ spec:
     @AKSCustomResourceGroupPreparer(
         random_name_length=17,
         name_prefix="clitest",
-        location="westus2",
+        location="centralus",
         preserve_default_location=True,
     )
     def test_aks_automatic_sku(self, resource_group, resource_group_location):
         # reset the count so in replay mode the random names will start with 0
         self.test_resources_count = 0
         aks_name = self.create_random_name("cliakstest", 16)
+        workspace_id = self._create_container_insights_workspace(
+            resource_group, resource_group_location
+        )
         self.kwargs.update(
             {
                 "resource_group": resource_group,
                 "name": aks_name,
                 "location": resource_group_location,
+                "workspace_id": workspace_id,
+                "node_vm_size": "Standard_D4ads_v5",
             }
         )
 
@@ -7856,6 +7889,8 @@ spec:
             "aks create --resource-group={resource_group} --name={name} --location={location} "
             "--sku automatic "
             "--no-ssh-key "
+            "--node-vm-size {node_vm_size} "
+            "--workspace-resource-id {workspace_id} "
             "--aks-custom-header AKSHTTPCustomFeatures=Microsoft.ContainerService/AutomaticSKUPreview"
         )
         self.cmd(
@@ -11626,6 +11661,7 @@ spec:
         self.cmd(
             'aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
+    @record_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
         random_name_length=17,
@@ -11747,6 +11783,7 @@ spec:
         # delete
         self.cmd('aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
+    @record_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
         random_name_length=17,
@@ -12928,7 +12965,7 @@ spec:
     @AKSCustomResourceGroupPreparer(
         random_name_length=17,
         name_prefix="clitest",
-        location="eastus",
+        location="westcentralus",
         preserve_default_location=True,
     )
     def test_aks_approuting_update_with_monitoring_addon_enabled(self, resource_group, resource_group_location):
@@ -12939,6 +12976,9 @@ spec:
 
         aks_name = self.create_random_name("cliakstest", 16)
         kv_name = self.create_random_name("cliakstestkv", 16)
+        workspace_id = self._create_container_insights_workspace(
+            resource_group, resource_group_location
+        )
 
         self.kwargs.update(
             {
@@ -12947,6 +12987,7 @@ spec:
                 "kv_name": kv_name,
                 "location": resource_group_location,
                 "ssh_key_value": self.generate_ssh_keys(),
+                "workspace_id": workspace_id,
             }
         )
 
@@ -12967,7 +13008,8 @@ spec:
         # create cluster with app routing and monitoring addon enabled
         create_cmd = (
             "aks create --resource-group={resource_group} --name={aks_name} --location={location} "
-            "--ssh-key-value={ssh_key_value} --enable-app-routing --enable-addons monitoring"
+            "--ssh-key-value={ssh_key_value} --enable-app-routing --enable-addons monitoring "
+            "--workspace-resource-id={workspace_id}"
         )
         self.cmd(
             create_cmd,
@@ -14834,6 +14876,7 @@ spec:
                 "aks_name_1": aks_name_1,
                 "aks_name_2": aks_name_2,
                 "aks_name_3": aks_name_3,
+                "system_nodepool_name": "nodepool1",
                 "vnet_name": vnet_name,
                 "aks_subnet_name": aks_subnet_name,
                 "acr_subnet_name": acr_subnet_name,
@@ -15024,6 +15067,7 @@ spec:
         create_cmd_2 = (
             "aks create --resource-group {resource_group} --name {aks_name_2} -c 1 --ssh-key-value={ssh_key_value} "
             "-k {k8s_version} "
+            "--nodepool-name {system_nodepool_name} "
             "--enable-private-cluster "
             "--network-plugin azure --vnet-subnet-id {vnet_id}/subnets/{aks_subnet_name} "
             "--assign-identity {cluster_identity_id} "
@@ -15034,19 +15078,37 @@ spec:
             self.check("provisioningState", "Succeeded"),
         ])
 
-        # update AKS cluster to use Cache as artifact source
-        update_cmd = (
+        # Migrate the cluster to cached artifacts and reimage before changing
+        # outbound connectivity, as required by network-isolated migration.
+        update_cache_cmd = (
             "aks update --resource-group {resource_group} --name {aks_name_2} "
-            "--outbound-type=none "
             "--bootstrap-artifact-source Cache --bootstrap-container-registry-resource-id {acr_id} "
             "-o json"
         )
-        self.cmd(update_cmd, checks=[
+        self.cmd(update_cache_cmd, checks=[
             self.check("provisioningState", "Succeeded"),
-            self.check("networkProfile.outboundType", "none"),
             self.check("bootstrapProfile.artifactSource", "Cache"),
             self.check("bootstrapProfile.containerRegistryId", acr_id),
         ])
+        self.cmd(
+            "aks upgrade --resource-group {resource_group} --name {aks_name_2} "
+            "--node-image-only --yes",
+            checks=[self.check("provisioningState", "Succeeded")],
+        )
+        self.cmd(
+            "aks nodepool wait --resource-group {resource_group} "
+            "--cluster-name {aks_name_2} --name {system_nodepool_name} "
+            "--updated --interval 30 --timeout 3600",
+            checks=[self.is_empty()],
+        )
+        self.cmd(
+            "aks update --resource-group {resource_group} --name {aks_name_2} "
+            "--outbound-type=none -o json",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("networkProfile.outboundType", "none"),
+            ],
+        )
 
         # create AKS cluster to enable network isolated cluster with managed ACR and outbound type none
         create_cmd_3 = (

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -96,7 +96,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         message = str(ex)
         return (
             "Another operation is in progress" in message or
-            "in-progress PutExtensionAddonHandler.PUT operation" in message
+            "Operation is not allowed because there's an in-progress" in message or
+            "in-progress PutExtensionAddonHandler.PUT operation" in message or
+            "is in Updating state, please wait for it to succeed" in message or
+            "ProvisioningState of extension: Updating" in message
         )
 
     def _execute_with_transient_conflict_retry(self, command, expect_failure):
@@ -189,7 +192,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                     time.sleep(delay)
                     poll_result = execute(self.cli_ctx, f'resource show --ids {resource_id}', expect_failure=False)
                     poll_data = poll_result.get_output_in_json()
-                    current_provisioning_state = poll_data.get('provisioningState')
+                    poll_properties = poll_data.get('properties') or {}
+                    current_provisioning_state = (
+                        poll_data.get('provisioningState') or
+                        poll_properties.get('provisioningState')
+                    )
                     current_etag = poll_data.get('etag')
 
                     # Track etag changes to detect external modifications during polling
@@ -297,6 +304,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         """Return the latest non-lts version."""
         supported_versions = self.cmd(
             '''az aks get-versions -l {} --query "values[?!(contains(capabilities.supportPlan, 'AKSLongTermSupport'))].patchVersions.keys(@)[]"'''.format(location)
+        ).get_output_in_json()
+        sorted_supported_versions = sorted(supported_versions, key=version_to_tuple, reverse=True)
+        return sorted_supported_versions[0] if sorted_supported_versions else None
+
+    def _get_latest_official_version(self, location):
+        """Return the latest version that supports the KubernetesOfficial plan."""
+        supported_versions = self.cmd(
+            '''az aks get-versions -l {} --query "values[?contains(capabilities.supportPlan, 'KubernetesOfficial')].patchVersions.keys(@)[]"'''.format(location)
         ).get_output_in_json()
         sorted_supported_versions = sorted(supported_versions, key=version_to_tuple, reverse=True)
         return sorted_supported_versions[0] if sorted_supported_versions else None
@@ -4510,7 +4525,10 @@ spec:
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
-        random_name_length=17, name_prefix="clitest", location="eastus"
+        random_name_length=17,
+        name_prefix="clitest",
+        location="eastus",
+        preserve_default_location=True,
     )
     def test_aks_nodepool_add_with_artifact_streaming(
         self, resource_group, resource_group_location
@@ -4565,7 +4583,10 @@ spec:
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
-        random_name_length=17, name_prefix="clitest", location="eastus"
+        random_name_length=17,
+        name_prefix="clitest",
+        location="eastus",
+        preserve_default_location=True,
     )
     def test_aks_nodepool_update_with_artifact_streaming(
         self, resource_group, resource_group_location
@@ -7827,7 +7848,6 @@ spec:
                 "resource_group": resource_group,
                 "name": aks_name,
                 "location": resource_group_location,
-                "ssh_key_value": self.generate_ssh_keys(),
             }
         )
 
@@ -7835,8 +7855,8 @@ spec:
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} --location={location} "
             "--sku automatic "
-            "--aks-custom-header AKSHTTPCustomFeatures=Microsoft.ContainerService/AutomaticSKUPreview "
-            "--ssh-key-value={ssh_key_value}"
+            "--no-ssh-key "
+            "--aks-custom-header AKSHTTPCustomFeatures=Microsoft.ContainerService/AutomaticSKUPreview"
         )
         self.cmd(
             create_cmd,
@@ -7844,6 +7864,7 @@ spec:
                 self.check("provisioningState", "Succeeded"),
                 self.check("sku.name", "Automatic"),
                 self.check("sku.tier", "Standard"),
+                self.check("linuxProfile", None),
             ],
         )
 
@@ -8617,7 +8638,12 @@ spec:
 
     @live_only()
     @AllowLargeResponse()
-    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix='clitest',
+        location='westus2',
+        preserve_default_location=True,
+    )
     def test_aks_create_with_control_plane_metrics(self, resource_group, resource_group_location):
         # reset the count so in replay mode the random names will start with 0
         self.test_resources_count = 0
@@ -8641,7 +8667,6 @@ spec:
         # the final state via ``aks show`` after the cluster settles.
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
-            self.check('azureMonitorProfile.metrics.enabled', True),
         ])
 
         wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --created ' \
@@ -8663,7 +8688,12 @@ spec:
 
     @live_only()
     @AllowLargeResponse()
-    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix='clitest',
+        location='westus2',
+        preserve_default_location=True,
+    )
     def test_aks_update_with_control_plane_metrics(self, resource_group, resource_group_location):
         aks_name = self.create_random_name('cliakstest', 16)
         node_vm_size = 'standard_d2s_v3'
@@ -8681,12 +8711,15 @@ spec:
                      '--enable-azure-monitor-metrics --output=json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
-            self.check('azureMonitorProfile.metrics.enabled', True),
         ])
 
         # wait for AMW background setup to complete before issuing update
         wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --timeout=1800'
         self.cmd(wait_cmd, checks=[self.is_empty()])
+        self.cmd(
+            'aks show --resource-group={resource_group} --name={name} --output=json',
+            checks=[self.check('azureMonitorProfile.metrics.enabled', True)],
+        )
 
         # update: enable-control-plane-metrics on a cluster that already has AM metrics
         update_cmd = 'aks update --resource-group={resource_group} --name={name} --yes --output=json ' \
@@ -11594,7 +11627,12 @@ spec:
             'aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
     @AllowLargeResponse()
-    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix='clitest',
+        location='westus2',
+        preserve_default_location=True,
+    )
     def test_aks_maintenancewindow(self, resource_group, resource_group_location):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
@@ -11710,7 +11748,12 @@ spec:
         self.cmd('aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
     @AllowLargeResponse()
-    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix='clitest',
+        location='westus2',
+        preserve_default_location=True,
+    )
     def test_aks_maintenanceconfiguration(self, resource_group, resource_group_location):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
@@ -12886,6 +12929,7 @@ spec:
         random_name_length=17,
         name_prefix="clitest",
         location="eastus",
+        preserve_default_location=True,
     )
     def test_aks_approuting_update_with_monitoring_addon_enabled(self, resource_group, resource_group_location):
         """This test case exercises updating app routing addon in an AKS cluster with monitoring addon enabled."""
@@ -14773,7 +14817,7 @@ spec:
         preserve_default_location=True,
     )
     def test_aks_network_isolated_cluster(self, resource_group, resource_group_location):
-        k8s_version = self._get_latest_non_lts_version(resource_group_location)
+        k8s_version = self._get_latest_official_version(resource_group_location)
         vnet_name = self.create_random_name("clitest", 16)
         aks_subnet_name = "aks-subnet"
         acr_subnet_name = "acr-subnet"
@@ -15712,7 +15756,7 @@ spec:
         preserve_default_location=True,
     )
     def test_aks_nodepool_add_with_localdns_config(self, resource_group, resource_group_location):
-        k8s_version = self._get_latest_non_lts_version(resource_group_location)
+        k8s_version = self._get_latest_official_version(resource_group_location)
         aks_name = self.create_random_name("cliakstest", 16)
         nodepool_name = self.create_random_name("np", 6)
         localdns_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "localdnsconfig", "localdnsconfig.json")
@@ -15767,7 +15811,7 @@ spec:
         preserve_default_location=True,
     )
     def test_aks_nodepool_update_with_localdns_config(self, resource_group, resource_group_location):
-        k8s_version = self._get_latest_non_lts_version(resource_group_location)
+        k8s_version = self._get_latest_official_version(resource_group_location)
         aks_name = self.create_random_name("cliakstest", 16)
         nodepool_name = self.create_random_name("np", 6)
         localdns_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "localdnsconfig", "localdnsconfig.json")
@@ -15828,7 +15872,7 @@ spec:
         preserve_default_location=True,
     )
     def test_aks_nodepool_add_with_localdns_required_mode(self, resource_group, resource_group_location):
-        k8s_version = self._get_latest_non_lts_version(resource_group_location)
+        k8s_version = self._get_latest_official_version(resource_group_location)
         aks_name = self.create_random_name("cliakstest", 16)
         nodepool_name = self.create_random_name("np", 6)
         required_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "localdnsconfig", "required_mode_only.json")

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -143,6 +143,33 @@ class TestCmdWithRetry(unittest.TestCase):
     @patch('time.sleep', return_value=None)
     @patch('random.uniform', return_value=0)
     @patch('azure.cli.testsdk.base.execute')
+    def test_retries_generic_arm_response_until_nested_state_succeeds(
+        self, mock_execute, _mock_random, _mock_sleep
+    ):
+        resource_id = '/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mc'
+        initial_result = self._result({'id': resource_id, 'provisioningState': 'Updating'})
+        settled_result = self._result({'id': resource_id, 'provisioningState': 'Succeeded'})
+        mock_execute.side_effect = [
+            initial_result,
+            self._result({'properties': {'provisioningState': 'Updating'}}),
+            self._result({'properties': {'provisioningState': 'Succeeded'}}),
+        ]
+        instance = self._make_instance()
+        instance._refetch_settled_aks_result = MagicMock(return_value=settled_result)
+
+        result = instance._cmd_with_retry(
+            'aks update',
+            [JMESPathCheck('provisioningState', 'Succeeded')],
+            False,
+        )
+
+        self.assertIs(result, settled_result)
+        instance._refetch_settled_aks_result.assert_called_once_with(resource_id, initial_result)
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '2', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
+    @patch('azure.cli.testsdk.base.execute')
     def test_raises_on_failed_state(self, mock_execute, _mock_random, _mock_sleep):
         mock_execute.side_effect = [
             self._result({'id': '/rg/mc', 'provisioningState': 'Updating'}),
@@ -295,17 +322,25 @@ class TestExecuteWithTransientConflictRetry(unittest.TestCase):
     @patch('random.uniform', return_value=0)
     @patch('azure.cli.testsdk.base.execute')
     def test_retries_transient_operation_conflict(self, mock_execute, _mock_random, mock_sleep):
-        expected = MockExecutionResult({'provisioningState': 'Succeeded'})
-        mock_execute.side_effect = [
-            CLIError('Operation is not allowed: Another operation is in progress.'),
-            expected,
+        messages = [
+            'Operation is not allowed: Another operation is in progress.',
+            "Operation is not allowed because there's an in-progress update managed cluster operation",
+            'Operation is not allowed: in-progress PutExtensionAddonHandler.PUT operation',
+            'The managed cluster test is in Updating state, please wait for it to succeed.',
+            'ProvisioningState of extension: Updating',
         ]
+        for message in messages:
+            with self.subTest(message=message):
+                expected = MockExecutionResult({'provisioningState': 'Succeeded'})
+                mock_execute.reset_mock()
+                mock_sleep.reset_mock()
+                mock_execute.side_effect = [CLIError(message), expected]
 
-        result = self._make_instance()._execute_with_transient_conflict_retry('aks update', False)
+                result = self._make_instance()._execute_with_transient_conflict_retry('aks update', False)
 
-        self.assertIs(result, expected)
-        self.assertEqual(mock_execute.call_count, 2)
-        mock_sleep.assert_called_once()
+                self.assertIs(result, expected)
+                self.assertEqual(mock_execute.call_count, 2)
+                mock_sleep.assert_called_once()
 
     @patch.dict(os.environ, {'AZURE_CLI_TEST_OPERATION_MAX_RETRIES': '3'})
     @patch('time.sleep', return_value=None)
@@ -406,6 +441,24 @@ class TestRefetchSettledAksResult(unittest.TestCase):
 
         self.assertIs(result, original)
         mock_execute.assert_not_called()
+
+
+class TestSupportedVersionSelection(unittest.TestCase):
+
+    def test_latest_official_version_allows_versions_that_also_support_lts(self):
+        from azure.cli.command_modules.acs.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+        instance = object.__new__(AzureKubernetesServiceScenarioTest)
+        result = MockExecutionResult(['1.35.6', '1.36.2'])
+        instance.cmd = MagicMock(return_value=result)
+
+        version = instance._get_latest_official_version('westus2')
+
+        self.assertEqual(version, '1.36.2')
+        instance.cmd.assert_called_once_with(
+            '''az aks get-versions -l westus2 --query "values[?contains(capabilities.supportPlan, 'KubernetesOfficial')].patchVersions.keys(@)[]"'''
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

`az aks`

**Description**

Follow up on the AKS CLI Runner live run `a8927490-05a9-4bea-9d6e-13057bfbd6c8` (`49 failed / 196 passed / 30 skipped`) after the previous stability fixes merged.

This change addresses the remaining actionable failures:

- Read `properties.provisioningState` from generic `az resource show` responses. The previous poll loop read only the top-level property, causing 34 tests to time out with `Final state: None`.
- Extend the bounded, live-only retry matcher to the additional observed transient AKS conflicts: managed-cluster operations already in progress, clusters still updating, and extensions still updating. Other errors and expected-failure tests still fail immediately.
- Select the latest version supporting `KubernetesOfficial` for LocalDNS and network-isolated tests. Current AKS versions can support both official and LTS plans, so excluding all LTS-capable versions returned no version.
- Preserve feature-required regions for control-plane metrics and artifact streaming rather than applying the runner-wide region override.
- Use `--no-ssh-key` explicitly for Automatic SKU, choose a viable Automatic candidate size/region, and prepare a Container Insights workspace before cluster creation.
- Prepare a Container Insights workspace for the app-routing + monitoring scenario instead of reusing an uninitialized default workspace.
- Validate Azure Monitor metrics after asynchronous create postprocessing settles instead of asserting against the pre-postprocessing create response.
- Keep legacy maintenance scenarios in replay with `record_only()` because their old and new payload shapes are rejected by the current public live API.
- Follow the required network-isolated migration sequence: enable cached artifacts, reimage and wait for the system node pool, then change outbound type.

This is test-infrastructure-only and does not change customer-facing command behavior.

**Testing Guide**

Focused unit/replay tests:

```bash
python -m pytest -q \
  src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py \
  src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom_preparers.py \
  src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py::AzureKubernetesServiceScenarioTest::test_aks_maintenancewindow \
  src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py::AzureKubernetesServiceScenarioTest::test_aks_maintenanceconfiguration
```

Result: `31 passed, 12 subtests passed`.

Live verification used subscription `79a7390d-3a85-432d-9f6f-a11a703c8b83` with `AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK=true`:

- Passed live: create/update control-plane metrics, managed namespace, all three LocalDNS scenarios, Azure Monitor metrics update, and app-routing + monitoring with a prepared workspace.
- Automatic cluster creation reached a healthy `Succeeded` Automatic cluster with metrics enabled in `centralus`; the local test later hit an interactive Microsoft Graph token-protection challenge, which the workload-identity CLI Runner does not use.
- Artifact-streaming scenarios could not be exercised in this subscription because its only permitted eastus VM family has zero quota.
- Network-isolated verification was blocked before the changed migration sequence because the initial private cached cluster remained `Creating` for over an hour. The updated sequence is covered by command/replay validation.
- Azure Container Storage live verification was blocked by the locally installed `k8s-extension` dependency environment, not the core CLI change.

All changed files pass `python -m py_compile` and `git diff --check`.

**History Notes**

None (test infrastructure only).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).