### PR TITLE
[profile] Enable token cache encryption on MacOS and Linux

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -183,7 +183,11 @@ class Profile:
             else:
                 identity.login_with_service_principal(username, password, scopes=scopes)
 
-        # We have finished login. Let's find all subscriptions.
+        # We have finished login. Warn once here if credentials fell back to plaintext.
+        from .auth.persistence import warn_if_encryption_unavailable
+        warn_if_encryption_unavailable()
+
+        # Let's find all subscriptions.
         if show_progress:
             message = ('Retrieving subscriptions for the selection...' if tenant else
                        'Retrieving tenants and subscriptions for the selection...')

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -230,7 +230,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     def logout_all_service_principal(self):
         # remove service principal secrets
         # MSAL provides no interface to enumerate the service principals in its token cache, so
-        # their access tokens are cleared by logout_all_users emptying the whole token cache.
+        # their access tokens are cleared by logout_all_users emptying the whole sp secret store
         erase_persistence(self._secret_file, self._encrypt, type="Secret store",
                           empty_payload='[]')
 

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -210,11 +210,12 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         for account in accounts:
             self._msal_app.remove_account(account)
 
-        # Empty the payload, then remove the files. MSAL only removes the accounts it knows about,
-        # and on Linux and macOS the credential lives in the OS keychain, where removing the
-        # signal file would leave it behind.
+        # MSAL only removes the accounts it knows about, and on Linux and macOS the credential
+        # lives in the OS keychain, so the payload has to be emptied, not just deleted.
+        # Every auth type has a token cache, but only service principals have a secret store, so
+        # this is the one location that warns about what the keychain may still hold.
         erase_persistence(self._token_cache_file, self._encrypt, type="Token cache",
-                          empty_payload='{}')
+                          empty_payload='{}', warn_if_credentials_may_remain=True)
 
     def logout_service_principal(self, client_id):
         # If client_id is a username, it is ignored
@@ -228,9 +229,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         self._service_principal_store.remove_entry(client_id)
 
     def logout_all_service_principal(self):
-        # remove service principal secrets
         # MSAL provides no interface to enumerate the service principals in its token cache, so
-        # their access tokens are cleared by logout_all_users emptying the whole sp secret store
+        # their access tokens are cleared by logout_all_users emptying the whole sp secret store.
         erase_persistence(self._secret_file, self._encrypt, type="Secret store",
                           empty_payload='[]')
 

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -15,8 +15,7 @@ from msal import PublicClientApplication, ConfidentialClientApplication
 
 from .constants import AZURE_CLI_CLIENT_ID
 from .msal_credentials import UserCredential, ServicePrincipalCredential
-from .persistence import (load_persisted_token_cache, file_extensions, load_secret_store,
-                          erase_persistence)
+from .persistence import load_persisted_token_cache, load_secret_store, erase_persistence
 from .util import check_result
 
 # Service principal entry properties. Names are taken from OAuth 2.0 client credentials flow parameters:
@@ -211,15 +210,11 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         for account in accounts:
             self._msal_app.remove_account(account)
 
-        # Empty the payload before removing the files. MSAL only removes the accounts it knows
-        # about, and on Linux and macOS the credential lives in the OS keychain, where removing
-        # the signal file would leave it behind.
+        # Empty the payload, then remove the files. MSAL only removes the accounts it knows about,
+        # and on Linux and macOS the credential lives in the OS keychain, where removing the
+        # signal file would leave it behind.
         erase_persistence(self._token_cache_file, self._encrypt, type="Token cache",
                           empty_payload='{}')
-
-        # Also remove token cache file
-        for e in file_extensions:
-            _try_remove(self._token_cache_file + e)
 
     def logout_service_principal(self, client_id):
         # If client_id is a username, it is ignored
@@ -238,9 +233,6 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         # their access tokens are cleared by logout_all_users emptying the whole token cache.
         erase_persistence(self._secret_file, self._encrypt, type="Secret store",
                           empty_payload='[]')
-
-        for e in file_extensions:
-            _try_remove(self._secret_file + e)
 
     def get_user(self, user=None):
         accounts = self._msal_app.get_accounts(user) if user else self._msal_app.get_accounts()
@@ -439,13 +431,6 @@ def _get_authority_url(authority_endpoint, tenant):
     else:
         authority_url = '{}/{}'.format(authority_endpoint, tenant or "organizations")
     return authority_url, is_adfs
-
-
-def _try_remove(path):
-    try:
-        os.remove(path)
-    except FileNotFoundError:
-        pass
 
 
 def get_environment_credential():

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -211,7 +211,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
             self._msal_app.remove_account(account)
 
         # Also remove token cache file
-        for e in file_extensions.values():
+        for e in file_extensions:
             _try_remove(self._token_cache_file + e)
 
     def logout_service_principal(self, client_id):
@@ -229,7 +229,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         # remove service principal secrets
         # TODO: As MSAL provides no interface to get all service principals in its token cache, this method can't
         #   clear all service principals' access tokens from MSAL token cache.
-        for e in file_extensions.values():
+        for e in file_extensions:
             _try_remove(self._secret_file + e)
 
     def get_user(self, user=None):

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -15,7 +15,8 @@ from msal import PublicClientApplication, ConfidentialClientApplication
 
 from .constants import AZURE_CLI_CLIENT_ID
 from .msal_credentials import UserCredential, ServicePrincipalCredential
-from .persistence import load_persisted_token_cache, file_extensions, load_secret_store
+from .persistence import (load_persisted_token_cache, file_extensions, load_secret_store,
+                          erase_persistence)
 from .util import check_result
 
 # Service principal entry properties. Names are taken from OAuth 2.0 client credentials flow parameters:
@@ -210,6 +211,12 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         for account in accounts:
             self._msal_app.remove_account(account)
 
+        # Empty the payload before removing the files. MSAL only removes the accounts it knows
+        # about, and on Linux and macOS the credential lives in the OS keychain, where removing
+        # the signal file would leave it behind.
+        erase_persistence(self._token_cache_file, self._encrypt, type="Token cache",
+                          empty_payload='{}')
+
         # Also remove token cache file
         for e in file_extensions:
             _try_remove(self._token_cache_file + e)
@@ -227,8 +234,11 @@ class Identity:  # pylint: disable=too-many-instance-attributes
 
     def logout_all_service_principal(self):
         # remove service principal secrets
-        # TODO: As MSAL provides no interface to get all service principals in its token cache, this method can't
-        #   clear all service principals' access tokens from MSAL token cache.
+        # MSAL provides no interface to enumerate the service principals in its token cache, so
+        # their access tokens are cleared by logout_all_users emptying the whole token cache.
+        erase_persistence(self._secret_file, self._encrypt, type="Secret store",
+                          empty_payload='[]')
+
         for e in file_extensions:
             _try_remove(self._secret_file + e)
 

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -83,10 +83,12 @@ def build_persistence(location, encrypt, type=None):  # pylint: disable=redefine
             logger.debug("Initializing LibsecretPersistence: location=%r", path)
             try:
                 attributes = {"type": type} if type else {}
+                label = f"{LIBSECRET_SCHEMA_NAME} - {type}" if type else LIBSECRET_SCHEMA_NAME
                 return LibsecretPersistence(
                     path,
                     schema_name=LIBSECRET_SCHEMA_NAME,
-                    attributes=attributes
+                    attributes=attributes,
+                    label=label
                 )
             except Exception as e:  # pylint: disable=broad-except
                 # LibsecretPersistence is known to be unavailable in some Linux environments.

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -28,6 +28,15 @@ file_extensions = [file_extension_encrypted, file_extension_plaintext, file_exte
 KEYCHAIN_SERVICE_NAME = 'Microsoft Azure CLI'
 LIBSECRET_SCHEMA_NAME = 'Microsoft Azure CLI'
 
+ENCRYPTION_FALLBACK_WARNING = (
+    "Encryption is unavailable on this machine, so the token cache and service principal secrets "
+    "are stored in plaintext. "
+    "Please follow https://aka.ms/azure-cli-credential-encryption to enable encryption.")
+
+# Set when a persistence falls back to plaintext, so sign-in can warn about it.
+_encryption_fallback = False
+
+
 def load_persisted_token_cache(location, encrypt):
     persistence = build_persistence(location, encrypt, type="Token cache")
     return PersistedTokenCache(persistence)
@@ -69,15 +78,29 @@ def build_persistence(location, encrypt, type=None):
                     attributes=attributes
                 )
             except Exception as e:
-                # Warn the user and continue with FilePersistence.
-                # LibsecretPersistence are known to be unavailable in some Linux environments.
+                # LibsecretPersistence is known to be unavailable in some Linux environments.
+                # Fall back to FilePersistence. The user is warned at sign-in.
                 logger.debug("Failed to initialize LibsecretPersistence: %s", e)
-                logger.warning("TBD: Encryption is unavailable. Falling back to plaintext persistence."
-                "Please follow https://aka.ms/azure-cli-credential-encryption to enable encryption.")
+                _record_encryption_fallback()
     # Either encryption is opted out or the OS is not supported for encryption. Use FilePersistence.
     path = location + file_extension_plaintext
     logger.debug("Initializing FilePersistence: location=%r", path)
     return FilePersistence(path)
+
+
+def _record_encryption_fallback():
+    global _encryption_fallback  # pylint: disable=global-statement
+    _encryption_fallback = True
+
+
+def warn_if_encryption_unavailable():
+    """Warn that credentials are persisted in plaintext.
+
+    Called at sign-in only. Every command runs in a new process, so warning once per session would
+    require storing state on the machine, and warning on every command is too noisy.
+    """
+    if _encryption_fallback:
+        logger.warning(ENCRYPTION_FALLBACK_WARNING)
 
 
 class SecretStore:

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -22,6 +22,8 @@ logger = get_logger(__name__)
 # Files extensions for encrypted and plaintext persistence
 file_extensions = {True: '.bin', False: '.json'}
 
