### PR TITLE
{AKS} `az aks nodepool rollback`: Show an accurate warning when only the node OS upgrade channel is enabled

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3180,14 +3180,12 @@ def aks_agentpool_rollback(
 
     if upgrade_channel_enabled:
         logger.warning(
-            "Auto-upgrade is enabled on cluster '%s' (upgradeChannel=%s, nodeOSUpgradeChannel=%s). "
+            "Auto-upgrade is enabled on cluster '%s' (upgradeChannel=%s). "
             "Rollback will not succeed until auto-upgrade is disabled. Please disable auto-upgrade to roll back the node pool.",
             cluster_name,
             upgrade_channel_value or "none",
-            node_os_upgrade_channel_value or "Unmanaged",
         )
-
-    if node_os_channel_enabled:
+    elif node_os_channel_enabled:
         logger.warning(
             "nodeOSUpgradeChannel is enabled on cluster '%s' (nodeOSUpgradeChannel=%s). "
             "The orchestrator version rollback will proceed, but the node image rollback "

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3178,13 +3178,22 @@ def aks_agentpool_rollback(
         node_os_upgrade_channel_value and str(node_os_upgrade_channel_value).lower() not in ["none", "unmanaged"]
     )
 
-    if upgrade_channel_enabled or node_os_channel_enabled:
+    if upgrade_channel_enabled:
         logger.warning(
             "Auto-upgrade is enabled on cluster '%s' (upgradeChannel=%s, nodeOSUpgradeChannel=%s). "
             "Rollback will not succeed until auto-upgrade is disabled. Please disable auto-upgrade to roll back the node pool.",
             cluster_name,
             upgrade_channel_value or "none",
             node_os_upgrade_channel_value or "Unmanaged",
+        )
+
+    if node_os_channel_enabled:
+        logger.warning(
+            "nodeOSUpgradeChannel is enabled on cluster '%s' (nodeOSUpgradeChannel=%s). "
+            "The orchestrator version rollback will proceed, but the node image rollback "
+            "will not succeed. Please disable nodeOSUpgradeChannel if you want to roll back the node image.",
+            cluster_name,
+            node_os_upgrade_channel_value,
         )
 
     logger.info("Fetching the most recent rollback version...")

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -1788,6 +1788,36 @@ class AksAgentpoolRollbackTest(unittest.TestCase):
 
         mock_sdk_no_wait.assert_not_called()
 
+    @mock.patch("azure.cli.command_modules.acs._client_factory.cf_managed_clusters")
+    @mock.patch("azure.cli.command_modules.acs.custom.sdk_no_wait")
+    def test_aks_agentpool_rollback_warns_node_image_only_for_node_os_channel(
+        self, mock_sdk_no_wait, mock_cf_managed_clusters
+    ):
+        rollback_version = mock.Mock(
+            orchestrator_version="1.34.8",
+            node_image_version="AKSUbuntu-2204gen2containerd-202607.20.0",
+            timestamp=datetime.datetime(2026, 8, 5),
+        )
+        client = mock.Mock()
+        client.get_upgrade_profile.return_value = mock.Mock(recently_used_versions=[rollback_version])
+        client.get.return_value = mock.Mock()
+        mock_cf_managed_clusters.return_value.get.return_value = mock.Mock(
+            auto_upgrade_profile=mock.Mock(
+                upgrade_channel=mock.Mock(value="none"),
+                node_os_upgrade_channel=mock.Mock(value="NodeImage"),
+            )
+        )
+
+        with mock.patch("azure.cli.command_modules.acs.custom.logger.warning") as mock_warning:
+            aks_agentpool_rollback(self.cmd, client, "rg", "cluster", "nodepool1")
+
+        mock_warning.assert_called_once()
+        warning = mock_warning.call_args.args[0]
+        self.assertIn("The orchestrator version rollback will proceed", warning)
+        self.assertIn("the node image rollback will not succeed", warning)
+        self.assertNotIn("Rollback will not succeed until auto-upgrade is disabled", warning)
+        mock_sdk_no_wait.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -1818,6 +1818,36 @@ class AksAgentpoolRollbackTest(unittest.TestCase):
         self.assertNotIn("Rollback will not succeed until auto-upgrade is disabled", warning)
         mock_sdk_no_wait.assert_called_once()
 
+    @mock.patch("azure.cli.command_modules.acs._client_factory.cf_managed_clusters")
+    @mock.patch("azure.cli.command_modules.acs.custom.sdk_no_wait")
+    def test_aks_agentpool_rollback_prioritizes_upgrade_channel_warning(
+        self, mock_sdk_no_wait, mock_cf_managed_clusters
+    ):
+        rollback_version = mock.Mock(
+            orchestrator_version="1.34.8",
+            node_image_version="AKSUbuntu-2204gen2containerd-202607.20.0",
+            timestamp=datetime.datetime(2026, 8, 5),
+        )
+        client = mock.Mock()
+        client.get_upgrade_profile.return_value = mock.Mock(recently_used_versions=[rollback_version])
+        client.get.return_value = mock.Mock()
+        mock_cf_managed_clusters.return_value.get.return_value = mock.Mock(
+            auto_upgrade_profile=mock.Mock(
+                upgrade_channel=mock.Mock(value="stable"),
+                node_os_upgrade_channel=mock.Mock(value="NodeImage"),
+            )
+        )
+
+        with mock.patch("azure.cli.command_modules.acs.custom.logger.warning") as mock_warning:
+            aks_agentpool_rollback(self.cmd, client, "rg", "cluster", "nodepool1")
+
+        mock_warning.assert_called_once()
+        warning = mock_warning.call_args.args[0]
+        self.assertIn("Rollback will not succeed until auto-upgrade is disabled", warning)
+        self.assertNotIn("nodeOSUpgradeChannel", warning)
+        self.assertNotIn("The orchestrator version rollback will proceed", warning)
+        mock_sdk_no_wait.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

`az aks nodepool rollback`

**Description**

When Kubernetes auto-upgrade is disabled but `nodeOSUpgradeChannel` is enabled, the core CLI currently warns that rollback will not succeed. This is misleading: the orchestrator version rollback proceeds; only the node image rollback is affected by the node OS upgrade channel.

This change ports the split warning behavior from Azure/azure-cli-extensions#9733 while retaining the enum `.value` normalization from Azure/azure-cli#33748:

- `upgradeChannel` enabled: retain the hard warning that rollback will not succeed until auto-upgrade is disabled.
- only `nodeOSUpgradeChannel` enabled: state that orchestrator rollback proceeds but node image rollback will not succeed.
- both disabled: emit no warning.

**Validation**

Live validation with Azure CLI 2.89.0 and no `aks-preview` extension:

1. Created a disposable node pool at Kubernetes 1.34.8.
2. Upgraded it to 1.34.9.
3. Confirmed rollback history targeted 1.34.8.
4. Ran `az aks nodepool rollback` with `upgradeChannel=none` and `nodeOSUpgradeChannel=NodeImage`.
5. Verified the pool returned to `Succeeded` on Kubernetes 1.34.8.
6. Deleted the disposable pool.

Targeted unit tests:

`PYTHONPATH=src/azure-cli /opt/homebrew/Cellar/azure-cli/2.89.0/libexec/bin/python -m unittest azure.cli.command_modules.acs.tests.latest.test_custom.AksAgentpoolRollbackTest`

Result: 4 tests passed.

`git diff --check` passed.

**History Notes**

[AKS] `az aks nodepool rollback`: Show an accurate warning when only the node OS upgrade channel is enabled