### PR TITLE
{AKS} Fix remaining CLI Runner test failures

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -338,9 +338,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 "promotionCode": "",
             },
         }
+        self.kwargs["container_insights_solution"] = json.dumps(solution)
         self.cmd(
             f"resource create --id {solution_id} --api-version 2015-11-01-preview "
-            f"--is-full-object --properties '{json.dumps(solution)}'"
+            "--is-full-object --properties '{container_insights_solution}'"
         )
         return workspace_id
 
@@ -4550,6 +4551,7 @@ spec:
 
     # the availability of features is controlled by a toggle and cannot be fully tested yet,
     # however, existing test results show that the client side works as expected, so exclude it at this moment
+    @unittest.skip("Artifact streaming is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
@@ -4608,6 +4610,7 @@ spec:
 
     # the availability of features is controlled by a toggle and cannot be fully tested yet,
     # however, existing test results show that the client side works as expected, so exclude it at this moment
+    @unittest.skip("Artifact streaming is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
@@ -5255,19 +5258,23 @@ spec:
     def test_aks_create_default_service_with_monitoring_addon_msi(self, resource_group, resource_group_location):
         # kwargs for string formatting
         aks_name = self.create_random_name('cliakstest', 16)
+        workspace_id = self._create_container_insights_workspace(
+            resource_group, resource_group_location
+        )
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
             'dns_name_prefix': self.create_random_name('cliaksdns', 16),
             'ssh_key_value': self.generate_ssh_keys(),
             'location': resource_group_location,
-            'resource_type': 'Microsoft.ContainerService/ManagedClusters'
+            'resource_type': 'Microsoft.ContainerService/ManagedClusters',
+            'workspace_id': workspace_id,
         })
 
         # create cluster with monitoring-addon
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
                      '--dns-name-prefix={dns_name_prefix} --node-count=1 --ssh-key-value={ssh_key_value} ' \
-                     '--enable-addons monitoring'
+                     '--enable-addons monitoring --workspace-resource-id={workspace_id}'
         self.cmd(create_cmd, checks=[
             self.exists('fqdn'),
             self.exists('nodeResourceGroup'),
@@ -8671,6 +8678,7 @@ spec:
             self.is_empty(),
         ])
 
+    @unittest.skip("Control plane metrics is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
@@ -8721,6 +8729,7 @@ spec:
         self.cmd('aks delete --resource-group={resource_group} --name={name} --yes --no-wait',
                  checks=[self.is_empty()])
 
+    @unittest.skip("Control plane metrics is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
@@ -15544,6 +15553,8 @@ spec:
             self.check('agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].minCount', 1),
             self.check('agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
         ])
+        wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --interval 30 --timeout 1800'
+        self.cmd(wait_cmd, checks=[self.is_empty()])
 
         # add another vms nodepool with autoscaler enabled
         add_nodepool_cmd = 'aks nodepool add -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15557,6 +15568,7 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 0),
             self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
         ])
+        self.cmd(wait_cmd, checks=[self.is_empty()])
 
         # update an existing autoscale profile using auto-scale update
         update_autoscale_cmd = 'aks nodepool auto-scale update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15569,6 +15581,7 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 1),
             self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 5),
         ])
+        self.cmd(wait_cmd, checks=[self.is_empty()])
 
         # add a second autoscale profile
         add_autoscale_cmd = 'aks nodepool auto-scale add -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15580,12 +15593,14 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[1].minCount', 1),
             self.check('virtualMachinesProfile.scale.autoscale[1].maxCount', 3),
         ])
+        self.cmd(wait_cmd, checks=[self.is_empty()])
 
         # delete the second autoscale profile
         delete_autoscale_cmd = 'aks nodepool auto-scale delete -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
                                '--current-node-vm-size {node_vm_size1} --yes'
         np = self.cmd(delete_autoscale_cmd).get_output_in_json()
         assert len(np["virtualMachinesProfile"]["scale"]["autoscale"]) == 1
+        self.cmd(wait_cmd, checks=[self.is_empty()])
 
         # disable autoscaler (auto to manual)
         disable_autoscaler_cmd = 'aks nodepool update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15594,6 +15609,7 @@ spec:
             self.check('provisioningState', 'Succeeded'),
             self.check('virtualMachinesProfile.scale.manual[0].size', 'standard_d4s_v3'),
         ])