+KEYCHAIN_SERVICE_NAME = 'azure-cli'
+LIBSECRET_SCHEMA_NAME = 'azure-cli'
 
 def load_persisted_token_cache(location, encrypt):
     persistence = build_persistence(location, encrypt)
@@ -39,14 +41,25 @@ def build_persistence(location, encrypt):
     logger.debug("build_persistence: location=%r, encrypt=%r", location, encrypt)
     if encrypt:
         if sys.platform.startswith('win'):
+            # For FilePersistenceWithDataProtection, location is where the credential is stored.
+            logger.debug("Initializing FilePersistenceWithDataProtection.")
             return FilePersistenceWithDataProtection(location)
         if sys.platform.startswith('darwin'):
-            return KeychainPersistence(location, "my_service_name", "my_account_name")
+            # For KeychainPersistence, location is only used as a signal for the credential's last modified time.
+            # The credential is stored in Keychain identified by (service_name, account_name) combination.
+            # msal-extensions automatically computes account_name from signal_location.
+            # https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/103
+            logger.debug("Initializing KeychainPersistence")
+            return KeychainPersistence(location, service_name=KEYCHAIN_SERVICE_NAME)
         if sys.platform.startswith('linux'):
+            # For LibsecretPersistence, location is only used as a signal for the credential's last modified time.
+            # The credential is stored in libsecret identified by (schema_name, attributes) combination.
+            # Doesn't seem to be a reason to use attributes to further filter the credential.
+            logger.debug("Initializing LibsecretPersistence.")
             return LibsecretPersistence(
                 location,
-                schema_name="my_schema_name",
-                attributes={"my_attr1": "foo", "my_attr2": "bar"}
+                schema_name=LIBSECRET_SCHEMA_NAME,
+                attributes={}
             )
     else:
         return FilePersistence(location)

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -20,10 +20,13 @@ from azure.cli.core.decorators import retry
 logger = get_logger(__name__)
 
 # Files extensions for encrypted and plaintext persistence
-file_extensions = {True: '.bin', False: '.json'}
+file_extension_encrypted = '.bin'
+file_extension_plaintext = '.json'
+file_extension_signal = '.sig'
+file_extensions = [file_extension_encrypted, file_extension_plaintext, file_extension_signal]
 
-KEYCHAIN_SERVICE_NAME = 'azure-cli'
-LIBSECRET_SCHEMA_NAME = 'azure-cli'
+KEYCHAIN_SERVICE_NAME = 'Microsoft Azure CLI MSAL Token Cache'
+LIBSECRET_SCHEMA_NAME = 'Microsoft Azure CLI MSAL Token Cache'
 
 def load_persisted_token_cache(location, encrypt):
     persistence = build_persistence(location, encrypt)
@@ -37,32 +40,43 @@ def load_secret_store(location, encrypt):
 
 def build_persistence(location, encrypt):
     """Build a suitable persistence instance based your current OS"""
-    location += file_extensions[encrypt]
     logger.debug("build_persistence: location=%r, encrypt=%r", location, encrypt)
     if encrypt:
         if sys.platform.startswith('win'):
             # For FilePersistenceWithDataProtection, location is where the credential is stored.
-            logger.debug("Initializing FilePersistenceWithDataProtection.")
-            return FilePersistenceWithDataProtection(location)
+            path = location + file_extension_encrypted
+            logger.debug("Initializing FilePersistenceWithDataProtection: location=%r", path)
+            return FilePersistenceWithDataProtection(path)
         if sys.platform.startswith('darwin'):
             # For KeychainPersistence, location is only used as a signal for the credential's last modified time.
             # The credential is stored in Keychain identified by (service_name, account_name) combination.
             # msal-extensions automatically computes account_name from signal_location.
             # https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/103
-            logger.debug("Initializing KeychainPersistence")
-            return KeychainPersistence(location, service_name=KEYCHAIN_SERVICE_NAME)
+            path = location + file_extension_signal
+            logger.debug("Initializing KeychainPersistence: location=%r", path)
+            return KeychainPersistence(path, service_name=KEYCHAIN_SERVICE_NAME)
         if sys.platform.startswith('linux'):
             # For LibsecretPersistence, location is only used as a signal for the credential's last modified time.
             # The credential is stored in libsecret identified by (schema_name, attributes) combination.
             # Doesn't seem to be a reason to use attributes to further filter the credential.
-            logger.debug("Initializing LibsecretPersistence.")
-            return LibsecretPersistence(
-                location,
-                schema_name=LIBSECRET_SCHEMA_NAME,
-                attributes={}
-            )
-    else:
-        return FilePersistence(location)
+            path = location + file_extension_signal
+            logger.debug("Initializing LibsecretPersistence: location=%r", path)
+            try:
+                return LibsecretPersistence(
+                    path,
+                    schema_name=LIBSECRET_SCHEMA_NAME,
+                    attributes={}
+                )
+            except Exception as e:
+                # Warn the user and continue with FilePersistence.
+                # LibsecretPersistence are known to be unavailable in some Linux environments.
+                logger.debug("Failed to initialize LibsecretPersistence: %s", e)
+                logger.warning("TBD: Encryption is unavailable. Falling back to plaintext persistence."
+                "Please follow https://aka.ms/azure-cli-credential-encryption to enable encryption.")
+    # Either encryption is opted out or the OS is not supported for encryption. Use FilePersistence.
+    path = location + file_extension_plaintext
+    logger.debug("Initializing FilePersistence: location=%r", path)
+    return FilePersistence(path)
 
 
 class SecretStore:

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -140,11 +140,6 @@ def erase_persistence(location, encrypt, type=None, empty_payload='{}'):  # pyli
 
 
 def warn_if_encryption_unavailable():
-    """Warn that credentials are persisted in plaintext.
-
-    Called at sign-in only. Every command runs in a new process, so warning once per session would
-    require storing state on the machine, and warning on every command is too noisy.
-    """
     if _encryption_fallback:
         logger.warning(ENCRYPTION_FALLBACK_WARNING)
 

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -171,8 +171,17 @@ def erase_persistence(location, encrypt, type=None, empty_payload='{}'):  # pyli
 
 
 def warn_if_encryption_unavailable():
-    if _encryption_fallback:
-        logger.warning(ENCRYPTION_FALLBACK_WARNING)
+    if not _encryption_fallback:
+        return
+
+    # The warning asks the user to make the OS credential store available, which can't be done on a
+    # platform-managed machine, so it would only be noise there.
+    from azure.cli.core.util import in_managed_environment
+    if in_managed_environment():
+        logger.debug("Encryption is unavailable, but the warning is suppressed in a managed environment.")
+        return
+
+    logger.warning(ENCRYPTION_FALLBACK_WARNING)
 
 
 class SecretStore:

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -48,7 +48,7 @@ def load_secret_store(location, encrypt):
     return SecretStore(persistence)
 
 
-def build_persistence(location, encrypt, type=None):
+def build_persistence(location, encrypt, type=None):  # pylint: disable=redefined-builtin
     """Build a suitable persistence instance based your current OS"""
     logger.debug("build_persistence: location=%r, encrypt=%r, type=%r", location, encrypt, type)
     if encrypt:
@@ -78,7 +78,7 @@ def build_persistence(location, encrypt, type=None):
                     schema_name=LIBSECRET_SCHEMA_NAME,
                     attributes=attributes
                 )
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 # LibsecretPersistence is known to be unavailable in some Linux environments.
                 # Fall back to FilePersistence. The user is warned at sign-in.
                 logger.debug("Failed to initialize LibsecretPersistence: %s", e)

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -32,7 +32,7 @@ LIBSECRET_SCHEMA_NAME = 'Microsoft Azure CLI'
 ENCRYPTION_FALLBACK_WARNING = (
     "Encryption is unavailable on this machine, so the token cache and service principal secrets "
     "are stored in plaintext. "
-    "Please follow https://aka.ms/azure-cli-credential-encryption to enable encryption.")
+    "Learn more: https://aka.ms/azure-cli-credential-encryption to enable encryption.")
 
 # Credentials left in the OS credential store by an earlier encrypted run, which a clear cannot
 # reach. Which one applies depends on why this run is not using the store.
@@ -170,10 +170,10 @@ def warn_if_encryption_unavailable():
     if not _encryption_fallback:
         return
 
-    # Nothing can be installed on a platform-managed machine, so the advice would only be noise.
-    from azure.cli.core.util import in_managed_environment
-    if in_managed_environment():
-        logger.debug("Encryption is unavailable, but the warning is suppressed in a managed environment.")
+    # Nothing can be installed on Cloud Shell's machine, so the advice would only be noise.
+    from azure.cli.core.util import in_cloud_console
+    if in_cloud_console():
+        logger.debug("Encryption is unavailable, but the warning is suppressed in Cloud Shell.")
         return
 
     logger.warning(ENCRYPTION_FALLBACK_WARNING)

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -93,6 +93,20 @@ def _record_encryption_fallback():
     _encryption_fallback = True
 
 
