### PR TITLE
[ARM] `az stack-whatif`: Render "NoEffect" changes in gray with a cross symbol

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_stacks_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_stacks_formatters.py
@@ -22,7 +22,8 @@ ALL_WHAT_IF_TOP_LEVEL_CHANGE_TYPES = [
     StackModels.DeploymentStacksWhatIfChangeType.MODIFY,
     StackModels.DeploymentStacksWhatIfChangeType.DELETE,
     StackModels.DeploymentStacksWhatIfChangeType.NO_CHANGE,
-    StackModels.DeploymentStacksWhatIfChangeType.DETACH
+    StackModels.DeploymentStacksWhatIfChangeType.DETACH,
+    StackModels.DeploymentStacksWhatIfPropertyChangeType.NO_EFFECT
 ]
 
 
@@ -38,7 +39,7 @@ class DeploymentStacksWhatIfResultFormatter:  # pylint: disable=too-few-public-m
             StackModels.DeploymentStacksWhatIfChangeType.DETACH: 'v',
             StackModels.DeploymentStacksWhatIfChangeType.MODIFY: '~',
             StackModels.DeploymentStacksWhatIfChangeType.NO_CHANGE: '=',
-            StackModels.DeploymentStacksWhatIfPropertyChangeType.NO_EFFECT: '=',
+            StackModels.DeploymentStacksWhatIfPropertyChangeType.NO_EFFECT: 'x',
             StackModels.DeploymentStacksWhatIfChangeType.UNSUPPORTED: '!',
         })
 
@@ -48,7 +49,8 @@ class DeploymentStacksWhatIfResultFormatter:  # pylint: disable=too-few-public-m
             StackModels.DeploymentStacksWhatIfChangeType.CREATE: Color.GREEN,
             StackModels.DeploymentStacksWhatIfChangeType.DELETE: Color.RED,
             StackModels.DeploymentStacksWhatIfChangeType.DETACH: Color.BLUE,
-            StackModels.DeploymentStacksWhatIfChangeType.MODIFY: Color.PURPLE
+            StackModels.DeploymentStacksWhatIfChangeType.MODIFY: Color.PURPLE,
+            StackModels.DeploymentStacksWhatIfPropertyChangeType.NO_EFFECT: Color.GRAY,
         })
 
     CHANGE_CERTAINTY_PRIORITIES = CaseInsensitiveDict(
@@ -481,9 +483,7 @@ class DeploymentStacksWhatIfResultFormatter:  # pylint: disable=too-few-public-m
             return False
 
         change_type = primitive_change.change_type if hasattr(primitive_change, "change_type") else None
-        change_type = (change_type or (StackModels.DeploymentStacksWhatIfPropertyChangeType.NO_EFFECT
-                                       if primitive_change.before == primitive_change.after
-                                       else StackModels.DeploymentStacksWhatIfPropertyChangeType.MODIFY))
+        change_type = change_type or StackModels.DeploymentStacksWhatIfPropertyChangeType.MODIFY
 
         property_path = self._get_change_path(primitive_change, parent_path)
         symbol, color = self._get_change_type_formatting(change_type)

--- a/src/azure-cli/azure/cli/command_modules/resource/_stacks_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_stacks_formatters.py
@@ -474,8 +474,11 @@ class DeploymentStacksWhatIfResultFormatter:  # pylint: disable=too-few-public-m
 
     def _format_primitive_change(
         self,
-        primitive_change: t.Optional[
-            t.Union[StackModels.DeploymentStacksChangeBase, StackModels.DeploymentStacksWhatIfPropertyChange]],
+        primitive_change: t.Optional[t.Union[
+            StackModels.DeploymentStacksChangeBase,
+            StackModels.DeploymentStacksWhatIfPropertyChange,
+            StackModels.DeploymentStacksChangeBaseDenyStatusMode,
+            StackModels.DeploymentStacksChangeBaseDeploymentStacksManagementStatus]],
         parent_path: t.Optional[str] = None,
         is_array_item: bool = False
     ) -> bool:
@@ -483,7 +486,9 @@ class DeploymentStacksWhatIfResultFormatter:  # pylint: disable=too-few-public-m
             return False
 
         change_type = primitive_change.change_type if hasattr(primitive_change, "change_type") else None
-        change_type = change_type or StackModels.DeploymentStacksWhatIfPropertyChangeType.MODIFY
+        change_type = (change_type or (StackModels.DeploymentStacksWhatIfChangeType.NO_CHANGE
+                                       if primitive_change.before == primitive_change.after
+                                       else StackModels.DeploymentStacksWhatIfPropertyChangeType.MODIFY))
 
         property_path = self._get_change_path(primitive_change, parent_path)
         symbol, color = self._get_change_type_formatting(change_type)

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/data/stacks-what-if/what-if-1.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/data/stacks-what-if/what-if-1.json
@@ -69,6 +69,12 @@
                 "before": "resourceA-before",
                 "after": "resourceA-after",
                 "children": []
+              },
+              {
+                "path": "sku.tier",
+                "changeType": "noEffect",
+                "after": "Standard",
+                "children": []
               }
             ]
           },

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_stack_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_stack_formatters.py
@@ -23,6 +23,7 @@ class TestStacksWhatIfResultFormatter(unittest.TestCase):
         what_if_result = self._get_stacks_what_if_result("what-if-1.json")
 
         formatted = DeploymentStacksWhatIfResultFormatter().format(what_if_result)