+        self.cmd(wait_cmd, checks=[self.is_empty()])
 
         # enable autoscaler (manual to auto)
         enable_autoscaler_cmd = 'aks nodepool update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15604,6 +15620,7 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 1),
             self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
         ])
+        self.cmd(wait_cmd, checks=[self.is_empty()])
 
         # delete
         self.cmd('aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -345,6 +345,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         )
         return workspace_id
 
+    def _wait_for_cluster_update(self):
+        if self.is_live or self.in_recording:
+            self.cmd(
+                'aks wait --resource-group={resource_group} --name={name} '
+                '--updated --interval 30 --timeout 1800',
+                checks=[self.is_empty()],
+            )
+
     def _get_lower_lts_version(self, location, version):
         """Return the highest LTS version that is lower than the given version."""
         lts_versions = self._get_lts_versions(location)
@@ -15549,8 +15557,7 @@ spec:
             self.check('agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].minCount', 1),
             self.check('agentPoolProfiles[0].virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
         ])
-        wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --interval 30 --timeout 1800'
-        self.cmd(wait_cmd, checks=[self.is_empty()])
+        self._wait_for_cluster_update()
 
         # add another vms nodepool with autoscaler enabled
         add_nodepool_cmd = 'aks nodepool add -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15564,7 +15571,7 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 0),
             self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
         ])
-        self.cmd(wait_cmd, checks=[self.is_empty()])
+        self._wait_for_cluster_update()
 
         # update an existing autoscale profile using auto-scale update
         update_autoscale_cmd = 'aks nodepool auto-scale update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15577,7 +15584,7 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 1),
             self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 5),
         ])
-        self.cmd(wait_cmd, checks=[self.is_empty()])
+        self._wait_for_cluster_update()
 
         # add a second autoscale profile
         add_autoscale_cmd = 'aks nodepool auto-scale add -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15589,14 +15596,14 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[1].minCount', 1),
             self.check('virtualMachinesProfile.scale.autoscale[1].maxCount', 3),
         ])
-        self.cmd(wait_cmd, checks=[self.is_empty()])
+        self._wait_for_cluster_update()
 
         # delete the second autoscale profile
         delete_autoscale_cmd = 'aks nodepool auto-scale delete -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
                                '--current-node-vm-size {node_vm_size1} --yes'
         np = self.cmd(delete_autoscale_cmd).get_output_in_json()
         assert len(np["virtualMachinesProfile"]["scale"]["autoscale"]) == 1
-        self.cmd(wait_cmd, checks=[self.is_empty()])
+        self._wait_for_cluster_update()
 
         # disable autoscaler (auto to manual)
         disable_autoscaler_cmd = 'aks nodepool update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15605,7 +15612,7 @@ spec:
             self.check('provisioningState', 'Succeeded'),
             self.check('virtualMachinesProfile.scale.manual[0].size', 'standard_d4s_v3'),
         ])
-        self.cmd(wait_cmd, checks=[self.is_empty()])
+        self._wait_for_cluster_update()
 
         # enable autoscaler (manual to auto)
         enable_autoscaler_cmd = 'aks nodepool update -g {resource_group} --cluster-name {name} -n {nodepool_name} ' \
@@ -15616,7 +15623,7 @@ spec:
             self.check('virtualMachinesProfile.scale.autoscale[0].minCount', 1),
             self.check('virtualMachinesProfile.scale.autoscale[0].maxCount', 3),
         ])