+def erase_persistence(location, encrypt, type=None, empty_payload='{}'):  # pylint: disable=redefined-builtin
+    """Overwrite a persisted payload with empty content.
+
+    Removing the files is not enough on Linux and macOS: the credential is held by libsecret or
+    Keychain and the file is only a modification signal. Write through the same persistence that
+    reads it, the way logging out of a single account does.
+    """
+    try:
+        build_persistence(location, encrypt, type=type).save(empty_payload)
+    except Exception as e:  # pylint: disable=broad-except
+        # Best effort. The files are removed by the caller regardless.
+        logger.debug("Failed to erase persisted payload at %r: %s", location, e)
+
+
 def warn_if_encryption_unavailable():
     """Warn that credentials are persisted in plaintext.
 

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -123,10 +123,8 @@ def _remove_persistence_files(location, keep_signal_file=False):
 
 def _warn_about_the_os_credential_store(location):
     # A signal file means this location was written with encryption on, so the OS credential store
-    # may still hold a payload. Encryption is what every capable machine should be using, but
-    # setting encrypt_token_cache to false is the escape hatch for the ones really do not want to, or for
-    # rolling back. Emptying the store under that setting would have the possibility of prompt to unlock the keyring, which
-    # is the interruption the user opted out of, so leave the payload alone and say so instead.
+    # may still hold a payload. Emptying it here may prompt to unlock the keyring, which is the
+    # interruption encrypt_token_cache=false opted out of, so leave the payload alone and say so.
     if not os.path.exists(location + file_extension_signal):
         return
     if _encryption_fallback:

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -7,6 +7,7 @@
 # https://github.com/AzureAD/microsoft-authentication-extensions-for-python/blob/dev/sample/token_cache_sample.py
 
 import json
+import os
 import sys
 
 from msal_extensions import (FilePersistenceWithDataProtection, KeychainPersistence, LibsecretPersistence,
@@ -93,18 +94,49 @@ def _record_encryption_fallback():
     _encryption_fallback = True
 
 
+def _try_remove(path):
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.debug("Failed to remove %r: %s", path, e)
+
+
+def _remove_persistence_files(location):
+    """Remove every persistence file for a location.
+
+    All extensions are tried, not just the one in use, so that a plaintext or DPAPI file left
+    over from a previous core.encrypt_token_cache setting is cleaned up too.
+    """
+    for extension in file_extensions:
+        _try_remove(location + extension)
+
+
 def erase_persistence(location, encrypt, type=None, empty_payload='{}'):  # pylint: disable=redefined-builtin
-    """Overwrite a persisted payload with empty content.
+    """Empty a persisted payload and remove its files. Returns whether it succeeded.
 
     Removing the files is not enough on Linux and macOS: the credential is held by libsecret or
     Keychain and the file is only a modification signal. Write through the same persistence that
     reads it, the way logging out of a single account does.
+
+    Emptying and removing happen under one lock, and nothing is touched unless the lock is held.
+    In practice this only fails when another az process is using the credential store, and
+    deleting its freshly written signal file would hide a credential rather than remove it.
     """
     try:
-        build_persistence(location, encrypt, type=type).save(empty_payload)
+        persistence = build_persistence(location, encrypt, type=type)
+        # Serialize against other az processes, like SecretStore.save and PersistedTokenCache do.
+        with CrossPlatLock(persistence.get_location() + '.lockfile'):
+            persistence.save(empty_payload)
+            _remove_persistence_files(location)
+        return True
     except Exception as e:  # pylint: disable=broad-except
-        # Best effort. The files are removed by the caller regardless.
+        # Logging out must not fail, but nothing was cleared and the credential is still readable,
+        # so this can't be silent. Details go to the debug log.
         logger.debug("Failed to erase persisted payload at %r: %s", location, e)
+        logger.warning("Could not clear credentials. Run 'az account clear' again.")
+        return False
 
 
 def warn_if_encryption_unavailable():

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -34,6 +34,16 @@ ENCRYPTION_FALLBACK_WARNING = (
     "are stored in plaintext. "
     "Please follow https://aka.ms/azure-cli-credential-encryption to enable encryption.")
 
+# Credentials left in the OS credential store by an earlier encrypted run, which a clear cannot
+# reach. Which one applies depends on why this run is not using the store.
+CREDENTIAL_STORE_UNAVAILABLE_WARNING = (
+    "Credentials may remain in the OS credential store, which is currently unavailable. "
+    "Clear again once it works.")
+CREDENTIAL_STORE_NOT_CLEARED_WARNING = (
+    "Credentials may remain in the OS credential store. It is not cleared because encryption is "
+    "off, and clearing it would prompt to unlock the keyring. Set 'core.encrypt_token_cache' to "
+    "true and clear again to remove them.")
+
 # Set when a persistence falls back to plaintext, so sign-in can warn about it.
 _encryption_fallback = False
 
@@ -103,68 +113,54 @@ def _try_remove(path):
         logger.debug("Failed to remove %r: %s", path, e)
 
 
-def _remove_persistence_files(location):
-    """Remove every persistence file for a location.
-
-    All extensions are tried, not just the one in use, so that a plaintext or DPAPI file left
-    over from a previous core.encrypt_token_cache setting is cleaned up too.
-    """
+def _remove_persistence_files(location, keep_signal_file=False):
+    # Every extension, not just the one in use, to clean up after a changed encrypt_token_cache.
     for extension in file_extensions:
+        if keep_signal_file and extension == file_extension_signal:
+            continue
         _try_remove(location + extension)
 
 
-def _try_erase_os_credential_store(location, type=None, empty_payload='{}'):  # pylint: disable=redefined-builtin
-    """Best effort erase of a payload the OS credential store may still hold.
-
-    On macOS and Linux the credential lives in Keychain or libsecret and the file is only a
-    modification signal, so removing the file hides the payload instead of removing it: a clear run
-    with core.encrypt_token_cache off would leave the credential readable as soon as the setting is
-    turned back on. Windows needs nothing here, because the DPAPI file is the ciphertext itself.
-
-    The persistence API has no delete, and macOS Keychain offers none at all, so an empty payload is
-    written over it instead. Like _try_remove, a failure must not stop the clear: an unreachable
-    credential store cannot be cleared by any means, so there is nothing to do but record it.
-    """
-    if not (sys.platform.startswith('darwin') or sys.platform.startswith('linux')):
+def _warn_about_the_os_credential_store(location):
+    # A signal file means this location was written with encryption on, so the OS credential store
+    # may still hold a payload. Encryption is what every capable machine should be using, but
+    # setting encrypt_token_cache to false is the escape hatch for the ones really do not want to, or for
+    # rolling back. Emptying the store under that setting would have the possibility of prompt to unlock the keyring, which
+    # is the interruption the user opted out of, so leave the payload alone and say so instead.
+    if not os.path.exists(location + file_extension_signal):
         return
-    try:
-        persistence = build_persistence(location, True, type=type)
-        if not persistence.is_encrypted:
-            # Fell back to plaintext, so the OS credential store is unreachable from here. The
-            # plaintext file is the caller's business and is dealt with there.
-            return
-        with CrossPlatLock(persistence.get_location() + '.lockfile'):
-            persistence.save(empty_payload)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.debug("Failed to erase the OS credential store at %r: %s", location, e)
+    if _encryption_fallback:
+        # Encryption is already on, so there is nothing to turn on. The keyring is what's broken.
+        logger.warning(CREDENTIAL_STORE_UNAVAILABLE_WARNING)
+    else:
+        logger.warning(CREDENTIAL_STORE_NOT_CLEARED_WARNING)
 
 
-def erase_persistence(location, encrypt, type=None, empty_payload='{}'):  # pylint: disable=redefined-builtin
+def erase_persistence(location, encrypt, type=None, empty_payload='{}',  # pylint: disable=redefined-builtin
+                      warn_if_credentials_may_remain=False):
     """Empty a persisted payload and remove its files. Returns whether it succeeded.
 
-    Removing the files is not enough on Linux and macOS: the credential is held by libsecret or
-    Keychain and the file is only a modification signal. Write through the same persistence that
-    reads it, the way logging out of a single account does.
+    With encryption on, the payload is held by libsecret or Keychain and the file is only a
+    modification signal, so it is overwritten rather than deleted. With encryption off the
+    credential store is not touched at all, so clearing never prompts to unlock a keyring the user
+    opted out of, and the signal file is kept as the evidence that it may still hold a payload.
 
-    The OS credential store is erased too when it is not the configured one, so that a payload
-    written under a previous core.encrypt_token_cache setting does not outlive the clear.
-
-    Emptying and removing happen under one lock, and nothing is touched unless the lock is held.
-    In practice this only fails when another az process is using the credential store, and
-    deleting its freshly written signal file would hide a credential rather than remove it.
+    :param warn_if_credentials_may_remain: Warn about what the credential store may still hold.
+        Only one location should, because the warning is about the store, not the location.
     """
     try:
         persistence = build_persistence(location, encrypt, type=type)
-        if not persistence.is_encrypted:
-            _try_erase_os_credential_store(location, type=type, empty_payload=empty_payload)
         # Serialize against other az processes, like SecretStore.save and PersistedTokenCache do.
         with CrossPlatLock(persistence.get_location() + '.lockfile'):
-            persistence.save(empty_payload)
-            _remove_persistence_files(location)
+            if persistence.is_encrypted:
+                persistence.save(empty_payload)
+            elif warn_if_credentials_may_remain:
+                _warn_about_the_os_credential_store(location)
+            _remove_persistence_files(location, keep_signal_file=not persistence.is_encrypted)
         return True
     except Exception as e:  # pylint: disable=broad-except
-        # Logging out must not fail, but nothing was cleared and the credential is still readable,
-        # so this can't be silent. Details go to the debug log.
+        # Clearing must not fail, but nothing was removed and the credential is still readable, so
+        # this can't be silent. In practice another az process is holding the lock.
         logger.debug("Failed to erase persisted payload at %r: %s", location, e)
         logger.warning("Could not clear credentials. Run 'az account clear' again.")
         return False
@@ -174,8 +170,7 @@ def warn_if_encryption_unavailable():
     if not _encryption_fallback:
         return
 