+        print(formatted)
         self.assertEqual(self.EXPECTED_STACKS_WHAT_IF_1, formatted)
 
         expected_no_color_result = self.EXPECTED_STACKS_WHAT_IF_1
@@ -36,6 +37,7 @@ class TestStacksWhatIfResultFormatter(unittest.TestCase):
         what_if_result = self._get_stacks_what_if_result("what-if-2.json")
 
         formatted = DeploymentStacksWhatIfResultFormatter().format(what_if_result)
+        print(formatted)
         self.assertEqual(self.EXPECTED_STACKS_WHAT_IF_2, formatted)
 
         expected_no_color_result = self.EXPECTED_STACKS_WHAT_IF_2
@@ -62,6 +64,7 @@ class TestStacksWhatIfResultFormatter(unittest.TestCase):
   {Color.GREEN}+{Color.RESET} Create              ! Unsupported
   {Color.PURPLE}~{Color.RESET} Modify              {Color.RED}-{Color.RESET} Delete
   = NoChange            {Color.BLUE}v{Color.RESET} Detach
+  {Color.GRAY}x{Color.RESET} NoEffect            
 
 {Color.DARK_YELLOW}Changes to Stack /subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Resources/deploymentStacks/testStack_9ef16884f0dad7d0e5de3d3ec57:{Color.RESET}
 {Color.PURPLE}~{Color.RESET} DeploymentScope: {Color.PURPLE}"ThisIsBefore"{Color.RESET} => {Color.PURPLE}"ThisIsAfter"{Color.RESET}
@@ -82,8 +85,8 @@ class TestStacksWhatIfResultFormatter(unittest.TestCase):
 
 Azure
   {Color.PURPLE}~{Color.RESET} {Color.PURPLE}/subscriptions/648e207a-a8cf-4a20-a557-59ee31ea46a3/resourceGroups/WhatIfTestNew/providers/Microsoft.Web/sites/web-gwfjnc7423h2a/providers/Microsoft.Insights/diagnosticSettings/diag-web-gwfjnc7423h2a [2021-05-01-preview]{Color.RESET}
-    = Management Status: "managed"
-    = Deny Status: "none"
+    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"managed"{Color.RESET} => {Color.PURPLE}"managed"{Color.RESET}
+    {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"none"{Color.RESET} => {Color.PURPLE}"none"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} properties.nestedArrays:
       {Color.GREEN}+{Color.RESET} 0:
           {Color.GREEN}[]{Color.RESET}
@@ -151,11 +154,12 @@ Azure
           {Color.GREEN}  }}{Color.RESET}
           {Color.GREEN}}}{Color.RESET}
   {Color.PURPLE}~{Color.RESET} {Color.PURPLE}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testA/resourceA [2021-05-01]{Color.RESET}
-    = Management Status: "Managed"
+    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"DenyDelete"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} properties.properties1: {Color.PURPLE}"resourceA-before"{Color.RESET} => {Color.PURPLE}"resourceA-after"{Color.RESET}
+    {Color.GRAY}x{Color.RESET} sku.tier: {Color.GRAY}"Standard"{Color.RESET}
   = /subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testB/resourceB [2021-05-01]