-        self.cmd(wait_cmd, checks=[self.is_empty()])
+        self._wait_for_cluster_update()
 
         # delete
         self.cmd('aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -4551,7 +4551,6 @@ spec:
 
     # the availability of features is controlled by a toggle and cannot be fully tested yet,
     # however, existing test results show that the client side works as expected, so exclude it at this moment
-    @unittest.skip("Artifact streaming is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
@@ -4610,7 +4609,6 @@ spec:
 
     # the availability of features is controlled by a toggle and cannot be fully tested yet,
     # however, existing test results show that the client side works as expected, so exclude it at this moment
-    @unittest.skip("Artifact streaming is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
@@ -8678,7 +8676,6 @@ spec:
             self.is_empty(),
         ])
 
-    @unittest.skip("Control plane metrics is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
@@ -8729,7 +8726,6 @@ spec:
         self.cmd('aks delete --resource-group={resource_group} --name={name} --yes --no-wait',
                  checks=[self.is_empty()])
 
-    @unittest.skip("Control plane metrics is not enabled in the live-test subscription")
     @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -130,6 +130,39 @@ class TestCreateContainerInsightsWorkspace(unittest.TestCase):
         self.assertNotIn('{"location"', solution_command)
 
 
+class TestWaitForClusterUpdate(unittest.TestCase):
+
+    @staticmethod
+    def _make_instance(is_live=False, in_recording=False):
+        from azure.cli.command_modules.acs.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+        instance = object.__new__(AzureKubernetesServiceScenarioTest)
+        instance.is_live = is_live
+        instance.in_recording = in_recording
+        instance.cmd = MagicMock()
+        instance.is_empty = MagicMock(return_value='empty-check')
+        return instance
+
+    def test_replay_does_not_issue_wait_request(self):
+        instance = self._make_instance()
+
+        instance._wait_for_cluster_update()
+
+        instance.cmd.assert_not_called()
+
+    def test_live_run_waits_for_cluster_update(self):
+        instance = self._make_instance(is_live=True)
+
+        instance._wait_for_cluster_update()
+
+        instance.cmd.assert_called_once_with(
+            'aks wait --resource-group={resource_group} --name={name} '
+            '--updated --interval 30 --timeout 1800',
+            checks=['empty-check'],
+        )
+
+
 class TestCmdWithRetry(unittest.TestCase):
 
     def _make_instance(self):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -100,6 +100,36 @@ class TestCmdRetryDispatch(unittest.TestCase):
         instance._cmd_with_retry.assert_called_once_with('aks delete', [], False)
 
 
+class TestCreateContainerInsightsWorkspace(unittest.TestCase):
+
+    def test_solution_payload_is_passed_as_registered_kwarg(self):
+        from azure.cli.command_modules.acs.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+        instance = object.__new__(AzureKubernetesServiceScenarioTest)
+        instance.kwargs = {}
+        instance.create_random_name = MagicMock(return_value='workspace')
+        workspace_result = MockExecutionResult({
+            'id': (
+                '/subscriptions/sub/resourceGroups/rg/providers/'
+                'Microsoft.OperationalInsights/workspaces/workspace'
+            )
+        })
+        solution_result = MockExecutionResult({})
+        instance.cmd = MagicMock(side_effect=[workspace_result, solution_result])
+
+        workspace_id = instance._create_container_insights_workspace('rg', 'westus2')
+
+        self.assertEqual(workspace_result.get_output_in_json()['id'], workspace_id)
+        self.assertEqual(
+            json.loads(instance.kwargs['container_insights_solution'])['location'],
+            'westus2',
+        )
+        solution_command = instance.cmd.call_args_list[1].args[0]
+        self.assertIn("'{container_insights_solution}'", solution_command)
+        self.assertNotIn('{"location"', solution_command)
+
+
 class TestCmdWithRetry(unittest.TestCase):
 
     def _make_instance(self):


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

`az aks`

**Description**

Fix the actionable failures observed in CLI Runner run `0c9345bc-24dd-493a-bab5-1ddce36bf31a`:

- pass the Container Insights solution JSON through a registered scenario kwarg so the live retry adapter does not interpret JSON braces as `str.format` placeholders;
- initialize the Container Insights solution before the monitoring-addon MSI scenario creates its cluster, avoiding DCR creation before workspace tables exist;
- wait for the cluster to settle between sequential VirtualMachines nodepool autoscaler operations, while keeping those additional requests out of cassette replay.

Artifact Streaming and Control Plane Metrics scenarios remain enabled. AKS RP investigation found that their failures reflect API-version and deployed-toggle rollout issues rather than deprecated features.

**Testing Guide**

```bash
AZURE_CONFIG_DIR=/tmp/clean-config VIRTUAL_ENV=/workspace/aenv \
  /workspace/aenv/bin/azdev test acs --no-exitfirst
```

Result: `980 passed, 84 skipped, 4 subtests passed`.

```bash
VIRTUAL_ENV=/workspace/aenv /workspace/aenv/bin/azdev style acs
```

Result: pylint and flake8 passed.

The exact Python 3.12/3.14 CI failure was also reproduced and verified with:

```bash
python -m pytest -q \
  src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py \
  src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py::AzureKubernetesServiceScenarioTest::test_aks_create_autoscaler_then_update_vms_pool
```

Result: `30 passed, 5 subtests passed`.

**History Notes**

None. Test-only changes.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