-    # The warning asks the user to make the OS credential store available, which can't be done on a
-    # platform-managed machine, so it would only be noise there.
+    # Nothing can be installed on a platform-managed machine, so the advice would only be noise.
     from azure.cli.core.util import in_managed_environment
     if in_managed_environment():
         logger.debug("Encryption is unavailable, but the warning is suppressed in a managed environment.")

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -25,22 +25,22 @@ file_extension_plaintext = '.json'
 file_extension_signal = '.sig'
 file_extensions = [file_extension_encrypted, file_extension_plaintext, file_extension_signal]
 
-KEYCHAIN_SERVICE_NAME = 'Microsoft Azure CLI MSAL Token Cache'
-LIBSECRET_SCHEMA_NAME = 'Microsoft Azure CLI MSAL Token Cache'
+KEYCHAIN_SERVICE_NAME = 'Microsoft Azure CLI'
+LIBSECRET_SCHEMA_NAME = 'Microsoft Azure CLI'
 
 def load_persisted_token_cache(location, encrypt):
-    persistence = build_persistence(location, encrypt)
+    persistence = build_persistence(location, encrypt, type="Token cache")
     return PersistedTokenCache(persistence)
 
 
 def load_secret_store(location, encrypt):
-    persistence = build_persistence(location, encrypt)
+    persistence = build_persistence(location, encrypt, type="Secret store")
     return SecretStore(persistence)
 
 
-def build_persistence(location, encrypt):
+def build_persistence(location, encrypt, type=None):
     """Build a suitable persistence instance based your current OS"""
-    logger.debug("build_persistence: location=%r, encrypt=%r", location, encrypt)
+    logger.debug("build_persistence: location=%r, encrypt=%r, type=%r", location, encrypt, type)
     if encrypt:
         if sys.platform.startswith('win'):
             # For FilePersistenceWithDataProtection, location is where the credential is stored.
@@ -54,7 +54,7 @@ def build_persistence(location, encrypt):
             # https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/103
             path = location + file_extension_signal
             logger.debug("Initializing KeychainPersistence: location=%r", path)
-            return KeychainPersistence(path, service_name=KEYCHAIN_SERVICE_NAME)
+            return KeychainPersistence(path, service_name=KEYCHAIN_SERVICE_NAME, account_name=type)
         if sys.platform.startswith('linux'):
             # For LibsecretPersistence, location is only used as a signal for the credential's last modified time.
             # The credential is stored in libsecret identified by (schema_name, attributes) combination.
@@ -62,10 +62,11 @@ def build_persistence(location, encrypt):
             path = location + file_extension_signal
             logger.debug("Initializing LibsecretPersistence: location=%r", path)
             try:
+                attributes = {"type": type} if type else {}
                 return LibsecretPersistence(
                     path,
                     schema_name=LIBSECRET_SCHEMA_NAME,
-                    attributes={}
+                    attributes=attributes
                 )
             except Exception as e:
                 # Warn the user and continue with FilePersistence.

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -113,6 +113,32 @@ def _remove_persistence_files(location):
         _try_remove(location + extension)
 
 
+def _try_erase_os_credential_store(location, type=None, empty_payload='{}'):  # pylint: disable=redefined-builtin
+    """Best effort erase of a payload the OS credential store may still hold.
+
+    On macOS and Linux the credential lives in Keychain or libsecret and the file is only a
+    modification signal, so removing the file hides the payload instead of removing it: a clear run
+    with core.encrypt_token_cache off would leave the credential readable as soon as the setting is
+    turned back on. Windows needs nothing here, because the DPAPI file is the ciphertext itself.
+
+    The persistence API has no delete, and macOS Keychain offers none at all, so an empty payload is
+    written over it instead. Like _try_remove, a failure must not stop the clear: an unreachable
+    credential store cannot be cleared by any means, so there is nothing to do but record it.
+    """
+    if not (sys.platform.startswith('darwin') or sys.platform.startswith('linux')):
+        return
+    try:
+        persistence = build_persistence(location, True, type=type)
+        if not persistence.is_encrypted:
+            # Fell back to plaintext, so the OS credential store is unreachable from here. The
+            # plaintext file is the caller's business and is dealt with there.
+            return
+        with CrossPlatLock(persistence.get_location() + '.lockfile'):
+            persistence.save(empty_payload)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug("Failed to erase the OS credential store at %r: %s", location, e)
+
+
 def erase_persistence(location, encrypt, type=None, empty_payload='{}'):  # pylint: disable=redefined-builtin
     """Empty a persisted payload and remove its files. Returns whether it succeeded.
 
@@ -120,12 +146,17 @@ def erase_persistence(location, encrypt, type=None, empty_payload='{}'):  # pyli
     Keychain and the file is only a modification signal. Write through the same persistence that
     reads it, the way logging out of a single account does.
 
+    The OS credential store is erased too when it is not the configured one, so that a payload
+    written under a previous core.encrypt_token_cache setting does not outlive the clear.
+
     Emptying and removing happen under one lock, and nothing is touched unless the lock is held.
     In practice this only fails when another az process is using the credential store, and
     deleting its freshly written signal file would hide a credential rather than remove it.
     """
     try:
         persistence = build_persistence(location, encrypt, type=type)
+        if not persistence.is_encrypted:
+            _try_erase_os_credential_store(location, type=type, empty_payload=empty_payload)
         # Serialize against other az processes, like SecretStore.save and PersistedTokenCache do.
         with CrossPlatLock(persistence.get_location() + '.lockfile'):
             persistence.save(empty_payload)

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -54,5 +54,29 @@ class TestEncryptionFallbackWarning(unittest.TestCase):
         self.assertFalse(persistence._encryption_fallback)
 
 
+class TestErasePersistence(unittest.TestCase):
+    """Clearing all accounts must empty the payload, not just remove the files.
+
+    On Linux and macOS the credential is held by libsecret or Keychain and the file is only a
+    modification signal, so removing files alone would leave the credential behind.
+    """
+
+    def test_payload_is_overwritten_through_the_persistence(self):
+        built = mock.MagicMock()
+        with mock.patch.object(persistence, 'build_persistence', return_value=built) as build_mock:
+            persistence.erase_persistence('/tmp/test_persistence', True, type='Secret store',
+                                          empty_payload='[]')
+
+        build_mock.assert_called_once_with('/tmp/test_persistence', True, type='Secret store')
+        built.save.assert_called_once_with('[]')
+
+    def test_failure_to_erase_is_swallowed(self):
+        # The caller removes the files regardless, so a keyring error must not break logout.
+        built = mock.MagicMock()
+        built.save.side_effect = Exception('keyring is gone')
+        with mock.patch.object(persistence, 'build_persistence', return_value=built):
+            persistence.erase_persistence('/tmp/test_persistence', True, type='Token cache')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -65,17 +65,16 @@ class TestEncryptionFallbackWarning(unittest.TestCase):
         self._build_with_libsecret_unavailable()
         self._build_with_libsecret_unavailable()
 
-        # az's own CI sets TF_BUILD/GITHUB_ACTIONS, which would suppress the warning.
+        # A CI agent gets the warning too, so clear the environment to keep az's own CI honest.
         with mock.patch.dict(os.environ, {}, clear=True), \
                 mock.patch.object(persistence.logger, 'warning') as warning_mock:
             persistence.warn_if_encryption_unavailable()
 
         warning_mock.assert_called_once_with(persistence.ENCRYPTION_FALLBACK_WARNING)
 
-    def test_no_warning_in_a_managed_environment(self):
-        # Cloud Shell and CI agents can't have an OS credential store installed, so the advice
-        # to enable encryption is unactionable there.
-        for name, value in [('ACC_CLOUD', 'PROD'), ('GITHUB_ACTIONS', 'true'), ('TF_BUILD', 'True')]:
+    def test_warning_shown_on_a_ci_agent(self):
+        # A CI agent is someone's own machine to configure, unlike Cloud Shell.
+        for name, value in [('GITHUB_ACTIONS', 'true'), ('TF_BUILD', 'True')]:
             with self.subTest(variable=name):
                 self._build_with_libsecret_unavailable()
 
@@ -83,7 +82,18 @@ class TestEncryptionFallbackWarning(unittest.TestCase):
                         mock.patch.object(persistence.logger, 'warning') as warning_mock:
                     persistence.warn_if_encryption_unavailable()
 
-                warning_mock.assert_not_called()
+                warning_mock.assert_called_once_with(persistence.ENCRYPTION_FALLBACK_WARNING)
+
+    def test_no_warning_in_cloud_shell(self):
+        # Cloud Shell can't have an OS credential store installed, so the advice to enable
+        # encryption is unactionable there.
+        self._build_with_libsecret_unavailable()
+
+        with mock.patch.dict(os.environ, {'ACC_CLOUD': 'PROD'}, clear=True), \
+                mock.patch.object(persistence.logger, 'warning') as warning_mock:
+            persistence.warn_if_encryption_unavailable()
+
+        warning_mock.assert_not_called()
 
     def test_no_warning_without_fallback(self):
         with mock.patch.dict(os.environ, {}, clear=True), \

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -63,19 +63,63 @@ class TestErasePersistence(unittest.TestCase):
 
     def test_payload_is_overwritten_through_the_persistence(self):
         built = mock.MagicMock()
-        with mock.patch.object(persistence, 'build_persistence', return_value=built) as build_mock:
-            persistence.erase_persistence('/tmp/test_persistence', True, type='Secret store',
-                                          empty_payload='[]')
+        built.get_location.return_value = '/tmp/test_persistence.sig'
+        with mock.patch.object(persistence, 'build_persistence', return_value=built) as build_mock, \
+                mock.patch.object(persistence, 'CrossPlatLock'), \
+                mock.patch.object(persistence, '_try_remove'):
+            result = persistence.erase_persistence('/tmp/test_persistence', True,
+                                                   type='Secret store', empty_payload='[]')
 
+        self.assertTrue(result)
         build_mock.assert_called_once_with('/tmp/test_persistence', True, type='Secret store')
         built.save.assert_called_once_with('[]')
 
