### PR TITLE
Update test utility to remove default resource group

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py
@@ -33,7 +33,7 @@ def get_test_resource_group():
     # is disabled. The recording principal must already hold "App Configuration Data Owner" at a
     # scope covering the store, so tests target a fixed resource group with that standing role
     # instead of an ephemeral @ResourceGroupPreparer group. Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    return os.environ.get("AZURE_CLI_APPCONFIG_TEST_RG", "mametcal-python")
+    return os.environ.get("AZURE_CLI_APPCONFIG_TEST_RG")
 
 
 def _case_insensitive_query_matcher(r1, r2):


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ❌ 128/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Failed" summary="128/130" -->
<details>
<summary>❌AzureCLI-FullTest</summary>

><details>
> <summary>️✔️acr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️acs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️advisor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️ams</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️apim</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>❌appconfig</summary>
>
>><details>
>> <summary>❌latest</summary>
>>
>>><details>
>>> <summary>❌3.12</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_azconfig_feature|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7ff073e82d50><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7ff07506c110><br>command&nbsp;=&nbsp;'appconfig&nbsp;create&nbsp;-n&nbsp;featuretest000001&nbsp;-g&nbsp;None&nbsp;-l&nbsp;eastus&nbsp;--sku&nbsp;standard&nbsp;--retention-days&nbsp;1&nbsp;--disable-local-auth&nbsp;true'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.12/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.12/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:120:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/appconfig/custom.py:108:&nbsp;in&nbsp;create_configstore<br>&nbsp;&nbsp;&nbsp;&nbsp;config_store&nbsp;=&nbsp;client.begin_create(resource_group_name,&nbsp;name,&nbsp;configstore_params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/tracing/decorator.py:119:&nbsp;in&nbsp;wrapper_use_tracer<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;func(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/mgmt/appconfiguration/operations/_operations.py:1274:&nbsp;in&nbsp;begin_create<br>&nbsp;&nbsp;&nbsp;&nbsp;raw_result&nbsp;=&nbsp;self._create_initial(<br>env/lib/python3.12/site-packages/azure/mgmt/appconfiguration/operations/_operations.py:1124:&nbsp;in&nbsp;_create_initial<br>&nbsp;&nbsp;&nbsp;&nbsp;pipeline_response:&nbsp;PipelineResponse&nbsp;=&nbsp;self._client._pipeline.run(&nbsp;&nbsp;#&nbsp;pylint:&nbsp;disable=protected-access<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:242:&nbsp;in&nbsp;run<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;first_node.send(pipeline_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/mgmt/core/policies/_base.py:95:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/policies/_redirect.py:205:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/policies/_retry.py:545:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/policies/_authentication.py:194:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:130:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;self._sender.send(request.http_request,&nbsp;**request.context.options),<br>&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/transport/_requests_basic.py:375:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.session.request(&nbsp;&nbsp;#&nbsp;type:&nbsp;ignore<br>env/lib/python3.12/site-packages/requests/sessions.py:592:&nbsp;in&nbsp;request<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;self.send(prep,&nbsp;**send_kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7ff074365640><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'_case_insensitive_query_matcher']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001&nbsp;!=&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001<br><br>env/lib/python3.12/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.appconfig.tests.latest.test_appconfig_feature_commands.AppConfigFeatureScenarioTest&nbsp;testMethod=test_azconfig_feature><br><br>&nbsp;&nbsp;&nbsp;&nbsp;@AllowLargeResponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Uses&nbsp;Entra&nbsp;ID&nbsp;auth&nbsp;(store&nbsp;created&nbsp;with&nbsp;local&nbsp;auth&nbsp;disabled);&nbsp;target&nbsp;a&nbsp;resource&nbsp;group&nbsp;where&nbsp;the<br>&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;recording&nbsp;principal&nbsp;holds&nbsp;"App&nbsp;Configuration&nbsp;Data&nbsp;Owner".&nbsp;Override&nbsp;via&nbsp;AZURE_CLI_APPCONFIG_TEST_RG.<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_azconfig_feature(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;feature_test_store_prefix&nbsp;=&nbsp;get_resource_name_prefix('featuretest')<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;config_store_name&nbsp;=&nbsp;self.create_random_name(prefix=feature_test_store_prefix,&nbsp;length=24)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;location&nbsp;=&nbsp;'eastus'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sku&nbsp;=&nbsp;'standard'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'config_store_name':&nbsp;config_store_name,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'rg_loc':&nbsp;location,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'rg':&nbsp;get_test_resource_group(),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'sku':&nbsp;sku,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'endpoint':&nbsp;'https://'&nbsp;+&nbsp;config_store_name&nbsp;+&nbsp;'.azconfig.io'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;create_config_store(self,&nbsp;self.kwargs,&nbsp;disable_local_auth=True)<br><br>src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:42:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py:21:&nbsp;in&nbsp;create_config_store<br>&nbsp;&nbsp;&nbsp;&nbsp;test.cmd(command)<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7ff073e82d50><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7ff07506c110><br>command&nbsp;=&nbsp;'appconfig&nbsp;create&nbsp;-n&nbsp;featuretest000001&nbsp;-g&nbsp;None&nbsp;-l&nbsp;eastus&nbsp;--sku&nbsp;standard&nbsp;--retention-days&nbsp;1&nbsp;--disable-local-auth&nbsp;true'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'_case_insensitive_query_matcher']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001&nbsp;!=&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:25|
>>>|Failed|test_azconfig_feature_namespacing|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:467|
>>>|Failed|test_azconfig_feature_telemetry|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:569|
>>>|Failed|test_azconfig_feature_filter|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:661|
>>>|Failed|test_azconfig_json_content_type|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_json_content_type.py:28|
>>>|Failed|test_azconfig_key_validation|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_key_validation.py:24|
>>>|Failed|test_azconfig_kv|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py:26|
>>>|Failed|test_azconfig_kv_revision_list|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py:367|
>>>|Failed|test_azconfig_import_export|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:28|
>>>|Failed|test_azconfig_import_export_kvset|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:400|
>>>|Failed|test_azconfig_import_export_new_fm_schema|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:290|
>>>|Failed|test_azconfig_strict_import|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:455|
>>>|Failed|test_azconfig_import_export_naming_conventions|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:760|
>>>|Failed|test_azconfig_import_export_respect_both_schemas_naming_conventions|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:845|
>>>|Failed|test_appconfig_to_appconfig_import_export|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:1001|
>>>|Failed|test_azconfig_kv_list_resolve_snapshot_references|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_snapshot_reference_commands.py:88|
>>>|Failed|test_azconfig_kv_set_snapshot_reference|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_snapshot_reference_commands.py:23|
>>>|Failed|test_azconfig_snapshot_filtering|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_snapshot_commands.py:183|
>>>|Failed|test_azconfig_snapshot_mgmt|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_snapshot_commands.py:23|
>>>
>>></details>
>>><details>
>>> <summary>❌3.14</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_azconfig_feature|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f2ada7c27b0><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f2ada746d50><br>command&nbsp;=&nbsp;'appconfig&nbsp;create&nbsp;-n&nbsp;featuretest000001&nbsp;-g&nbsp;None&nbsp;-l&nbsp;eastus&nbsp;--sku&nbsp;standard&nbsp;--retention-days&nbsp;1&nbsp;--disable-local-auth&nbsp;true'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.14/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.14/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:120:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/appconfig/custom.py:108:&nbsp;in&nbsp;create_configstore<br>&nbsp;&nbsp;&nbsp;&nbsp;config_store&nbsp;=&nbsp;client.begin_create(resource_group_name,&nbsp;name,&nbsp;configstore_params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/tracing/decorator.py:119:&nbsp;in&nbsp;wrapper_use_tracer<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;func(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/mgmt/appconfiguration/operations/_operations.py:1274:&nbsp;in&nbsp;begin_create<br>&nbsp;&nbsp;&nbsp;&nbsp;raw_result&nbsp;=&nbsp;self._create_initial(<br>env/lib/python3.14/site-packages/azure/mgmt/appconfiguration/operations/_operations.py:1124:&nbsp;in&nbsp;_create_initial<br>&nbsp;&nbsp;&nbsp;&nbsp;pipeline_response:&nbsp;PipelineResponse&nbsp;=&nbsp;self._client._pipeline.run(&nbsp;&nbsp;#&nbsp;pylint:&nbsp;disable=protected-access<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:242:&nbsp;in&nbsp;run<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;first_node.send(pipeline_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/mgmt/core/policies/_base.py:95:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/policies/_redirect.py:205:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/policies/_retry.py:545:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/policies/_authentication.py:194:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:130:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;self._sender.send(request.http_request,&nbsp;**request.context.options),<br>&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/transport/_requests_basic.py:375:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.session.request(&nbsp;&nbsp;#&nbsp;type:&nbsp;ignore<br>env/lib/python3.14/site-packages/requests/sessions.py:592:&nbsp;in&nbsp;request<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;self.send(prep,&nbsp;**send_kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7f2ad984c440><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'_case_insensitive_query_matcher']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001&nbsp;!=&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001<br><br>env/lib/python3.14/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.appconfig.tests.latest.test_appconfig_feature_commands.AppConfigFeatureScenarioTest&nbsp;testMethod=test_azconfig_feature><br><br>&nbsp;&nbsp;&nbsp;&nbsp;@AllowLargeResponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Uses&nbsp;Entra&nbsp;ID&nbsp;auth&nbsp;(store&nbsp;created&nbsp;with&nbsp;local&nbsp;auth&nbsp;disabled);&nbsp;target&nbsp;a&nbsp;resource&nbsp;group&nbsp;where&nbsp;the<br>&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;recording&nbsp;principal&nbsp;holds&nbsp;"App&nbsp;Configuration&nbsp;Data&nbsp;Owner".&nbsp;Override&nbsp;via&nbsp;AZURE_CLI_APPCONFIG_TEST_RG.<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_azconfig_feature(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;feature_test_store_prefix&nbsp;=&nbsp;get_resource_name_prefix('featuretest')<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;config_store_name&nbsp;=&nbsp;self.create_random_name(prefix=feature_test_store_prefix,&nbsp;length=24)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;location&nbsp;=&nbsp;'eastus'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sku&nbsp;=&nbsp;'standard'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'config_store_name':&nbsp;config_store_name,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'rg_loc':&nbsp;location,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'rg':&nbsp;get_test_resource_group(),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'sku':&nbsp;sku,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'endpoint':&nbsp;'https://'&nbsp;+&nbsp;config_store_name&nbsp;+&nbsp;'.azconfig.io'<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;create_config_store(self,&nbsp;self.kwargs,&nbsp;disable_local_auth=True)<br><br>src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:42:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py:21:&nbsp;in&nbsp;create_config_store<br>&nbsp;&nbsp;&nbsp;&nbsp;test.cmd(command)<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f2ada7c27b0><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f2ada746d50><br>command&nbsp;=&nbsp;'appconfig&nbsp;create&nbsp;-n&nbsp;featuretest000001&nbsp;-g&nbsp;None&nbsp;-l&nbsp;eastus&nbsp;--sku&nbsp;standard&nbsp;--retention-days&nbsp;1&nbsp;--disable-local-auth&nbsp;true'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(PUT)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'_case_insensitive_query_matcher']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/None/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001&nbsp;!=&nbsp;/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:25|
>>>|Failed|test_azconfig_feature_namespacing|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:467|
>>>|Failed|test_azconfig_feature_telemetry|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:569|
>>>|Failed|test_azconfig_feature_filter|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py:661|
>>>|Failed|test_azconfig_json_content_type|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_json_content_type.py:28|
>>>|Failed|test_azconfig_key_validation|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_key_validation.py:24|
>>>|Failed|test_azconfig_kv|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py:26|
>>>|Failed|test_azconfig_kv_revision_list|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py:367|
>>>|Failed|test_azconfig_import_export|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:28|
>>>|Failed|test_azconfig_import_export_kvset|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:400|
>>>|Failed|test_azconfig_import_export_new_fm_schema|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:290|
>>>|Failed|test_azconfig_strict_import|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:455|
>>>|Failed|test_azconfig_import_export_naming_conventions|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:760|
>>>|Failed|test_azconfig_import_export_respect_both_schemas_naming_conventions|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:845|
>>>|Failed|test_appconfig_to_appconfig_import_export|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py:1001|
>>>|Failed|test_azconfig_kv_list_resolve_snapshot_references|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_snapshot_reference_commands.py:88|
>>>|Failed|test_azconfig_kv_set_snapshot_reference|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_snapshot_reference_commands.py:23|
>>>|Failed|test_azconfig_snapshot_filtering|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_snapshot_commands.py:183|
>>>|Failed|test_azconfig_snapshot_mgmt|The error message is too long, please check the pipeline log for details.|azure/cli/command_modules/appconfig/tests/latest/test_appconfig_snapshot_commands.py:23|
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️aro</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️backup</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batch</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batchai</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️billing</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️botservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cloud</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cognitiveservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️compute_recommender</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️computefleet</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️config</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️configure</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️consumption</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️container</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️containerapp</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️core</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cosmosdb</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️databoxedge</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dls</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventgrid</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventhubs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️feedback</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️find</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️hdinsight</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️identity</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️iot</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️keyvault</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️lab</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️managedservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️maps</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️marketplaceordering</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️monitor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️mysql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️netappfiles</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️network</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️policyinsights</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️postgresql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️privatedns</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️profile</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️rdbms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️redis</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️relay</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️resource</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️role</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️search</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️security</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicebus</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️serviceconnector</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicefabric</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️signalr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sqlvm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️storage</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️synapse</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️telemetry</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️util</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️vm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Remove default resource group value for tests.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