-    = Management Status: "Managed"
+    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"DenyDelete"{Color.RESET}
   {Color.GREEN}+{Color.RESET} {Color.GREEN}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testD/resourceD [2021-05-01]{Color.RESET}
     {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"NotManaged"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
@@ -163,17 +167,17 @@ Azure
 
   >> {Color.PURPLE}Potential Resource Changes (Learn more at https://aka.ms/whatIfPotentialChanges){Color.RESET}
   {Color.CYAN}?{Color.RESET}{Color.PURPLE}~{Color.RESET} {Color.CYAN}[Potential] {Color.RESET}{Color.PURPLE}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testC/resourceC [2021-05-01]{Color.RESET}
-    = Management Status: "Managed"
+    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"DenyDelete"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} properties.properties1: {Color.PURPLE}"resourceC-before"{Color.RESET} => {Color.PURPLE}"resourceC-potential-after"{Color.RESET}
   {Color.CYAN}?{Color.RESET}{Color.RED}-{Color.RESET} {Color.CYAN}[Potential] {Color.RESET}{Color.RED}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testC/resourceC{Color.RESET}
     {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"NotManaged"{Color.RESET}
-    = Deny Status: "None"
+    {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"None"{Color.RESET}
 
 Contoso@2.0.0
   {Color.PURPLE}~{Color.RESET} {Color.PURPLE}Contoso/example name="abcResource" [v1]{Color.RESET}
-    = Management Status: "Managed"
-    = Deny Status: "NotSupported"
+    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
+    {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"NotSupported"{Color.RESET} => {Color.PURPLE}"NotSupported"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} properties.properties1: {Color.PURPLE}"resourceA-before"{Color.RESET} => {Color.PURPLE}"resourceA-after"{Color.RESET}
     {Color.GREEN}+{Color.RESET} properties.someConfig: {Color.GREEN}{{{Color.RESET}
       {Color.GREEN}  "type": "object",{Color.RESET}

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_stack_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_stack_formatters.py
@@ -85,8 +85,8 @@ class TestStacksWhatIfResultFormatter(unittest.TestCase):
 
 Azure
   {Color.PURPLE}~{Color.RESET} {Color.PURPLE}/subscriptions/648e207a-a8cf-4a20-a557-59ee31ea46a3/resourceGroups/WhatIfTestNew/providers/Microsoft.Web/sites/web-gwfjnc7423h2a/providers/Microsoft.Insights/diagnosticSettings/diag-web-gwfjnc7423h2a [2021-05-01-preview]{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"managed"{Color.RESET} => {Color.PURPLE}"managed"{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"none"{Color.RESET} => {Color.PURPLE}"none"{Color.RESET}
+    = Management Status: "managed"
+    = Deny Status: "none"
     {Color.PURPLE}~{Color.RESET} properties.nestedArrays:
       {Color.GREEN}+{Color.RESET} 0:
           {Color.GREEN}[]{Color.RESET}
@@ -154,12 +154,12 @@ Azure
           {Color.GREEN}  }}{Color.RESET}
           {Color.GREEN}}}{Color.RESET}
   {Color.PURPLE}~{Color.RESET} {Color.PURPLE}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testA/resourceA [2021-05-01]{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
+    = Management Status: "Managed"
     {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"DenyDelete"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} properties.properties1: {Color.PURPLE}"resourceA-before"{Color.RESET} => {Color.PURPLE}"resourceA-after"{Color.RESET}
     {Color.GRAY}x{Color.RESET} sku.tier: {Color.GRAY}"Standard"{Color.RESET}
   = /subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testB/resourceB [2021-05-01]
-    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
+    = Management Status: "Managed"
     {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"DenyDelete"{Color.RESET}
   {Color.GREEN}+{Color.RESET} {Color.GREEN}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testD/resourceD [2021-05-01]{Color.RESET}
     {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"NotManaged"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
@@ -167,17 +167,17 @@ Azure
 
   >> {Color.PURPLE}Potential Resource Changes (Learn more at https://aka.ms/whatIfPotentialChanges){Color.RESET}
   {Color.CYAN}?{Color.RESET}{Color.PURPLE}~{Color.RESET} {Color.CYAN}[Potential] {Color.RESET}{Color.PURPLE}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testC/resourceC [2021-05-01]{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
+    = Management Status: "Managed"
     {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"DenyDelete"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} properties.properties1: {Color.PURPLE}"resourceC-before"{Color.RESET} => {Color.PURPLE}"resourceC-potential-after"{Color.RESET}
   {Color.CYAN}?{Color.RESET}{Color.RED}-{Color.RESET} {Color.CYAN}[Potential] {Color.RESET}{Color.RED}/subscriptions/6d41d86d-eb6b-473a-b31d-bbd084e1814d/resourceGroups/503ace4c-9b1c-4059-a3e9-09553d24e9e1/providers/Microsoft.Test/testC/resourceC{Color.RESET}
     {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"NotManaged"{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"None"{Color.RESET} => {Color.PURPLE}"None"{Color.RESET}
+    = Deny Status: "None"
 
 Contoso@2.0.0
   {Color.PURPLE}~{Color.RESET} {Color.PURPLE}Contoso/example name="abcResource" [v1]{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} Management Status: {Color.PURPLE}"Managed"{Color.RESET} => {Color.PURPLE}"Managed"{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} Deny Status: {Color.PURPLE}"NotSupported"{Color.RESET} => {Color.PURPLE}"NotSupported"{Color.RESET}
+    = Management Status: "Managed"
+    = Deny Status: "NotSupported"
     {Color.PURPLE}~{Color.RESET} properties.properties1: {Color.PURPLE}"resourceA-before"{Color.RESET} => {Color.PURPLE}"resourceA-after"{Color.RESET}
     {Color.GREEN}+{Color.RESET} properties.someConfig: {Color.GREEN}{{{Color.RESET}
       {Color.GREEN}  "type": "object",{Color.RESET}
@@ -243,6 +243,7 @@ INFO: [InfoCode]
   {Color.GREEN}+{Color.RESET} Create              ! Unsupported
   {Color.PURPLE}~{Color.RESET} Modify              {Color.RED}-{Color.RESET} Delete
   = NoChange            {Color.BLUE}v{Color.RESET} Detach
+  {Color.GRAY}x{Color.RESET} NoEffect            
 
 {Color.DARK_YELLOW}Changes to Managed Resources:{Color.RESET}
 


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->





**Related command**
`az stack-whatif`

**Description**<!--Mandatory-->
Fixes rendering issue with stacks what-if.

**Testing Guide**
Refer to the unit tests for rendering related updates.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] `az stack-whatif`: Resource changes with the type "NoEffect" are now colored gray and marked with a cross symbol instead of using the same appearance as the "NoChange" change type

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