-    def test_failure_to_erase_is_swallowed(self):
-        # The caller removes the files regardless, so a keyring error must not break logout.
+    def test_files_are_removed_under_the_same_lock_as_the_erase(self):
+        # A login landing between the erase and the removal would leave a credential in the OS
+        # credential store that the removed signal file no longer points at.
         built = mock.MagicMock()
-        built.save.side_effect = Exception('keyring is gone')
-        with mock.patch.object(persistence, 'build_persistence', return_value=built):
+        built.get_location.return_value = '/tmp/test_persistence.sig'
+        calls = []
+        with mock.patch.object(persistence, 'build_persistence', return_value=built), \
+                mock.patch.object(persistence, 'CrossPlatLock') as lock_mock, \
+                mock.patch.object(persistence, '_try_remove') as remove_mock:
+            lock_mock.return_value.__enter__.side_effect = lambda: calls.append('lock')
+            lock_mock.return_value.__exit__.side_effect = lambda *a: calls.append('unlock')
+            built.save.side_effect = lambda _: calls.append('save')
+            remove_mock.side_effect = lambda path: calls.append('remove')
             persistence.erase_persistence('/tmp/test_persistence', True, type='Token cache')
+
+        lock_mock.assert_called_once_with('/tmp/test_persistence.sig.lockfile')
+        self.assertEqual(calls[0], 'lock')
+        self.assertEqual(calls[-1], 'unlock')
+        # The erase must precede the removal, or the save would recreate the removed files.
+        self.assertLess(calls.index('save'), calls.index('remove'))
+        self.assertEqual(
+            [mock.call('/tmp/test_persistence' + e) for e in persistence.file_extensions],
+            remove_mock.call_args_list)
+
+    def test_failure_to_erase_warns_and_leaves_everything_alone(self):
+        # The realistic failure is another az process holding the lock. Removing the files it just
+        # wrote would hide its credential instead of removing it, so the clear is all-or-nothing
+        # and the user is told to retry.
+        built = mock.MagicMock()
+        built.get_location.return_value = '/tmp/test_persistence.sig'
+        built.save.side_effect = Exception('AlreadyLocked')
+        with mock.patch.object(persistence, 'build_persistence', return_value=built), \
+                mock.patch.object(persistence, 'CrossPlatLock'), \
+                mock.patch.object(persistence, '_try_remove') as remove_mock, \
+                mock.patch.object(persistence.logger, 'warning') as warning_mock:
+            result = persistence.erase_persistence('/tmp/test_persistence', True,
+                                                   type='Token cache')
+
+        self.assertFalse(result)
+        warning_mock.assert_called_once()
+        remove_mock.assert_not_called()
+
+    def test_removal_survives_a_locked_file(self):
+        # On Windows, removing a file another az process holds open raises a sharing violation.
+        with mock.patch.object(persistence.os, 'remove', side_effect=PermissionError('in use')):
+            persistence._try_remove('/tmp/test_persistence.bin')
 
 
 if __name__ == '__main__':

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -32,18 +32,44 @@ class TestEncryptionFallbackWarning(unittest.TestCase):
         warning_mock.assert_not_called()
         self.assertTrue(persistence._encryption_fallback)
 
+    def test_fallback_reason_goes_to_the_debug_log(self):
+        # The warning says the credentials are in plaintext; only this says what went wrong, and
+        # it is all a user has to go on when the keyring is meant to be working.
+        with mock.patch.object(persistence.logger, 'debug') as debug_mock:
+            self._build_with_libsecret_unavailable()
+
+        logged = ' '.join(str(call) for call in debug_mock.call_args_list)
+        self.assertIn('Failed to initialize LibsecretPersistence', logged)
+        self.assertIn('no libsecret', logged)
+
     def test_warning_shown_at_sign_in(self):
         # Token cache and secret store both fall back, but sign-in warns once.
         self._build_with_libsecret_unavailable()
         self._build_with_libsecret_unavailable()
 
-        with mock.patch.object(persistence.logger, 'warning') as warning_mock:
+        # az's own CI sets TF_BUILD/GITHUB_ACTIONS, which would suppress the warning.
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(persistence.logger, 'warning') as warning_mock:
             persistence.warn_if_encryption_unavailable()
 
         warning_mock.assert_called_once_with(persistence.ENCRYPTION_FALLBACK_WARNING)
 
+    def test_no_warning_in_a_managed_environment(self):
+        # Cloud Shell and CI agents can't have an OS credential store installed, so the advice
+        # to enable encryption is unactionable there.
+        for name, value in [('ACC_CLOUD', 'PROD'), ('GITHUB_ACTIONS', 'true'), ('TF_BUILD', 'True')]:
+            with self.subTest(variable=name):
+                self._build_with_libsecret_unavailable()
+
+                with mock.patch.dict(os.environ, {name: value}, clear=True), \
+                        mock.patch.object(persistence.logger, 'warning') as warning_mock:
+                    persistence.warn_if_encryption_unavailable()
+
+                warning_mock.assert_not_called()
+
     def test_no_warning_without_fallback(self):
-        with mock.patch.object(persistence.logger, 'warning') as warning_mock:
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(persistence.logger, 'warning') as warning_mock:
             persistence.warn_if_encryption_unavailable()
 
         warning_mock.assert_not_called()

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import os
+import tempfile
 import unittest
 from unittest import mock
 
@@ -52,6 +54,140 @@ class TestEncryptionFallbackWarning(unittest.TestCase):
 
         self.assertIsInstance(store, persistence.FilePersistence)
         self.assertFalse(persistence._encryption_fallback)
+
+
+class TestEraseOsCredentialStore(unittest.TestCase):
+    """A clear must not leave a credential in the OS credential store.
+
+    On Linux and macOS the payload lives in libsecret or Keychain and the file is only a signal, so
+    a clear run with core.encrypt_token_cache off would remove the signal and leave the credential
+    readable as soon as the setting is turned back on.
+    """
+
+    LOCATION = '/tmp/test_persistence'
+
+    @staticmethod
+    def _persistence_mock(is_encrypted, extension):
+        built = mock.MagicMock()
+        built.is_encrypted = is_encrypted
+        built.get_location.return_value = TestEraseOsCredentialStore.LOCATION + extension
+        return built
+
+    def _erase(self, encrypt=False, platform='linux', os_store=None):
+        """Run a clear with the configured persistence and the OS credential store separated."""
+        plaintext = self._persistence_mock(False, persistence.file_extension_plaintext)
+        encrypted = os_store if os_store is not None else \
+            self._persistence_mock(True, persistence.file_extension_signal)
+
+        def build(location, wants_encryption, type=None):  # pylint: disable=redefined-builtin
+            return encrypted if wants_encryption else plaintext
+
+        with mock.patch.object(persistence.sys, 'platform', platform), \
+                mock.patch.object(persistence, 'build_persistence', side_effect=build), \
+                mock.patch.object(persistence, 'CrossPlatLock'), \
+                mock.patch.object(persistence, '_try_remove') as remove_mock, \
+                mock.patch.object(persistence.logger, 'warning') as warning_mock:
+            result = persistence.erase_persistence(self.LOCATION, encrypt, type='Secret store',
+                                                   empty_payload='[]')
+        return result, plaintext, encrypted, remove_mock, warning_mock
+
+    def test_encrypted_payload_is_erased_when_encryption_is_off(self):
+        # The case a plain 'az account clear' used to miss entirely.
+        result, plaintext, encrypted, _, warning_mock = self._erase(encrypt=False)
+
+        self.assertTrue(result)
+        plaintext.save.assert_called_once_with('[]')
+        encrypted.save.assert_called_once_with('[]')
+        warning_mock.assert_not_called()
+
+    def test_configured_encrypted_store_is_erased_once(self):
+        # With encryption on, the configured persistence already is the OS credential store.
+        result, _, encrypted, _, warning_mock = self._erase(encrypt=True)
+
+        self.assertTrue(result)
+        encrypted.save.assert_called_once_with('[]')
+        warning_mock.assert_not_called()
+
+    def test_windows_needs_no_second_pass(self):
+        # The DPAPI file is the ciphertext, so removing the files is the whole of the erase.
+        result, plaintext, encrypted, _, warning_mock = self._erase(encrypt=False, platform='win32')
+
+        self.assertTrue(result)
+        plaintext.save.assert_called_once_with('[]')
+        encrypted.save.assert_not_called()
+        warning_mock.assert_not_called()
+
+    def test_unreachable_credential_store_is_skipped(self):
+        # Falling back means the keyring cannot be reached, so there is nothing that can be done
+        # about whatever it holds. The plaintext clear must still go ahead.
+        fallback = self._persistence_mock(False, persistence.file_extension_plaintext)
+        result, plaintext, _, remove_mock, warning_mock = self._erase(encrypt=False, os_store=fallback)
+
+        self.assertTrue(result)
+        plaintext.save.assert_called_once_with('[]')
+        remove_mock.assert_called()
+        warning_mock.assert_not_called()
+
+    def test_a_failing_credential_store_does_not_fail_the_clear(self):
+        # Best effort, like _try_remove: the files still have to go, and the caller still succeeds.
+        encrypted = self._persistence_mock(True, persistence.file_extension_signal)
+        encrypted.save.side_effect = Exception('keyring is locked')
+        with mock.patch.object(persistence.logger, 'debug') as debug_mock:
+            result, plaintext, _, remove_mock, warning_mock = self._erase(
+                encrypt=False, os_store=encrypted)
+
+        self.assertTrue(result)
+        plaintext.save.assert_called_once_with('[]')
+        remove_mock.assert_called()
+        warning_mock.assert_not_called()
+        self.assertTrue(any('OS credential store' in str(call) for call in debug_mock.call_args_list))
+
+    def test_credential_store_is_erased_before_the_files_are_removed(self):
+        # Keychain and libsecret touch the signal file on save, so erasing after the removal would
+        # put the file back. The order is what keeps the clear from leaving one behind.
+        plaintext = self._persistence_mock(False, persistence.file_extension_plaintext)
+        encrypted = self._persistence_mock(True, persistence.file_extension_signal)
+        calls = []
+        plaintext.save.side_effect = lambda _: calls.append('save plaintext')
+        encrypted.save.side_effect = lambda _: calls.append('save credential store')
+
+        def build(location, wants_encryption, type=None):  # pylint: disable=redefined-builtin
+            return encrypted if wants_encryption else plaintext
+
+        with mock.patch.object(persistence.sys, 'platform', 'linux'), \
+                mock.patch.object(persistence, 'build_persistence', side_effect=build), \
+                mock.patch.object(persistence, 'CrossPlatLock'), \
+                mock.patch.object(persistence, '_try_remove',
+                                  side_effect=lambda path: calls.append('remove')):
+            persistence.erase_persistence(self.LOCATION, False, type='Secret store')
+
+        self.assertLess(calls.index('save credential store'), calls.index('remove'))
+
+    def test_no_signal_file_is_left_behind(self):
+        # The failure the order above prevents, reproduced end to end: a real save touches the
+        # signal file, and a real _try_remove has to be the last thing that runs.
+        with tempfile.TemporaryDirectory() as directory:
+            location = os.path.join(directory, 'service_principal_entries')
+            plaintext = self._persistence_mock(False, persistence.file_extension_plaintext)
+            encrypted = self._persistence_mock(True, persistence.file_extension_signal)
+            plaintext.get_location.return_value = location + persistence.file_extension_plaintext
+            encrypted.get_location.return_value = location + persistence.file_extension_signal
+
+            def touch(path):
+                return lambda _: open(path, 'w').close()  # pylint: disable=consider-using-with
+
+            plaintext.save.side_effect = touch(location + persistence.file_extension_plaintext)
+            encrypted.save.side_effect = touch(location + persistence.file_extension_signal)
+
+            def build(location_, wants_encryption, type=None):  # pylint: disable=redefined-builtin
+                return encrypted if wants_encryption else plaintext
+
+            with mock.patch.object(persistence.sys, 'platform', 'linux'), \
+                    mock.patch.object(persistence, 'build_persistence', side_effect=build), \
+                    mock.patch.object(persistence, 'CrossPlatLock'):
+                persistence.erase_persistence(location, False, type='Secret store')
+
+            self.assertEqual([], os.listdir(directory), 'the clear left a persistence file behind')
 
 
 class TestErasePersistence(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -11,6 +11,24 @@ from unittest import mock
 from azure.cli.core.auth import persistence
 
 
+class TestLibsecretLabel(unittest.TestCase):
+
+    @staticmethod
+    def _build(type):
+        with mock.patch.object(persistence.sys, 'platform', 'linux'), \
+                mock.patch.object(persistence, 'LibsecretPersistence') as libsecret_mock:
+            persistence.build_persistence('/tmp/test_persistence', True, type=type)
+        return libsecret_mock.call_args.kwargs
+
+    def test_label_names_the_store(self):
+        # Without it libsecret stores an empty label, which shows as a blank row in keyring viewers.
+        self.assertEqual(self._build('Token cache')['label'], 'Microsoft Azure CLI - Token cache')
+        self.assertEqual(self._build('Secret store')['label'], 'Microsoft Azure CLI - Secret store')
+
+    def test_label_falls_back_to_the_schema_name(self):
+        self.assertEqual(self._build(None)['label'], 'Microsoft Azure CLI')
+
+
 class TestEncryptionFallbackWarning(unittest.TestCase):
     """The plaintext fallback warning is shown at sign-in, not by each persistence build."""
 

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -82,142 +82,120 @@ class TestEncryptionFallbackWarning(unittest.TestCase):
         self.assertFalse(persistence._encryption_fallback)
 
 
-class TestEraseOsCredentialStore(unittest.TestCase):
-    """A clear must not leave a credential in the OS credential store.
+class TestPlaintextClear(unittest.TestCase):
+    """With encryption off, clearing must not touch the OS credential store.
 
-    On Linux and macOS the payload lives in libsecret or Keychain and the file is only a signal, so
-    a clear run with core.encrypt_token_cache off would remove the signal and leave the credential
-    readable as soon as the setting is turned back on.
+    Opting out of core.encrypt_token_cache opts out of the keyring prompt, and saving an empty
+    payload to libsecret or Keychain is what would raise it. The signal file stays behind, so a
+    later clear with encryption on still finds the payload.
     """
 
     LOCATION = '/tmp/test_persistence'
 
-    @staticmethod
-    def _persistence_mock(is_encrypted, extension):
+    def setUp(self):
+        persistence._encryption_fallback = False
+        self.addCleanup(setattr, persistence, '_encryption_fallback', False)
+
+    def _erase(self, signal_file_exists=False, warn_if_credentials_may_remain=False):
         built = mock.MagicMock()
-        built.is_encrypted = is_encrypted
-        built.get_location.return_value = TestEraseOsCredentialStore.LOCATION + extension
-        return built
-
-    def _erase(self, encrypt=False, platform='linux', os_store=None):
-        """Run a clear with the configured persistence and the OS credential store separated."""
-        plaintext = self._persistence_mock(False, persistence.file_extension_plaintext)
-        encrypted = os_store if os_store is not None else \
-            self._persistence_mock(True, persistence.file_extension_signal)
-
-        def build(location, wants_encryption, type=None):  # pylint: disable=redefined-builtin
-            return encrypted if wants_encryption else plaintext
-
-        with mock.patch.object(persistence.sys, 'platform', platform), \
-                mock.patch.object(persistence, 'build_persistence', side_effect=build), \
+        built.is_encrypted = False
+        built.get_location.return_value = self.LOCATION + persistence.file_extension_plaintext
+        with mock.patch.object(persistence, 'build_persistence', return_value=built), \
                 mock.patch.object(persistence, 'CrossPlatLock'), \
+                mock.patch.object(persistence.os.path, 'exists', return_value=signal_file_exists), \
                 mock.patch.object(persistence, '_try_remove') as remove_mock, \
                 mock.patch.object(persistence.logger, 'warning') as warning_mock:
-            result = persistence.erase_persistence(self.LOCATION, encrypt, type='Secret store',
-                                                   empty_payload='[]')
-        return result, plaintext, encrypted, remove_mock, warning_mock
+            result = persistence.erase_persistence(
+                self.LOCATION, False, type='Token cache',
+                warn_if_credentials_may_remain=warn_if_credentials_may_remain)
+        return result, built, remove_mock, warning_mock
 
-    def test_encrypted_payload_is_erased_when_encryption_is_off(self):
-        # The case a plain 'az account clear' used to miss entirely.
-        result, plaintext, encrypted, _, warning_mock = self._erase(encrypt=False)
-
-        self.assertTrue(result)
-        plaintext.save.assert_called_once_with('[]')
-        encrypted.save.assert_called_once_with('[]')
-        warning_mock.assert_not_called()
-
-    def test_configured_encrypted_store_is_erased_once(self):
-        # With encryption on, the configured persistence already is the OS credential store.
-        result, _, encrypted, _, warning_mock = self._erase(encrypt=True)
+    def test_credential_store_is_left_alone(self):
+        result, built, _, _ = self._erase()
 
         self.assertTrue(result)
-        encrypted.save.assert_called_once_with('[]')
+        built.save.assert_not_called()
+
+    def test_signal_file_is_kept(self):
+        # Removing it would orphan the payload the clear could not reach.
+        _, _, remove_mock, _ = self._erase()
+
+        self.assertNotIn(mock.call(self.LOCATION + persistence.file_extension_signal),
+                         remove_mock.call_args_list)
+
+    def test_the_other_files_are_removed(self):
+        # Including a .bin written while encryption was on.
+        _, _, remove_mock, _ = self._erase()
+
+        for extension in (persistence.file_extension_plaintext, persistence.file_extension_encrypted):
+            self.assertIn(mock.call(self.LOCATION + extension), remove_mock.call_args_list)
+
+    def test_a_leftover_signal_file_warns_about_the_credential_store(self):
+        _, _, _, warning_mock = self._erase(signal_file_exists=True,
+                                            warn_if_credentials_may_remain=True)
+
+        warning_mock.assert_called_once()
+        message = warning_mock.call_args[0][0]
+        self.assertIn('OS credential store', message)
+        self.assertIn('core.encrypt_token_cache', message)
+
+    def test_only_the_asked_location_warns(self):
+        # az account clear erases two locations, but the warning is about the store, not the file.
+        _, _, _, warning_mock = self._erase(signal_file_exists=True)
+
         warning_mock.assert_not_called()
 
-    def test_windows_needs_no_second_pass(self):
-        # The DPAPI file is the ciphertext, so removing the files is the whole of the erase.
-        result, plaintext, encrypted, _, warning_mock = self._erase(encrypt=False, platform='win32')
+    def test_no_warning_when_encryption_was_never_used(self):
+        _, _, _, warning_mock = self._erase(signal_file_exists=False,
+                                            warn_if_credentials_may_remain=True)
 
-        self.assertTrue(result)
-        plaintext.save.assert_called_once_with('[]')
-        encrypted.save.assert_not_called()
         warning_mock.assert_not_called()
 
-    def test_unreachable_credential_store_is_skipped(self):
-        # Falling back means the keyring cannot be reached, so there is nothing that can be done
-        # about whatever it holds. The plaintext clear must still go ahead.
-        fallback = self._persistence_mock(False, persistence.file_extension_plaintext)
-        result, plaintext, _, remove_mock, warning_mock = self._erase(encrypt=False, os_store=fallback)
+    def test_a_fallback_is_not_told_to_enable_encryption(self):
+        # Encryption is already on here; the keyring is what is broken.
+        persistence._encryption_fallback = True
+        _, _, _, warning_mock = self._erase(signal_file_exists=True,
+                                            warn_if_credentials_may_remain=True)
 
-        self.assertTrue(result)
-        plaintext.save.assert_called_once_with('[]')
-        remove_mock.assert_called()
-        warning_mock.assert_not_called()
+        message = warning_mock.call_args[0][0]
+        self.assertIn('OS credential store', message)
+        self.assertNotIn('core.encrypt_token_cache', message)
 
-    def test_a_failing_credential_store_does_not_fail_the_clear(self):
-        # Best effort, like _try_remove: the files still have to go, and the caller still succeeds.
-        encrypted = self._persistence_mock(True, persistence.file_extension_signal)
-        encrypted.save.side_effect = Exception('keyring is locked')
-        with mock.patch.object(persistence.logger, 'debug') as debug_mock:
-            result, plaintext, _, remove_mock, warning_mock = self._erase(
-                encrypt=False, os_store=encrypted)
-
-        self.assertTrue(result)
-        plaintext.save.assert_called_once_with('[]')
-        remove_mock.assert_called()
-        warning_mock.assert_not_called()
-        self.assertTrue(any('OS credential store' in str(call) for call in debug_mock.call_args_list))
-
-    def test_credential_store_is_erased_before_the_files_are_removed(self):
-        # Keychain and libsecret touch the signal file on save, so erasing after the removal would
-        # put the file back. The order is what keeps the clear from leaving one behind.
-        plaintext = self._persistence_mock(False, persistence.file_extension_plaintext)
-        encrypted = self._persistence_mock(True, persistence.file_extension_signal)
-        calls = []
-        plaintext.save.side_effect = lambda _: calls.append('save plaintext')
-        encrypted.save.side_effect = lambda _: calls.append('save credential store')
-
-        def build(location, wants_encryption, type=None):  # pylint: disable=redefined-builtin
-            return encrypted if wants_encryption else plaintext
-
-        with mock.patch.object(persistence.sys, 'platform', 'linux'), \
-                mock.patch.object(persistence, 'build_persistence', side_effect=build), \
+    def test_encryption_on_erases_and_removes_everything(self):
+        built = mock.MagicMock()
+        built.is_encrypted = True
+        built.get_location.return_value = self.LOCATION + persistence.file_extension_signal
+        with mock.patch.object(persistence, 'build_persistence', return_value=built), \
                 mock.patch.object(persistence, 'CrossPlatLock'), \
-                mock.patch.object(persistence, '_try_remove',
-                                  side_effect=lambda path: calls.append('remove')):
-            persistence.erase_persistence(self.LOCATION, False, type='Secret store')
+                mock.patch.object(persistence.os.path, 'exists', return_value=True), \
+                mock.patch.object(persistence, '_try_remove') as remove_mock, \
+                mock.patch.object(persistence.logger, 'warning') as warning_mock:
+            persistence.erase_persistence(self.LOCATION, True, type='Token cache',
+                                          warn_if_credentials_may_remain=True)
 
-        self.assertLess(calls.index('save credential store'), calls.index('remove'))
+        built.save.assert_called_once()
+        warning_mock.assert_not_called()
+        self.assertEqual(
+            [mock.call(self.LOCATION + e) for e in persistence.file_extensions],
+            remove_mock.call_args_list)
 
-    def test_no_signal_file_is_left_behind(self):
-        # The failure the order above prevents, reproduced end to end: a real save touches the
-        # signal file, and a real _try_remove has to be the last thing that runs.
+    def test_only_the_signal_file_is_left_behind(self):
+        # End to end with a real _try_remove, whichever setting wrote the files.
         with tempfile.TemporaryDirectory() as directory:
-            location = os.path.join(directory, 'service_principal_entries')
-            plaintext = self._persistence_mock(False, persistence.file_extension_plaintext)
-            encrypted = self._persistence_mock(True, persistence.file_extension_signal)
-            plaintext.get_location.return_value = location + persistence.file_extension_plaintext
-            encrypted.get_location.return_value = location + persistence.file_extension_signal
+            location = os.path.join(directory, 'msal_token_cache')
+            for extension in persistence.file_extensions:
+                open(location + extension, 'w').close()  # pylint: disable=consider-using-with
 
-            def touch(path):
-                return lambda _: open(path, 'w').close()  # pylint: disable=consider-using-with
+            with mock.patch.object(persistence.sys, 'platform', 'linux'):
+                result = persistence.erase_persistence(location, False, type='Token cache')
 
-            plaintext.save.side_effect = touch(location + persistence.file_extension_plaintext)
-            encrypted.save.side_effect = touch(location + persistence.file_extension_signal)
-
-            def build(location_, wants_encryption, type=None):  # pylint: disable=redefined-builtin
-                return encrypted if wants_encryption else plaintext
-
-            with mock.patch.object(persistence.sys, 'platform', 'linux'), \
-                    mock.patch.object(persistence, 'build_persistence', side_effect=build), \
-                    mock.patch.object(persistence, 'CrossPlatLock'):
-                persistence.erase_persistence(location, False, type='Secret store')
-
-            self.assertEqual([], os.listdir(directory), 'the clear left a persistence file behind')
+            self.assertTrue(result)
+            left = sorted(f for f in os.listdir(directory) if not f.endswith('.lockfile'))
+            self.assertEqual(['msal_token_cache' + persistence.file_extension_signal], left)
 
 
 class TestErasePersistence(unittest.TestCase):
-    """Clearing all accounts must empty the payload, not just remove the files.
+    """With encryption on, clearing must empty the payload, not just remove the files.
 
     On Linux and macOS the credential is held by libsecret or Keychain and the file is only a
     modification signal, so removing files alone would leave the credential behind.
@@ -225,6 +203,7 @@ class TestErasePersistence(unittest.TestCase):
 
     def test_payload_is_overwritten_through_the_persistence(self):
         built = mock.MagicMock()
+        built.is_encrypted = True
         built.get_location.return_value = '/tmp/test_persistence.sig'
         with mock.patch.object(persistence, 'build_persistence', return_value=built) as build_mock, \
                 mock.patch.object(persistence, 'CrossPlatLock'), \
@@ -240,6 +219,7 @@ class TestErasePersistence(unittest.TestCase):
         # A login landing between the erase and the removal would leave a credential in the OS
         # credential store that the removed signal file no longer points at.
         built = mock.MagicMock()
+        built.is_encrypted = True
         built.get_location.return_value = '/tmp/test_persistence.sig'
         calls = []
         with mock.patch.object(persistence, 'build_persistence', return_value=built), \
@@ -265,6 +245,7 @@ class TestErasePersistence(unittest.TestCase):
         # wrote would hide its credential instead of removing it, so the clear is all-or-nothing
         # and the user is told to retry.
         built = mock.MagicMock()
+        built.is_encrypted = True
         built.get_location.return_value = '/tmp/test_persistence.sig'
         built.save.side_effect = Exception('AlreadyLocked')
         with mock.patch.object(persistence, 'build_persistence', return_value=built), \

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
@@ -1,0 +1,58 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+
+from azure.cli.core.auth import persistence
+
+
+class TestEncryptionFallbackWarning(unittest.TestCase):
+    """The plaintext fallback warning is shown at sign-in, not by each persistence build."""
+
+    def setUp(self):
+        persistence._encryption_fallback = False
+        self.addCleanup(setattr, persistence, '_encryption_fallback', False)
+
+    @staticmethod
+    def _build_with_libsecret_unavailable():
+        with mock.patch.object(persistence.sys, 'platform', 'linux'), \
+                mock.patch.object(persistence, 'LibsecretPersistence', side_effect=ImportError('no libsecret')):
+            return persistence.build_persistence('/tmp/test_persistence', True, type='Token cache')
+
+    def test_fallback_is_silent_but_recorded(self):
+        with mock.patch.object(persistence.logger, 'warning') as warning_mock:
+            store = self._build_with_libsecret_unavailable()
+
+        self.assertIsInstance(store, persistence.FilePersistence)
+        warning_mock.assert_not_called()
+        self.assertTrue(persistence._encryption_fallback)
+
+    def test_warning_shown_at_sign_in(self):
+        # Token cache and secret store both fall back, but sign-in warns once.
+        self._build_with_libsecret_unavailable()
+        self._build_with_libsecret_unavailable()
+
+        with mock.patch.object(persistence.logger, 'warning') as warning_mock:
+            persistence.warn_if_encryption_unavailable()
+
+        warning_mock.assert_called_once_with(persistence.ENCRYPTION_FALLBACK_WARNING)
+
+    def test_no_warning_without_fallback(self):
+        with mock.patch.object(persistence.logger, 'warning') as warning_mock:
+            persistence.warn_if_encryption_unavailable()
+
+        warning_mock.assert_not_called()
+
+    def test_no_warning_when_encryption_opted_out(self):
+        with mock.patch.object(persistence.sys, 'platform', 'linux'):
+            store = persistence.build_persistence('/tmp/test_persistence', False, type='Token cache')
+
+        self.assertIsInstance(store, persistence.FilePersistence)
+        self.assertFalse(persistence._encryption_fallback)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -245,6 +245,25 @@ class TestUtils(unittest.TestCase):
         actual = get_az_user_agent()
         self.assertEqual(actual, 'AZURECLI/7.8.9')
 
+    def test_in_managed_environment(self):
+        from azure.cli.core.util import in_ci, in_managed_environment
+
+        for variables in [{}, {'CODESPACES': 'true'}]:
+            with self.subTest(variables=variables):
+                with mock.patch.dict('os.environ', variables, clear=True):
+                    self.assertFalse(in_ci())
+                    self.assertFalse(in_managed_environment())
+
+        with mock.patch.dict('os.environ', {'ACC_CLOUD': 'PROD'}, clear=True):
+            self.assertFalse(in_ci())
+            self.assertTrue(in_managed_environment())
+
+        for variables in [{'GITHUB_ACTIONS': 'true'}, {'TF_BUILD': 'True'}]:
+            with self.subTest(variables=variables):
+                with mock.patch.dict('os.environ', variables, clear=True):
+                    self.assertTrue(in_ci())
+                    self.assertTrue(in_managed_environment())
+
     @mock.patch.dict('os.environ')
     @mock.patch('azure.cli.core._profile.Profile.get_raw_token', autospec=True)
     @mock.patch('requests.Session.send', autospec=True)
@@ -583,6 +602,28 @@ class TestGetProperty(unittest.TestCase):
             getprop(self, 'new_props')
         self.assertEqual(getprop(self, 'maxDiff'), self.maxDiff)
         self.assertEqual(getprop(self, 'new_props', "new_props"), "new_props")
+
+
+class TestShouldEncryptTokenCache(unittest.TestCase):
+    """The default is what a user who never touched the config runs with, so it is pinned here.
+
+    The live encryption tests all set core.encrypt_token_cache or its environment override, so
+    flipping the fallback back to plaintext would not fail any of them.
+    """
+
+    def test_encryption_is_on_by_default(self):
+        from azure.cli.core.util import should_encrypt_token_cache
+        cli = DummyCli()
+        # Nothing configured: the value the caller passes as fallback is what takes effect.
+        with mock.patch.object(cli.config, 'getboolean',
+                               side_effect=lambda section, option, fallback=None: fallback):
+            self.assertTrue(should_encrypt_token_cache(cli))
+
+    def test_config_can_turn_encryption_off(self):
+        from azure.cli.core.util import should_encrypt_token_cache
+        cli = DummyCli()
+        with mock.patch.object(cli.config, 'getboolean', return_value=False):
+            self.assertFalse(should_encrypt_token_cache(cli))
 
 
 class TestHandleException(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -245,25 +245,6 @@ class TestUtils(unittest.TestCase):
         actual = get_az_user_agent()
         self.assertEqual(actual, 'AZURECLI/7.8.9')
 
-    def test_in_managed_environment(self):
-        from azure.cli.core.util import in_ci, in_managed_environment
-
-        for variables in [{}, {'CODESPACES': 'true'}]:
-            with self.subTest(variables=variables):
-                with mock.patch.dict('os.environ', variables, clear=True):
-                    self.assertFalse(in_ci())
-                    self.assertFalse(in_managed_environment())
-
-        with mock.patch.dict('os.environ', {'ACC_CLOUD': 'PROD'}, clear=True):
-            self.assertFalse(in_ci())
-            self.assertTrue(in_managed_environment())
-
-        for variables in [{'GITHUB_ACTIONS': 'true'}, {'TF_BUILD': 'True'}]:
-            with self.subTest(variables=variables):
-                with mock.patch.dict('os.environ', variables, clear=True):
-                    self.assertTrue(in_ci())
-                    self.assertTrue(in_managed_environment())
-
     @mock.patch.dict('os.environ')
     @mock.patch('azure.cli.core._profile.Profile.get_raw_token', autospec=True)
     @mock.patch('requests.Session.send', autospec=True)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1514,9 +1514,10 @@ def get_secret_store(cli_ctx, name):
 
 
 def should_encrypt_token_cache(cli_ctx):
-    # Only enable encryption for Windows (for now).
-    fallback = sys.platform.startswith('win32')
+    # Encryption enabled by default
+    fallback = True
 
+    # TODO: Remove the config and always enable encryption
     # EXPERIMENTAL: Use core.encrypt_token_cache=False to turn off token cache encryption.
     # encrypt_token_cache affects both MSAL token cache and service principal entries.
     encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -843,23 +843,6 @@ def is_github_codespaces():
     return os.environ.get('CODESPACES') == 'true'
 
 
-def in_ci():
-    """Whether az is running on a CI agent."""
-    # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-    # https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables
-    return 'GITHUB_ACTIONS' in os.environ or 'TF_BUILD' in os.environ
-
-
-def in_managed_environment():
-    """Whether az is running on a platform-managed machine that the user doesn't control.
-
-    Covers Cloud Shell and CI agents. Such machines are ephemeral and provide no way to install
-    or unlock an OS credential store, so advice that asks the user to change the machine's
-    configuration is only noise there.
-    """
-    return bool(in_cloud_console() or in_ci())
-
-
 def can_launch_browser():
     import webbrowser
     platform_name, _ = _get_platform_info()

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1624,9 +1624,10 @@ def get_secret_store(cli_ctx, name):
 
 
 def should_encrypt_token_cache(cli_ctx):
-    # Only enable encryption for Windows (for now).
-    fallback = sys.platform.startswith('win32')
+    # Encryption enabled by default
+    fallback = True
 
+    # TODO: Remove the config and always enable encryption
     # EXPERIMENTAL: Use core.encrypt_token_cache=False to turn off token cache encryption.
     # encrypt_token_cache affects both MSAL token cache and service principal entries.
     encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -843,6 +843,23 @@ def is_github_codespaces():
     return os.environ.get('CODESPACES') == 'true'
 
 
+def in_ci():
+    """Whether az is running on a CI agent."""
+    # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    # https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables
+    return 'GITHUB_ACTIONS' in os.environ or 'TF_BUILD' in os.environ
+
+
+def in_managed_environment():
+    """Whether az is running on a platform-managed machine that the user doesn't control.
+
+    Covers Cloud Shell and CI agents. Such machines are ephemeral and provide no way to install
+    or unlock an OS credential store, so advice that asks the user to change the machine's
+    configuration is only noise there.
+    """
+    return bool(in_cloud_console() or in_ci())
+
+
 def can_launch_browser():
     import webbrowser
     platform_name, _ = _get_platform_info()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
`az login`, `az logout`, `az account clear`

**Description**<!--Mandatory-->

Token cache encryption has been Windows-only so far. On macOS and Linux the MSAL token cache and the service principal secret store are written to disk in plaintext, so anything that can read `~/.azure` can read a usable credential.

This PR turns encryption on by default on all platforms, and fixes what that exposes in the surrounding code.

- **Encryption on by default.** `should_encrypt_token_cache` now falls back to `True` instead of `sys.platform.startswith('win32')`. `core.encrypt_token_cache=false` still opts out, and is now the documented escape hatch for machines where the keyring prompt is unwanted.

- **Real names in the OS credential store.** Keychain and libsecret entries were registered under placeholders (`my_service_name`, `my_account_name`, `my_schema_name`, `my_attr1=foo`). They now use `Microsoft Azure CLI` plus the persistence type, so a user browsing Keychain Access or Seahorse sees `Microsoft Azure CLI - Token cache` / `- Secret store` rather than an unlabeled row.

- **Separate file extension for the signal file.** With encryption on, the payload lives in the OS credential store and the file on disk is only a last-modified signal — it is not `.bin` content. Signal files now use `.sig` so the three states (`.bin` encrypted-on-Windows, `.json` plaintext, `.sig` signal) are distinguishable, which is what makes correct cleanup possible.

- **Logout actually clears the credential.** `az logout` / `az account clear` used to just delete the cache files. With encryption on, that orphans the payload in libsecret/Keychain: the credential stays readable. `erase_persistence` now overwrites the payload with an empty one under the same `CrossPlatLock` used by writers, then removes the files. It also cleans up files from every extension, so switching `encrypt_token_cache` doesn't leave stale credentials behind.

- **Plaintext fallback is graceful, and reported.** `LibsecretPersistence` fails to initialize in some Linux environments (no D-Bus session, headless containers). Instead of failing the command, we fall back to `FilePersistence` and warn once at sign-in that credentials are in plaintext. The warning is suppressed in Cloud Shell, where nothing can be installed to fix it.

- **Honest warnings when a clear can't reach the credential store.** With encryption off we deliberately do not touch the keyring — emptying it would raise the unlock prompt the user opted out of. The `.sig` file is kept as evidence that a payload may still be there, and the user is told how to remove it. If the clear itself fails (typically another `az` process holding the lock), nothing is removed and the user is asked to retry, rather than the files being deleted while the credential survives.

**Testing Guide**

macOS / Linux, with a keyring available:

```bash
az login
ls ~/.azure/msal_token_cache.*        # msal_token_cache.sig, no .json
# macOS: Keychain Access shows "Microsoft Azure CLI - Token cache"
# Linux: secret-tool / Seahorse shows "Microsoft Azure CLI - Token cache"

az account clear
az account get-access-token           # must fail: credential is gone, not just the file
```

Opting out:

```bash
az config set core.encrypt_token_cache=false
az login
ls ~/.azure/msal_token_cache.*        # msal_token_cache.json
az account clear                      # no keyring prompt; warns that the store may still hold credentials
```

Linux without a keyring (e.g. `docker run` with no D-Bus): `az login` succeeds and warns that credentials are stored in plaintext.

Unit tests:

```bash
azdev test --src-file-changed
python -m pytest src/azure-cli-core/azure/cli/core/auth/tests/test_persistence.py
```

**History Notes**

[Core] `az login`: Enable token cache and service principal secret encryption by default on macOS and Linux. Set `core.encrypt_token_cache=false` to opt out.
[Core] `az account clear`: Also remove leftover plaintext cache files when `core.encrypt_token_cache` is on.
[Core] `az logout`: Clear the persisted credential according to `core.encrypt_token_cache` — the OS credential store payload when encryption is on, the plaintext files when it is off.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).


