### PR TITLE
[App Service] `az functionapp flex-migration start/revert`: Add in-place CV1 to Flex Consumption upgrade and revert support

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1233,7 +1233,7 @@ examples:
 
   - name: Upgrade a Linux Consumption function app to Flex Consumption in place (same app, same name).
     text: >
-        az functionapp flex-migration start --source-name MyLinuxConsumptionApp --source-resource-group MyResourceGroup --in-place
+        az functionapp flex-migration start --source-name MyLinuxConsumptionApp --source-resource-group MyLinuxConsumptionResourceGroup --in-place
 """
 
 helps['functionapp flex-migration revert'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1216,7 +1216,7 @@ short-summary: List available built-in stacks which can be used for function app
 
 helps['functionapp flex-migration'] = """
 type: group
-short-summary: Manage migration of Linux Consumption function apps to the Flex Consumption plan — side-by-side (new app) or in place (same app).
+short-summary: Manage migration between Linux Consumption and Flex Consumption plans.
 """
 
 helps['functionapp flex-migration start'] = """
@@ -1234,6 +1234,15 @@ examples:
   - name: Upgrade a Linux Consumption function app to Flex Consumption in place (same app, same name).
     text: >
         az functionapp flex-migration start --source-name MyLinuxConsumptionApp --source-resource-group MyResourceGroup --in-place
+"""
+
+helps['functionapp flex-migration revert'] = """
+type: command
+short-summary: Revert an in-place upgraded Flex Consumption function app to Linux Consumption.
+examples:
+  - name: Revert a function app to Linux Consumption within its revert window.
+    text: >
+        az functionapp flex-migration revert --source-name MyFunctionApp --source-resource-group MyResourceGroup
 """
 
 helps['functionapp flex-migration list'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1216,20 +1216,24 @@ short-summary: List available built-in stacks which can be used for function app
 
 helps['functionapp flex-migration'] = """
 type: group
-short-summary: Manage migration of Linux Consumption function apps to the Flex Consumption plan.
+short-summary: Manage migration of Linux Consumption function apps to the Flex Consumption plan — side-by-side (new app) or in place (same app).
 """
 
 helps['functionapp flex-migration start'] = """
 type: command
-short-summary: Create a Flex Consumption app with the same settings as the provided Linux Consumption function app.
+short-summary: Migrate a Linux Consumption function app to Flex Consumption. Supports side-by-side (new app) or in-place (same app) upgrade.
 examples:
-  - name: Migrate a Linux Consumption function app to the Flex Consumption plan.
+  - name: Migrate a Linux Consumption function app to the Flex Consumption plan (side-by-side, creates a new app).
     text: >
         az functionapp flex-migration start --source-name MyLinuxConsumptionApp --source-resource-group MyLinuxConsumptionResourceGroup --name MyFunctionApp --resource-group MyResourceGroup --storage-account MyStorageAccount
 
   - name: Migrate a Linux Consumption function app to the Flex Consumption plan without migrating managed identity configurations.
     text: >
         az functionapp flex-migration start --source-name MyLinuxConsumptionApp --source-resource-group MyLinuxConsumptionResourceGroup --name MyFunctionApp --resource-group MyResourceGroup --storage-account MyStorageAccount --skip-managed-identities
+
+  - name: Upgrade a Linux Consumption function app to Flex Consumption in place (same app, same name).
+    text: >
+        az functionapp flex-migration start --source-name MyLinuxConsumptionApp --source-resource-group MyResourceGroup --in-place
 """
 
 helps['functionapp flex-migration list'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -458,6 +458,10 @@ subscription than the app service environment, please use the resource ID for --
         c.argument('skip_hostnames', options_list=['--skip-hostnames', '--sh'], arg_type=get_three_state_flag(return_label=True), help="Skip migrating hostnames.")
         c.argument('skip_cors', options_list=['--skip-cors', '--sc'], arg_type=get_three_state_flag(return_label=True), help="Skip migrating CORS settings.")
 
+    with self.argument_context('functionapp flex-migration revert') as c:
+        c.argument('source_resource_group', help='The resource group of the function app to revert.')
+        c.argument('source_name', help='The name of the function app to revert.')
+
     with self.argument_context('webapp deleted list') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
         c.argument('slot', options_list=['--slot', '-s'], help='Name of the deleted web app slot.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -439,10 +439,19 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('functionapp flex-migration start') as c:
         c.argument('source_resource_group', help='The resource group of the source function app to migrate from.')
         c.argument('source_name', help='The name of the source function app to migrate from.')
-        c.argument('resource_group', help='The resource group of the target function app to migrate to.')
-        c.argument('name', help='The name of the target function app to migrate to.')
+        c.argument('resource_group', help='The resource group of the target function app to migrate to. Not applicable with --in-place.')
+        c.argument('name', help='The name of the target function app to migrate to. Not applicable with --in-place.')
         c.argument('storage_account', help='The storage account to use for the target function app. If no storage account is provided, the storage account of the source function app will be used.')
         c.argument('maximum_instance_count', type=int, help="The maximum number of instances.")
+        c.argument('in_place', options_list=['--in-place', '-i'], arg_type=get_three_state_flag(), help="Upgrade the source app to Flex Consumption in place (same app, same name, same hostname). Cannot be used with --name or --resource-group.", is_preview=True)
+        c.argument('instance_memory', type=int, help="The instance memory size in MB. See https://aka.ms/flex-instance-sizes for more information on the supported values.")
+        c.argument('always_ready_instances', nargs='+', help="space-separated configuration for the number of pre-allocated instances in the format `<name>=<value>`")
+        c.argument('deployment_storage_name', options_list=['--deployment-storage-name', '--dsn'], help="The deployment storage account name.")
+        c.argument('deployment_storage_container_name', options_list=['--deployment-storage-container-name', '--dscn'], help="The deployment storage account container name.")
+        c.argument('deployment_storage_auth_type', options_list=['--deployment-storage-auth-type', '--dsat'], arg_type=get_enum_type(DEPLOYMENT_STORAGE_AUTH_TYPES), help="The deployment storage account authentication type.")
+        c.argument('deployment_storage_auth_value', options_list=['--deployment-storage-auth-value', '--dsav'], help="The deployment storage account authentication value. For the user-assigned managed identity authentication type, "
+                   "this should be the user assigned identity resource id. For the storage account connection string authentication type, this should be the name of the app setting that will contain the storage account connection "
+                   "string. For the system assigned managed-identity authentication type, this parameter is not applicable and should be left empty.")
         c.argument('skip_managed_identities', options_list=['--skip-managed-identities', '--smi'], arg_type=get_three_state_flag(return_label=True), help="Skip migrating managed identities.")
         c.argument('skip_access_restrictions', options_list=['--skip-access-restrictions', '--sar'], arg_type=get_three_state_flag(return_label=True), help="Skip migrating access restrictions.")
         c.argument('skip_storage_mount', options_list=['--skip-storage-mount', '--ssm'], arg_type=get_three_state_flag(return_label=True), help="Skip migrating storage mounts.")

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -480,6 +480,7 @@ def load_command_table(self, _):
 
     with self.command_group('functionapp flex-migration') as g:
         g.custom_command('start', 'migrate_consumption_to_flex', exception_handler=ex_handler_factory())
+        g.custom_command('revert', 'revert_flex_migration', exception_handler=ex_handler_factory(), is_preview=True)
         g.custom_command('list', 'list_flex_migration_candidates', exception_handler=ex_handler_factory())
 
     with self.command_group('functionapp deployment config') as g:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1504,6 +1504,12 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     # NOTE: serverFarmId is deliberately left unchanged (existing CV1 plan id).
     # The orchestrator (SkuTransitionResolver) owns FC server-farm creation on the same stamp.
 
+    # Clear CV1-specific siteConfig properties that are invalid for Flex Consumption.
+    # The GET returns the existing site with these set; the server rejects them on a Flex PUT.
+    if site.site_config is not None:
+        site.site_config.linux_fx_version = None
+        site.site_config.function_app_scale_limit = None
+
     # Add deployment storage connection string app setting if using connection string auth
     if app_settings_to_add:
         from azure.mgmt.web.models import NameValuePair

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1521,8 +1521,14 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         for setting in app_settings_to_add:
             site.site_config.app_settings.append(NameValuePair(name=setting['name'], value=setting['value']))
 
+    # The SkuTransitionResolver reads from a top-level "sku" object (siteEnvelope.Sku.Name),
+    # not from properties.sku. The SDK Site model doesn't expose a top-level sku field,
+    # so we serialize to dict and inject it manually.
+    site_dict = site.as_dict()
+    site_dict['sku'] = {'name': 'FlexConsumption'}
+
     print(f"Submitting upgrade request for '{source_name}'...")
-    poller = flex_client.web_apps.begin_create_or_update(source_resource_group, source_name, site)
+    poller = flex_client.web_apps.begin_create_or_update(source_resource_group, source_name, site_dict)
     LongRunningOperation(cmd.cli_ctx)(poller)
 
     print(f"\nUpgrade complete. Function app '{source_name}' is now on Flex Consumption."

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1529,6 +1529,33 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     return get_functionapp(cmd, source_resource_group, source_name)
 
 
+def revert_flex_migration(cmd, source_resource_group, source_name):
+    site = get_raw_functionapp(cmd.cli_ctx, source_resource_group, source_name)
+    sku = site.get('properties', {}).get('sku')
+    if not sku or sku.lower() != 'flexconsumption':
+        raise ValidationError(
+            "The site '{}' is not on Flex Consumption. Only function apps upgraded in place from Linux Consumption "
+            "can be reverted.".format(source_name))
+
+    flex_client = web_client_factory(cmd.cli_ctx, api_version='2025-05-01')
+    revert_request = {
+        'kind': 'functionapp,linux',
+        'location': site['location'],
+        'properties': {
+            'reserved': True,
+            'sku': 'Dynamic'
+        },
+        'sku': {'name': 'Dynamic'}
+    }
+
+    print(f"Reverting function app '{source_name}' to Linux Consumption...")
+    poller = flex_client.web_apps.begin_create_or_update(source_resource_group, source_name, revert_request)
+    LongRunningOperation(cmd.cli_ctx)(poller)
+
+    print(f"Function app '{source_name}' reverted to Linux Consumption.")
+    return get_functionapp(cmd, source_resource_group, source_name)
+
+
 def _migrate_app_settings(cmd, source_resource_group, source_name, resource_group, name, storage_account):
     print(f"\nMigrating app settings from source function app '{source_name}' to target function app '{name}'...")
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1274,10 +1274,26 @@ def get_storage_account_from_functionapp(cmd, resource_group_name, name):
                                 .format(storage_account_name, name))
 
 
-def migrate_consumption_to_flex(cmd, source_resource_group, source_name, resource_group, name, storage_account=None,
+def migrate_consumption_to_flex(cmd, source_resource_group, source_name, resource_group=None, name=None,
+                                storage_account=None,
                                 maximum_instance_count=None, skip_managed_identities=False,
                                 skip_access_restrictions=False, skip_storage_mount=False, skip_hostnames=False,
-                                skip_cors=False):
+                                skip_cors=False, in_place=False,
+                                instance_memory=None, always_ready_instances=None,
+                                deployment_storage_name=None, deployment_storage_container_name=None,
+                                deployment_storage_auth_type=None, deployment_storage_auth_value=None):
+
+    # Validate --in-place mutual exclusions
+    if in_place:
+        if name or resource_group:
+            raise MutuallyExclusiveArgumentError(
+                "'--in-place' cannot be used with '--name' or '--resource-group'. "
+                "In-place upgrade operates on the source app directly.")
+    else:
+        if not name or not resource_group:
+            raise RequiredArgumentMissingError(
+                "'--name' and '--resource-group' are required for side-by-side migration. "
+                "Use '--in-place' to upgrade the source app directly.")
 
     web_client = get_mgmt_service_client(cmd.cli_ctx, WebSiteManagementClient)
 
@@ -1285,6 +1301,11 @@ def migrate_consumption_to_flex(cmd, source_resource_group, source_name, resourc
     print(f"Validating that the app '{source_name}' is eligible for Flex Consumption migration...")
     flex_regions = [region['name'] for region in list_flexconsumption_locations(cmd)]
     source = web_client.web_apps.get(source_resource_group, source_name)
+
+    # Check if already on Flex (in-place only)
+    if in_place and is_flex_functionapp(cmd.cli_ctx, source_resource_group, source_name):
+        raise ValidationError("The site '{}' is already on Flex Consumption. No upgrade needed."
+                              .format(source_name))
 
     if not _is_linux_consumption_function_app(cmd, source):
         raise ValidationError("The site '{}' is not on a Linux Dynamic (Consumption) plan. Flex Consumption "
@@ -1308,6 +1329,15 @@ def migrate_consumption_to_flex(cmd, source_resource_group, source_name, resourc
     source_runtime_info = _get_functionapp_runtime_info_helper(cmd, source_linux_fx_version, None, None, True)
     source_runtime = source_runtime_info['app_runtime']
     source_runtime_version = source_runtime_info['app_runtime_version']
+
+    # Branch: in-place upgrade vs side-by-side migration
+    if in_place:
+        return _upgrade_consumption_to_flex_in_place(
+            cmd, source, source_resource_group, source_name,
+            storage_account, deployment_storage_name, deployment_storage_container_name,
+            deployment_storage_auth_type, deployment_storage_auth_value,
+            source_runtime, source_runtime_version,
+            instance_memory, maximum_instance_count, always_ready_instances)
 
     print(f"\nCreating Flex Consumption function app '{name}' in resource group '{resource_group}'...")
 
@@ -1369,6 +1399,131 @@ def migrate_consumption_to_flex(cmd, source_resource_group, source_name, resourc
           f"https://learn.microsoft.com/en-us/azure/azure-functions/migration/migrate-plan-consumption-to-flex")
 
     return get_functionapp(cmd, resource_group, name)
+
+
+def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, source_name,
+                                          storage_account, deployment_storage_name,
+                                          deployment_storage_container_name,
+                                          deployment_storage_auth_type, deployment_storage_auth_value,
+                                          source_runtime, source_runtime_version,
+                                          instance_memory, maximum_instance_count, always_ready_instances):
+    """Upgrade an existing CV1 Linux Consumption function app to Flex Consumption in place."""
+    from azure.mgmt.web.models import SiteProperties
+    from ._validators import validate_and_convert_to_int
+
+    print(f"\nUpgrading function app '{source_name}' to Flex Consumption in place...")
+
+    # Resolve deployment storage (same logic as create)
+    if not storage_account:
+        storage_account = get_storage_account_from_functionapp(cmd, source_resource_group, source_name)
+    storage_account_name = parse_resource_id(storage_account)['name'] if is_valid_resource_id(storage_account) \
+        else storage_account
+
+    if not deployment_storage_name:
+        deployment_storage_name = storage_account_name
+
+    deployment_storage = _validate_and_get_deployment_storage(cmd.cli_ctx, source_resource_group,
+                                                              deployment_storage_name)
+
+    deployment_storage_container = _get_or_create_deployment_storage_container(
+        cmd, source_resource_group, source_name, deployment_storage_name, deployment_storage_container_name)
+    deployment_storage_container_name = deployment_storage_container.name
+
+    endpoints = deployment_storage.primary_endpoints
+    deployment_config_storage_value = getattr(endpoints, 'blob') + deployment_storage_container_name
+
+    # Build deployment storage auth config
+    deployment_storage_auth_type = deployment_storage_auth_type or 'StorageAccountConnectionString'
+
+    if deployment_storage_auth_value and deployment_storage_auth_type == 'SystemAssignedIdentity':
+        raise ArgumentUsageError(
+            '--deployment-storage-auth-value is only a valid input when '
+            '--deployment-storage-auth-type is set to UserAssignedIdentity or StorageAccountConnectionString. '
+            'Please try again with --deployment-storage-auth-type set to UserAssignedIdentity or '
+            'StorageAccountConnectionString.')
+
+    deployment_storage_auth_config = {"type": deployment_storage_auth_type}
+
+    # Handle auth type-specific configuration
+    app_settings_to_add = []
+    if deployment_storage_auth_type == 'UserAssignedIdentity':
+        deployment_storage_user_assigned_identity = _get_or_create_user_assigned_identity(
+            cmd, source_resource_group, source_name, deployment_storage_auth_value, source.location)
+        deployment_storage_auth_value = deployment_storage_user_assigned_identity.id
+        deployment_storage_auth_config["userAssignedIdentityResourceId"] = deployment_storage_auth_value
+    elif deployment_storage_auth_type == 'StorageAccountConnectionString':
+        deployment_storage_conn_string = _get_storage_connection_string(cmd.cli_ctx, deployment_storage)
+        conn_string_app_setting = deployment_storage_auth_value or 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+        app_settings_to_add.append({'name': conn_string_app_setting, 'value': deployment_storage_conn_string})
+        deployment_storage_auth_value = conn_string_app_setting
+        deployment_storage_auth_config["storageAccountConnectionStringName"] = deployment_storage_auth_value
+
+    # Build functionAppConfig
+    function_app_config = {}
+    function_app_config["deployment"] = {
+        "storage": {
+            "type": "blobContainer",
+            "value": deployment_config_storage_value,
+            "authentication": deployment_storage_auth_config
+        }
+    }
+
+    # Resolve runtime from the source app's existing runtime
+    runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, source.location, source_runtime, source_runtime_version)
+    matched_runtime = runtime_helper.resolve(source_runtime, source_runtime_version)
+    flex_sku = matched_runtime.sku
+
+    runtime = flex_sku['functionAppConfigProperties']['runtime']['name']
+    version = flex_sku['functionAppConfigProperties']['runtime']['version']
+    function_app_config["runtime"] = {"name": runtime, "version": version}
+
+    # Scale and concurrency
+    always_ready_dict = _parse_key_value_pairs(always_ready_instances)
+    always_ready_config = []
+    for key, value in always_ready_dict.items():
+        always_ready_config.append({
+            "name": key,
+            "instanceCount": max(0, validate_and_convert_to_int(key, value))
+        })
+
+    default_instance_memory = [x for x in flex_sku['instanceMemoryMB'] if x['isDefault'] is True][0]
+    function_app_config["scaleAndConcurrency"] = {
+        "maximumInstanceCount": maximum_instance_count or flex_sku['maximumInstanceCount']['defaultValue'],
+        "instanceMemoryMB": instance_memory or default_instance_memory['size'],
+        "alwaysReady": always_ready_config
+    }
+
+    # GET-mutate-PUT against the EXISTING site (no new plan, no new app)
+    flex_client = web_client_factory(cmd.cli_ctx, api_version='2025-05-01')
+    site = flex_client.web_apps.get(source_resource_group, source_name)
+
+    if site.properties is None:
+        site.properties = SiteProperties()
+    site.properties.function_app_config = function_app_config
+    site.properties.sku = "FlexConsumption"
+    # NOTE: serverFarmId is deliberately left unchanged (existing CV1 plan id).
+    # The orchestrator (SkuTransitionResolver) owns FC server-farm creation on the same stamp.
+
+    # Add deployment storage connection string app setting if using connection string auth
+    if app_settings_to_add:
+        from azure.mgmt.web.models import NameValuePair
+        if site.site_config is None:
+            from azure.mgmt.web.models import SiteConfig
+            site.site_config = SiteConfig()
+        if site.site_config.app_settings is None:
+            site.site_config.app_settings = []
+        for setting in app_settings_to_add:
+            site.site_config.app_settings.append(NameValuePair(name=setting['name'], value=setting['value']))
+
+    print(f"Submitting upgrade request for '{source_name}'...")
+    poller = flex_client.web_apps.begin_create_or_update(source_resource_group, source_name, site)
+    LongRunningOperation(cmd.cli_ctx)(poller)
+
+    print(f"\nUpgrade complete. Function app '{source_name}' is now on Flex Consumption."
+          f"\nNote: The app may take a few moments to become fully operational on Flex infrastructure."
+          f"\nA 7-day revert window is available via ACIS if needed.")
+
+    return get_functionapp(cmd, source_resource_group, source_name)
 
 
 def _migrate_app_settings(cmd, source_resource_group, source_name, resource_group, name, storage_account):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1437,6 +1437,10 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
 
     deployment_storage = _validate_and_get_deployment_storage(cmd.cli_ctx, source_resource_group,
                                                               deployment_storage_name)
+    if deployment_storage.sku.name == 'Premium_LRS':
+        raise ValidationError("Premium deployment storage is not supported for in-place Flex Consumption upgrade.")
+    if getattr(deployment_storage, 'is_hns_enabled', False) is True:
+        raise ValidationError("ADLS Gen2 deployment storage is not supported for in-place Flex Consumption upgrade.")
 
     deployment_storage_container = _get_or_create_deployment_storage_container(
         cmd, source_resource_group, source_name, deployment_storage_name, deployment_storage_container_name)
@@ -1461,37 +1465,12 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         deployment_storage_auth_value = conn_string_app_setting
         deployment_storage_auth_config["storageAccountConnectionStringName"] = deployment_storage_auth_value
 
-    function_app_config = {}
-    function_app_config["deployment"] = {
-        "storage": {
-            "type": "blobContainer",
-            "value": deployment_config_storage_value,
-            "authentication": deployment_storage_auth_config
-        }
-    }
-
     runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, source.location, source_runtime, source_runtime_version)
     matched_runtime = runtime_helper.resolve(source_runtime, source_runtime_version)
     flex_sku = matched_runtime.sku
-
-    runtime = flex_sku['functionAppConfigProperties']['runtime']['name']
-    version = flex_sku['functionAppConfigProperties']['runtime']['version']
-    function_app_config["runtime"] = {"name": runtime, "version": version}
-
-    always_ready_dict = _parse_key_value_pairs(always_ready_instances)
-    always_ready_config = []
-    for key, value in always_ready_dict.items():
-        always_ready_config.append({
-            "name": key,
-            "instanceCount": max(0, validate_and_convert_to_int(key, value))
-        })
-
-    default_instance_memory = [x for x in flex_sku['instanceMemoryMB'] if x['isDefault'] is True][0]
-    function_app_config["scaleAndConcurrency"] = {
-        "maximumInstanceCount": maximum_instance_count or flex_sku['maximumInstanceCount']['defaultValue'],
-        "instanceMemoryMB": instance_memory or default_instance_memory['size'],
-        "alwaysReady": always_ready_config
-    }
+    function_app_config = _build_flex_function_app_config(
+        deployment_config_storage_value, deployment_storage_auth_config, flex_sku,
+        instance_memory, maximum_instance_count, always_ready_instances)
 
     _prepare_flex_migration_deployment_storage_identity(
         cmd, source_resource_group, source_name, deployment_storage_auth_type, deployment_storage_auth_value,
@@ -1559,6 +1538,35 @@ def _prepare_flex_migration_deployment_storage_identity(
     elif deployment_storage_auth_type == 'SystemAssignedIdentity':
         assign_identity(cmd, resource_group_name, name, ['[system]'], 'Storage Blob Data Contributor',
                         None, deployment_storage.id)
+
+
+def _build_flex_function_app_config(deployment_storage_value, deployment_storage_auth_config, flex_sku,
+                                    instance_memory, maximum_instance_count, always_ready_instances):
+    always_ready_config = [{
+        "name": key,
+        "instanceCount": max(0, validate_and_convert_to_int(key, value))
+    } for key, value in _parse_key_value_pairs(always_ready_instances).items()]
+    default_instance_memory = [x for x in flex_sku['instanceMemoryMB'] if x['isDefault'] is True][0]
+    runtime = flex_sku['functionAppConfigProperties']['runtime']
+
+    return {
+        "deployment": {
+            "storage": {
+                "type": "blobContainer",
+                "value": deployment_storage_value,
+                "authentication": deployment_storage_auth_config
+            }
+        },
+        "runtime": {
+            "name": runtime['name'],
+            "version": runtime['version']
+        },
+        "scaleAndConcurrency": {
+            "maximumInstanceCount": maximum_instance_count or flex_sku['maximumInstanceCount']['defaultValue'],
+            "instanceMemoryMB": instance_memory or default_instance_memory['size'],
+            "alwaysReady": always_ready_config
+        }
+    }
 
 
 def revert_flex_migration(cmd, source_resource_group, source_name):
@@ -9655,16 +9663,8 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
                     'StorageAccountConnectionString.'
                 )
 
-            function_app_config = {}
             deployment_storage_auth_config = {
                 "type": deployment_storage_auth_type
-            }
-            function_app_config["deployment"] = {
-                "storage": {
-                    "type": "blobContainer",
-                    "value": deployment_config_storage_value,
-                    "authentication": deployment_storage_auth_config
-                }
             }
 
             if deployment_storage_auth_type == 'UserAssignedIdentity':
@@ -9687,31 +9687,9 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
                 deployment_storage_auth_config["storageAccountConnectionStringName"] = deployment_storage_auth_value
 
             flex_sku = matched_runtime.sku
-            runtime = flex_sku['functionAppConfigProperties']['runtime']['name']
-            version = flex_sku['functionAppConfigProperties']['runtime']['version']
-            runtime_config = {
-                "name": runtime,
-                "version": version
-            }
-            function_app_config["runtime"] = runtime_config
-            always_ready_dict = _parse_key_value_pairs(always_ready_instances)
-            always_ready_config = []
-
-            for key, value in always_ready_dict.items():
-                always_ready_config.append(
-                    {
-                        "name": key,
-                        "instanceCount": max(0, validate_and_convert_to_int(key, value))
-                    }
-                )
-
-            default_instance_memory = [x for x in flex_sku['instanceMemoryMB'] if x['isDefault'] is True][0]
-
-            function_app_config["scaleAndConcurrency"] = {
-                "maximumInstanceCount": maximum_instance_count or flex_sku['maximumInstanceCount']['defaultValue'],
-                "instanceMemoryMB": instance_memory or default_instance_memory['size'],
-                "alwaysReady": always_ready_config
-            }
+            function_app_config = _build_flex_function_app_config(
+                deployment_config_storage_value, deployment_storage_auth_config, flex_sku,
+                instance_memory, maximum_instance_count, always_ready_instances)
 
             # Set flex consumption properties on the site
             from azure.mgmt.web.models import SiteProperties

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1413,7 +1413,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
 
     print(f"\nUpgrading function app '{source_name}' to Flex Consumption in place...")
 
-    # Resolve deployment storage (same logic as create)
     if not storage_account:
         storage_account = get_storage_account_from_functionapp(cmd, source_resource_group, source_name)
     storage_account_name = parse_resource_id(storage_account)['name'] if is_valid_resource_id(storage_account) \
@@ -1432,7 +1431,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     endpoints = deployment_storage.primary_endpoints
     deployment_config_storage_value = getattr(endpoints, 'blob') + deployment_storage_container_name
 
-    # Build deployment storage auth config
     deployment_storage_auth_type = deployment_storage_auth_type or 'StorageAccountConnectionString'
 
     if deployment_storage_auth_value and deployment_storage_auth_type == 'SystemAssignedIdentity':
@@ -1444,7 +1442,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
 
     deployment_storage_auth_config = {"type": deployment_storage_auth_type}
 
-    # Handle auth type-specific configuration
     app_settings_to_add = []
     if deployment_storage_auth_type == 'UserAssignedIdentity':
         deployment_storage_user_assigned_identity = _get_or_create_user_assigned_identity(
@@ -1458,7 +1455,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         deployment_storage_auth_value = conn_string_app_setting
         deployment_storage_auth_config["storageAccountConnectionStringName"] = deployment_storage_auth_value
 
-    # Build functionAppConfig
     function_app_config = {}
     function_app_config["deployment"] = {
         "storage": {
@@ -1468,7 +1464,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         }
     }
 
-    # Resolve runtime from the source app's existing runtime
     runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, source.location, source_runtime, source_runtime_version)
     matched_runtime = runtime_helper.resolve(source_runtime, source_runtime_version)
     flex_sku = matched_runtime.sku
@@ -1477,7 +1472,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     version = flex_sku['functionAppConfigProperties']['runtime']['version']
     function_app_config["runtime"] = {"name": runtime, "version": version}
 
-    # Scale and concurrency
     always_ready_dict = _parse_key_value_pairs(always_ready_instances)
     always_ready_config = []
     for key, value in always_ready_dict.items():
@@ -1493,7 +1487,7 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         "alwaysReady": always_ready_config
     }
 
-    # GET-mutate-PUT against the EXISTING site (no new plan, no new app)
+    # GET-mutate-PUT the existing site
     flex_client = web_client_factory(cmd.cli_ctx, api_version='2025-05-01')
     site = flex_client.web_apps.get(source_resource_group, source_name)
 
@@ -1501,40 +1495,31 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         site.properties = SiteProperties()
     site.properties.function_app_config = function_app_config
     site.properties.sku = "FlexConsumption"
-    # NOTE: serverFarmId is deliberately left unchanged (existing CV1 plan id).
-    # The orchestrator (SkuTransitionResolver) owns FC server-farm creation on the same stamp.
+    # serverFarmId left unchanged; the orchestrator creates the FC plan on the same stamp.
 
-    # Clear CV1-specific siteConfig properties that are invalid for Flex Consumption.
-    # The GET returns the existing site with these set; the server rejects them on a Flex PUT.
+    # Clear CV1 siteConfig properties that the server rejects on a Flex PUT.
     if site.site_config is not None:
         site.site_config.linux_fx_version = None
         site.site_config.function_app_scale_limit = None
 
-    # Do NOT add app_settings_to_add to site.site_config.app_settings for the PUT.
-    # The GET returns site_config.app_settings as None (settings live in /config/appsettings).
-    # If we set them here, the server treats it as the full list and drops existing settings.
-    # Instead, we merge them via a separate update_app_settings call after the upgrade completes.
+    # Set app settings via dedicated API BEFORE the PUT — the orchestrator's
+    # MigrateDeploymentAsync reads from the appsettings store, not from the PUT body.
+    if app_settings_to_add:
+        from azure.mgmt.web.models import StringDictionary
+        existing_settings = flex_client.web_apps.list_application_settings(source_resource_group, source_name)
+        settings_dict = existing_settings.properties or {}
+        for setting in app_settings_to_add:
+            settings_dict[setting['name']] = setting['value']
+        flex_client.web_apps.update_application_settings(
+            source_resource_group, source_name, StringDictionary(properties=settings_dict))
 
-    # The SkuTransitionResolver reads from a top-level "sku" object (siteEnvelope.Sku.Name),
-    # not from properties.sku. The SDK Site model doesn't expose a top-level sku field,
-    # so we serialize to dict and inject it manually.
+    # SkuTransitionResolver reads top-level sku.name, not properties.sku — inject manually.
     site_dict = site.as_dict()
     site_dict['sku'] = {'name': 'FlexConsumption'}
 
     print(f"Submitting upgrade request for '{source_name}'...")
     poller = flex_client.web_apps.begin_create_or_update(source_resource_group, source_name, site_dict)
     LongRunningOperation(cmd.cli_ctx)(poller)
-
-    # After upgrade completes, merge new app settings (e.g. DEPLOYMENT_STORAGE_CONNECTION_STRING)
-    # into the existing settings via the dedicated appsettings API. This preserves existing settings.
-    if app_settings_to_add:
-        existing_settings = flex_client.web_apps.list_application_settings(source_resource_group, source_name)
-        settings_dict = existing_settings.properties or {}
-        for setting in app_settings_to_add:
-            settings_dict[setting['name']] = setting['value']
-        from azure.mgmt.web.models import StringDictionary
-        flex_client.web_apps.update_application_settings(
-            source_resource_group, source_name, StringDictionary(properties=settings_dict))
 
     print(f"\nUpgrade complete. Function app '{source_name}' is now on Flex Consumption."
           f"\nNote: The app may take a few moments to become fully operational on Flex infrastructure."

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1422,6 +1422,19 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     if not deployment_storage_name:
         deployment_storage_name = storage_account_name
 
+    deployment_storage_auth_type = deployment_storage_auth_type or 'StorageAccountConnectionString'
+
+    if deployment_storage_auth_value and deployment_storage_auth_type == 'SystemAssignedIdentity':
+        raise ArgumentUsageError(
+            '--deployment-storage-auth-value is only a valid input when '
+            '--deployment-storage-auth-type is set to UserAssignedIdentity or StorageAccountConnectionString. '
+            'Please try again with --deployment-storage-auth-type set to UserAssignedIdentity or '
+            'StorageAccountConnectionString.')
+    if deployment_storage_auth_type == 'UserAssignedIdentity' and not deployment_storage_auth_value:
+        raise ArgumentUsageError(
+            '--deployment-storage-auth-value is required when '
+            '--deployment-storage-auth-type is set to UserAssignedIdentity.')
+
     deployment_storage = _validate_and_get_deployment_storage(cmd.cli_ctx, source_resource_group,
                                                               deployment_storage_name)
 
@@ -1432,18 +1445,10 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     endpoints = deployment_storage.primary_endpoints
     deployment_config_storage_value = getattr(endpoints, 'blob') + deployment_storage_container_name
 
-    deployment_storage_auth_type = deployment_storage_auth_type or 'StorageAccountConnectionString'
-
-    if deployment_storage_auth_value and deployment_storage_auth_type == 'SystemAssignedIdentity':
-        raise ArgumentUsageError(
-            '--deployment-storage-auth-value is only a valid input when '
-            '--deployment-storage-auth-type is set to UserAssignedIdentity or StorageAccountConnectionString. '
-            'Please try again with --deployment-storage-auth-type set to UserAssignedIdentity or '
-            'StorageAccountConnectionString.')
-
     deployment_storage_auth_config = {"type": deployment_storage_auth_type}
 
     app_settings_to_add = []
+    deployment_storage_user_assigned_identity = None
     if deployment_storage_auth_type == 'UserAssignedIdentity':
         deployment_storage_user_assigned_identity = _get_or_create_user_assigned_identity(
             cmd, source_resource_group, source_name, deployment_storage_auth_value, source.location)
@@ -1488,6 +1493,10 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         "alwaysReady": always_ready_config
     }
 
+    _prepare_flex_migration_deployment_storage_identity(
+        cmd, source_resource_group, source_name, deployment_storage_auth_type, deployment_storage_auth_value,
+        deployment_storage, deployment_storage_name, deployment_storage_user_assigned_identity)
+
     # GET-mutate-PUT the existing site
     flex_client = web_client_factory(cmd.cli_ctx, api_version='2025-05-01')
     site = flex_client.web_apps.get(source_resource_group, source_name)
@@ -1524,9 +1533,32 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
 
     print(f"\nUpgrade complete. Function app '{source_name}' is now on Flex Consumption."
           f"\nNote: The app may take a few moments to become fully operational on Flex infrastructure."
-          f"\nA 7-day revert window is available via ACIS if needed.")
+          f"\nA 7-day revert window is available via 'az functionapp flex-migration revert' if needed.")
 
     return get_functionapp(cmd, source_resource_group, source_name)
+
+
+def _prepare_flex_migration_deployment_storage_identity(
+        cmd, resource_group_name, name, deployment_storage_auth_type, deployment_storage_auth_value,
+        deployment_storage, deployment_storage_name, deployment_storage_user_assigned_identity=None):
+    """Attach the deployment storage identity and grant access before migration begins."""
+    if deployment_storage_auth_type == 'UserAssignedIdentity':
+        assign_identity(cmd, resource_group_name, name, [deployment_storage_auth_value])
+        if not _has_deployment_storage_role_assignment_on_resource(
+                cmd.cli_ctx,
+                deployment_storage,
+                deployment_storage_user_assigned_identity.principal_id):
+            _assign_deployment_storage_managed_identity_role(
+                cmd.cli_ctx,
+                deployment_storage,
+                deployment_storage_user_assigned_identity.principal_id)
+        else:
+            logger.warning("User assigned identity '%s' already has the role assignment on "
+                           "the storage account '%s'",
+                           deployment_storage_user_assigned_identity.principal_id, deployment_storage_name)
+    elif deployment_storage_auth_type == 'SystemAssignedIdentity':
+        assign_identity(cmd, resource_group_name, name, ['[system]'], 'Storage Blob Data Contributor',
+                        None, deployment_storage.id)
 
 
 def revert_flex_migration(cmd, source_resource_group, source_name):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1510,16 +1510,10 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
         site.site_config.linux_fx_version = None
         site.site_config.function_app_scale_limit = None
 
-    # Add deployment storage connection string app setting if using connection string auth
-    if app_settings_to_add:
-        from azure.mgmt.web.models import NameValuePair
-        if site.site_config is None:
-            from azure.mgmt.web.models import SiteConfig
-            site.site_config = SiteConfig()
-        if site.site_config.app_settings is None:
-            site.site_config.app_settings = []
-        for setting in app_settings_to_add:
-            site.site_config.app_settings.append(NameValuePair(name=setting['name'], value=setting['value']))
+    # Do NOT add app_settings_to_add to site.site_config.app_settings for the PUT.
+    # The GET returns site_config.app_settings as None (settings live in /config/appsettings).
+    # If we set them here, the server treats it as the full list and drops existing settings.
+    # Instead, we merge them via a separate update_app_settings call after the upgrade completes.
 
     # The SkuTransitionResolver reads from a top-level "sku" object (siteEnvelope.Sku.Name),
     # not from properties.sku. The SDK Site model doesn't expose a top-level sku field,
@@ -1530,6 +1524,17 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     print(f"Submitting upgrade request for '{source_name}'...")
     poller = flex_client.web_apps.begin_create_or_update(source_resource_group, source_name, site_dict)
     LongRunningOperation(cmd.cli_ctx)(poller)
+
+    # After upgrade completes, merge new app settings (e.g. DEPLOYMENT_STORAGE_CONNECTION_STRING)
+    # into the existing settings via the dedicated appsettings API. This preserves existing settings.
+    if app_settings_to_add:
+        existing_settings = flex_client.web_apps.list_application_settings(source_resource_group, source_name)
+        settings_dict = existing_settings.properties or {}
+        for setting in app_settings_to_add:
+            settings_dict[setting['name']] = setting['value']
+        from azure.mgmt.web.models import StringDictionary
+        flex_client.web_apps.update_application_settings(
+            source_resource_group, source_name, StringDictionary(properties=settings_dict))
 
     print(f"\nUpgrade complete. Function app '{source_name}' is now on Flex Consumption."
           f"\nNote: The app may take a few moments to become fully operational on Flex infrastructure."

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1274,6 +1274,18 @@ def get_storage_account_from_functionapp(cmd, resource_group_name, name):
                                 .format(storage_account_name, name))
 
 
+def _validate_flex_migration_target_arguments(in_place, name, resource_group):
+    if in_place:
+        if name or resource_group:
+            raise MutuallyExclusiveArgumentError(
+                "'--in-place' cannot be used with '--name' or '--resource-group'. "
+                "In-place upgrade operates on the source app directly.")
+    elif not name or not resource_group:
+        raise RequiredArgumentMissingError(
+            "'--name' and '--resource-group' are required for side-by-side migration. "
+            "Use '--in-place' to upgrade the source app directly.")
+
+
 def migrate_consumption_to_flex(cmd, source_resource_group, source_name, resource_group=None, name=None,
                                 storage_account=None,
                                 maximum_instance_count=None, skip_managed_identities=False,
@@ -1283,17 +1295,7 @@ def migrate_consumption_to_flex(cmd, source_resource_group, source_name, resourc
                                 deployment_storage_name=None, deployment_storage_container_name=None,
                                 deployment_storage_auth_type=None, deployment_storage_auth_value=None):
 
-    # Validate --in-place mutual exclusions
-    if in_place:
-        if name or resource_group:
-            raise MutuallyExclusiveArgumentError(
-                "'--in-place' cannot be used with '--name' or '--resource-group'. "
-                "In-place upgrade operates on the source app directly.")
-    else:
-        if not name or not resource_group:
-            raise RequiredArgumentMissingError(
-                "'--name' and '--resource-group' are required for side-by-side migration. "
-                "Use '--in-place' to upgrade the source app directly.")
+    _validate_flex_migration_target_arguments(in_place, name, resource_group)
 
     web_client = get_mgmt_service_client(cmd.cli_ctx, WebSiteManagementClient)
 
@@ -1409,7 +1411,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
                                           instance_memory, maximum_instance_count, always_ready_instances):
     """Upgrade an existing CV1 Linux Consumption function app to Flex Consumption in place."""
     from azure.mgmt.web.models import SiteProperties
-    from ._validators import validate_and_convert_to_int
 
     print(f"\nUpgrading function app '{source_name}' to Flex Consumption in place...")
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1410,8 +1410,6 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
                                           source_runtime, source_runtime_version,
                                           instance_memory, maximum_instance_count, always_ready_instances):
     """Upgrade an existing CV1 Linux Consumption function app to Flex Consumption in place."""
-    from azure.mgmt.web.models import SiteProperties
-
     print(f"\nUpgrading function app '{source_name}' to Flex Consumption in place...")
 
     if not storage_account:
@@ -1435,80 +1433,71 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
             '--deployment-storage-auth-value is required when '
             '--deployment-storage-auth-type is set to UserAssignedIdentity.')
 
-    deployment_storage = _validate_and_get_deployment_storage(cmd.cli_ctx, source_resource_group,
-                                                              deployment_storage_name)
-    if deployment_storage.sku.name == 'Premium_LRS':
-        raise ValidationError("Premium deployment storage is not supported for in-place Flex Consumption upgrade.")
-    if getattr(deployment_storage, 'is_hns_enabled', False) is True:
-        raise ValidationError("ADLS Gen2 deployment storage is not supported for in-place Flex Consumption upgrade.")
-
-    deployment_storage_container = _get_or_create_deployment_storage_container(
-        cmd, source_resource_group, source_name, deployment_storage_name, deployment_storage_container_name)
-    deployment_storage_container_name = deployment_storage_container.name
-
-    endpoints = deployment_storage.primary_endpoints
-    deployment_config_storage_value = getattr(endpoints, 'blob') + deployment_storage_container_name
-
-    deployment_storage_auth_config = {"type": deployment_storage_auth_type}
-
-    app_settings_to_add = []
-    deployment_storage_user_assigned_identity = None
-    if deployment_storage_auth_type == 'UserAssignedIdentity':
-        deployment_storage_user_assigned_identity = _get_or_create_user_assigned_identity(
-            cmd, source_resource_group, source_name, deployment_storage_auth_value, source.location)
-        deployment_storage_auth_value = deployment_storage_user_assigned_identity.id
-        deployment_storage_auth_config["userAssignedIdentityResourceId"] = deployment_storage_auth_value
-    elif deployment_storage_auth_type == 'StorageAccountConnectionString':
-        deployment_storage_conn_string = _get_storage_connection_string(cmd.cli_ctx, deployment_storage)
-        conn_string_app_setting = deployment_storage_auth_value or 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
-        app_settings_to_add.append({'name': conn_string_app_setting, 'value': deployment_storage_conn_string})
-        deployment_storage_auth_value = conn_string_app_setting
-        deployment_storage_auth_config["storageAccountConnectionStringName"] = deployment_storage_auth_value
-
     runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, source.location, source_runtime, source_runtime_version)
     matched_runtime = runtime_helper.resolve(source_runtime, source_runtime_version)
     flex_sku = matched_runtime.sku
-    function_app_config = _build_flex_function_app_config(
-        deployment_config_storage_value, deployment_storage_auth_config, flex_sku,
-        instance_memory, maximum_instance_count, always_ready_instances)
-
-    _prepare_flex_migration_deployment_storage_identity(
-        cmd, source_resource_group, source_name, deployment_storage_auth_type, deployment_storage_auth_value,
-        deployment_storage, deployment_storage_name, deployment_storage_user_assigned_identity)
-
-    # GET-mutate-PUT the existing site
     flex_client = web_client_factory(cmd.cli_ctx, api_version='2025-05-01')
-    site = flex_client.web_apps.get(source_resource_group, source_name)
+    existing_settings = flex_client.web_apps.list_application_settings(source_resource_group, source_name)
+    existing_settings_dict = dict(existing_settings.properties or {})
+    deployment_storage_account_name = parse_resource_id(deployment_storage_name)['name'] \
+        if is_valid_resource_id(deployment_storage_name) else deployment_storage_name
+    default_connection_string_name = 'AzureWebJobsStorage' \
+        if deployment_storage_account_name.lower() == storage_account_name.lower() and \
+        'AzureWebJobsStorage' in existing_settings_dict else 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
 
-    if site.properties is None:
-        site.properties = SiteProperties()
-    site.properties.function_app_config = function_app_config
-    site.properties.sku = "FlexConsumption"
-    # serverFarmId left unchanged; the orchestrator creates the FC plan on the same stamp.
+    storage_setup = _prepare_flex_deployment_storage(
+        cmd, source_resource_group, source_name, deployment_storage_name,
+        deployment_storage_container_name, deployment_storage_auth_type, deployment_storage_auth_value,
+        source.location, flex_sku, instance_memory, maximum_instance_count, always_ready_instances,
+        existing_settings_dict, default_connection_string_name, validate_for_in_place=True)
 
-    # Clear CV1 siteConfig properties that the server rejects on a Flex PUT.
-    if site.site_config is not None:
-        site.site_config.linux_fx_version = None
-        site.site_config.function_app_scale_limit = None
+    identity_changes = None
+    settings_updated = False
+    request_submitted = False
+    try:
+        identity_changes = _prepare_flex_deployment_storage_identity(
+            cmd, source_resource_group, source_name, storage_setup, getattr(source, 'identity', None))
 
-    # Set app settings via dedicated API BEFORE the PUT — the orchestrator's
-    # MigrateDeploymentAsync reads from the appsettings store, not from the PUT body.
-    if app_settings_to_add:
-        from azure.mgmt.web.models import StringDictionary
-        existing_settings = flex_client.web_apps.list_application_settings(source_resource_group, source_name)
-        settings_dict = existing_settings.properties or {}
-        for setting in app_settings_to_add:
-            settings_dict[setting['name']] = setting['value']
-        flex_client.web_apps.update_application_settings(
-            source_resource_group, source_name, StringDictionary(properties=settings_dict))
+        # MigrateDeploymentAsync reads connection strings from the app settings store.
+        if storage_setup['app_settings_to_add']:
+            settings_dict = dict(existing_settings_dict)
+            for setting in storage_setup['app_settings_to_add']:
+                settings_dict[setting['name']] = setting['value']
+            settings_updated = True
+            from azure.mgmt.web.models import StringDictionary
+            flex_client.web_apps.update_application_settings(
+                source_resource_group, source_name, StringDictionary(properties=settings_dict))
 
-    # SkuTransitionResolver reads top-level sku.name, not properties.sku — inject manually.
-    site_dict = site.as_dict()
-    site_dict['sku'] = {'name': 'FlexConsumption'}
+        upgrade_request = {
+            'location': source.location,
+            'sku': {'name': 'FlexConsumption'},
+            'properties': {
+                'serverFarmId': source.server_farm_id,
+                'functionAppConfig': {
+                    'deployment': storage_setup['function_app_config']['deployment']
+                }
+            }
+        }
 
-    print(f"Submitting upgrade request for '{source_name}'...")
-    poller = flex_client.web_apps.begin_create_or_update(source_resource_group, source_name, site_dict)
-    LongRunningOperation(cmd.cli_ctx)(poller)
+        print(f"Submitting upgrade request for '{source_name}'...")
+        poller = flex_client.web_apps.begin_create_or_update(
+            source_resource_group, source_name, upgrade_request)
+        request_submitted = True
+        LongRunningOperation(cmd.cli_ctx)(poller)
+    except Exception:
+        if request_submitted:
+            raise
+        try:
+            if settings_updated:
+                _rollback_flex_deployment_storage_app_settings(
+                    flex_client, source_resource_group, source_name, storage_setup['app_settings_to_add'])
+        finally:
+            try:
+                _rollback_flex_deployment_storage_identity(
+                    cmd, source_resource_group, source_name, identity_changes)
+            finally:
+                _cleanup_flex_deployment_storage(cmd, source_resource_group, storage_setup)
+        raise
 
     print(f"\nUpgrade complete. Function app '{source_name}' is now on Flex Consumption."
           f"\nNote: The app may take a few moments to become fully operational on Flex infrastructure."
@@ -1517,27 +1506,146 @@ def _upgrade_consumption_to_flex_in_place(cmd, source, source_resource_group, so
     return get_functionapp(cmd, source_resource_group, source_name)
 
 
-def _prepare_flex_migration_deployment_storage_identity(
-        cmd, resource_group_name, name, deployment_storage_auth_type, deployment_storage_auth_value,
-        deployment_storage, deployment_storage_name, deployment_storage_user_assigned_identity=None):
-    """Attach the deployment storage identity and grant access before migration begins."""
-    if deployment_storage_auth_type == 'UserAssignedIdentity':
-        assign_identity(cmd, resource_group_name, name, [deployment_storage_auth_value])
-        if not _has_deployment_storage_role_assignment_on_resource(
-                cmd.cli_ctx,
-                deployment_storage,
-                deployment_storage_user_assigned_identity.principal_id):
-            _assign_deployment_storage_managed_identity_role(
-                cmd.cli_ctx,
-                deployment_storage,
-                deployment_storage_user_assigned_identity.principal_id)
+def _rollback_flex_deployment_storage_app_settings(
+        flex_client, resource_group_name, name, app_settings_to_add):
+    current_settings = flex_client.web_apps.list_application_settings(resource_group_name, name)
+    current_settings_dict = dict(current_settings.properties or {})
+    settings_changed = False
+    for setting in app_settings_to_add:
+        if current_settings_dict.get(setting['name']) == setting['value']:
+            del current_settings_dict[setting['name']]
+            settings_changed = True
+    if settings_changed:
+        from azure.mgmt.web.models import StringDictionary
+        flex_client.web_apps.update_application_settings(
+            resource_group_name, name, StringDictionary(properties=current_settings_dict))
+
+
+def _prepare_flex_deployment_storage(
+        cmd, resource_group_name, name, deployment_storage_name, deployment_storage_container_name,
+        deployment_storage_auth_type, deployment_storage_auth_value, location, flex_sku,
+        instance_memory, maximum_instance_count, always_ready_instances, existing_app_settings=None,
+        default_connection_string_name='DEPLOYMENT_STORAGE_CONNECTION_STRING', validate_for_in_place=False):
+    """Prepare Flex deployment storage resources and authentication configuration."""
+    setup = {
+        'deployment_storage_name': deployment_storage_name,
+        'storage_container_created': False,
+        'user_assigned_identity_created': False,
+        'user_assigned_identity': None,
+        'app_settings_to_add': []
+    }
+    try:
+        deployment_storage = _validate_and_get_deployment_storage(
+            cmd.cli_ctx, resource_group_name, deployment_storage_name)
+        if validate_for_in_place and deployment_storage.sku.name == 'Premium_LRS':
+            raise ValidationError("Premium deployment storage is not supported for in-place Flex Consumption upgrade.")
+        if validate_for_in_place and getattr(deployment_storage, 'is_hns_enabled', False) is True:
+            raise ValidationError(
+                "ADLS Gen2 deployment storage is not supported for in-place Flex Consumption upgrade.")
+        setup['deployment_storage'] = deployment_storage
+
+        deployment_storage_container = _get_or_create_deployment_storage_container(
+            cmd, resource_group_name, name, deployment_storage_name, deployment_storage_container_name)
+        setup['storage_container_created'] = deployment_storage_container_name is None
+        setup['deployment_storage_container_name'] = deployment_storage_container.name
+
+        deployment_storage_auth_config = {'type': deployment_storage_auth_type}
+        if deployment_storage_auth_type == 'UserAssignedIdentity':
+            identity = _get_or_create_user_assigned_identity(
+                cmd, resource_group_name, name, deployment_storage_auth_value, location)
+            setup['user_assigned_identity_created'] = deployment_storage_auth_value is None
+            setup['user_assigned_identity'] = identity
+            setup['deployment_storage_auth_value'] = identity.id
+            deployment_storage_auth_config['userAssignedIdentityResourceId'] = identity.id
+        elif deployment_storage_auth_type == 'StorageAccountConnectionString':
+            connection_string_name = deployment_storage_auth_value or default_connection_string_name
+            setup['deployment_storage_auth_value'] = connection_string_name
+            deployment_storage_auth_config['storageAccountConnectionStringName'] = connection_string_name
+            if connection_string_name not in (existing_app_settings or {}):
+                setup['app_settings_to_add'].append({
+                    'name': connection_string_name,
+                    'value': _get_storage_connection_string(cmd.cli_ctx, deployment_storage)
+                })
         else:
-            logger.warning("User assigned identity '%s' already has the role assignment on "
-                           "the storage account '%s'",
-                           deployment_storage_user_assigned_identity.principal_id, deployment_storage_name)
-    elif deployment_storage_auth_type == 'SystemAssignedIdentity':
-        assign_identity(cmd, resource_group_name, name, ['[system]'], 'Storage Blob Data Contributor',
-                        None, deployment_storage.id)
+            setup['deployment_storage_auth_value'] = deployment_storage_auth_value
+
+        deployment_storage_value = \
+            getattr(deployment_storage.primary_endpoints, 'blob') + deployment_storage_container.name
+        setup['function_app_config'] = _build_flex_function_app_config(
+            deployment_storage_value, deployment_storage_auth_config, flex_sku,
+            instance_memory, maximum_instance_count, always_ready_instances)
+        return setup
+    except Exception:
+        _cleanup_flex_deployment_storage(cmd, resource_group_name, setup)
+        raise
+
+
+def _cleanup_flex_deployment_storage(cmd, resource_group_name, setup):
+    if not setup:
+        return
+    if setup.get('storage_container_created'):
+        delete_storage_container(
+            cmd, resource_group_name, setup['deployment_storage_name'],
+            setup['deployment_storage_container_name'])
+    if setup.get('user_assigned_identity_created'):
+        identity = setup['user_assigned_identity']
+        identity_resource_group = parse_resource_id(identity.id)['resource_group']
+        delete_user_assigned_identity(cmd, identity_resource_group, identity.name)
+
+
+def _prepare_flex_deployment_storage_identity(cmd, resource_group_name, name, storage_setup,
+                                              existing_identity=None):
+    """Attach the deployment identity and grant any missing storage role."""
+    auth_type = storage_setup['function_app_config']['deployment']['storage']['authentication']['type']
+    changes = {'identity_added': False, 'role_assignment_id': None, 'auth_type': auth_type}
+
+    try:
+        if auth_type == 'UserAssignedIdentity':
+            identity = storage_setup['user_assigned_identity']
+            identity_id = storage_setup['deployment_storage_auth_value']
+            changes['identity_resource_id'] = identity_id
+            existing_user_identities = {
+                key.lower() for key in getattr(existing_identity, 'user_assigned_identities', {}) or {}
+            }
+            changes['identity_added'] = identity_id.lower() not in existing_user_identities
+            assign_identity(cmd, resource_group_name, name, [identity_id])
+            if not _has_deployment_storage_role_assignment_on_resource(
+                    cmd.cli_ctx, storage_setup['deployment_storage'], identity.principal_id):
+                assignment = _assign_deployment_storage_managed_identity_role(
+                    cmd.cli_ctx, storage_setup['deployment_storage'], identity.principal_id)
+                changes['role_assignment_id'] = assignment.id
+            else:
+                logger.warning("User assigned identity '%s' already has the role assignment on "
+                               "the storage account '%s'",
+                               identity.principal_id, storage_setup['deployment_storage_name'])
+        elif auth_type == 'SystemAssignedIdentity':
+            existing_identity_type = str(getattr(existing_identity, 'type', '')).lower()
+            changes['identity_added'] = 'systemassigned' not in existing_identity_type.replace('_', '')
+            identity = assign_identity(cmd, resource_group_name, name, ['[system]'])
+            if not _has_deployment_storage_role_assignment_on_resource(
+                    cmd.cli_ctx, storage_setup['deployment_storage'], identity.principal_id):
+                assignment = _assign_deployment_storage_managed_identity_role(
+                    cmd.cli_ctx, storage_setup['deployment_storage'], identity.principal_id)
+                changes['role_assignment_id'] = assignment.id
+    except Exception:
+        _rollback_flex_deployment_storage_identity(cmd, resource_group_name, name, changes)
+        raise
+
+    return changes
+
+
+def _rollback_flex_deployment_storage_identity(cmd, resource_group_name, name, changes):
+    if not changes:
+        return
+    try:
+        if changes.get('role_assignment_id'):
+            auth_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_AUTHORIZATION)
+            auth_client.role_assignments.delete_by_id(changes['role_assignment_id'])
+    finally:
+        if changes.get('identity_added'):
+            identity_to_remove = '[system]' if changes['auth_type'] == 'SystemAssignedIdentity' else \
+                changes.get('identity_resource_id')
+            remove_identity(cmd, resource_group_name, name, [identity_to_remove])
 
 
 def _build_flex_function_app_config(deployment_storage_value, deployment_storage_auth_config, flex_sku,
@@ -9340,8 +9448,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
     if runtime is not None:
         runtime = runtime.lower()
 
-    is_storage_container_created = False
-    is_user_assigned_identity_created = False
+    flex_storage_setup = None
 
     if consumption_plan_location:
         locations = list_consumption_locations(cmd)
@@ -9639,22 +9746,8 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
             functionapp_def.server_farm_id = plan_info.id
             functionapp_def.location = flexconsumption_location
 
-            if not deployment_storage_name:
-                deployment_storage_name = storage_account
-            deployment_storage = _validate_and_get_deployment_storage(cmd.cli_ctx, resource_group_name,
-                                                                      deployment_storage_name)
-
-            deployment_storage_container = _get_or_create_deployment_storage_container(
-                cmd, resource_group_name, name, deployment_storage_name, deployment_storage_container_name)
-            if deployment_storage_container_name is None:
-                is_storage_container_created = True
-            deployment_storage_container_name = deployment_storage_container.name
-
-            endpoints = deployment_storage.primary_endpoints
-            deployment_config_storage_value = getattr(endpoints, 'blob') + deployment_storage_container_name
-
+            deployment_storage_name = deployment_storage_name or storage_account
             deployment_storage_auth_type = deployment_storage_auth_type or 'StorageAccountConnectionString'
-
             if deployment_storage_auth_value and deployment_storage_auth_type == 'SystemAssignedIdentity':
                 raise ArgumentUsageError(
                     '--deployment-storage-auth-value is only a valid input when '
@@ -9663,39 +9756,20 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
                     'StorageAccountConnectionString.'
                 )
 
-            deployment_storage_auth_config = {
-                "type": deployment_storage_auth_type
-            }
-
-            if deployment_storage_auth_type == 'UserAssignedIdentity':
-                deployment_storage_user_assigned_identity = _get_or_create_user_assigned_identity(
-                    cmd,
-                    resource_group_name,
-                    name,
-                    deployment_storage_auth_value,
-                    flexconsumption_location)
-                if deployment_storage_auth_value is None:
-                    is_user_assigned_identity_created = True
-                deployment_storage_auth_value = deployment_storage_user_assigned_identity.id
-                deployment_storage_auth_config["userAssignedIdentityResourceId"] = deployment_storage_auth_value
-            elif deployment_storage_auth_type == 'StorageAccountConnectionString':
-                deployment_storage_conn_string = _get_storage_connection_string(cmd.cli_ctx, deployment_storage)
-                conn_string_app_setting = deployment_storage_auth_value or 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
-                site_config.app_settings.append(NameValuePair(name=conn_string_app_setting,
-                                                              value=deployment_storage_conn_string))
-                deployment_storage_auth_value = conn_string_app_setting
-                deployment_storage_auth_config["storageAccountConnectionStringName"] = deployment_storage_auth_value
-
             flex_sku = matched_runtime.sku
-            function_app_config = _build_flex_function_app_config(
-                deployment_config_storage_value, deployment_storage_auth_config, flex_sku,
+            flex_storage_setup = _prepare_flex_deployment_storage(
+                cmd, resource_group_name, name, deployment_storage_name, deployment_storage_container_name,
+                deployment_storage_auth_type, deployment_storage_auth_value, flexconsumption_location, flex_sku,
                 instance_memory, maximum_instance_count, always_ready_instances)
+            deployment_storage_auth_value = flex_storage_setup['deployment_storage_auth_value']
+            for setting in flex_storage_setup['app_settings_to_add']:
+                site_config.app_settings.append(NameValuePair(name=setting['name'], value=setting['value']))
 
             # Set flex consumption properties on the site
             from azure.mgmt.web.models import SiteProperties
             if functionapp_def.properties is None:
                 functionapp_def.properties = SiteProperties()
-            functionapp_def.properties.function_app_config = function_app_config
+            functionapp_def.properties.function_app_config = flex_storage_setup['function_app_config']
             functionapp_def.properties.sku = "FlexConsumption"
             # Use a client with specific API version for flex consumption
             flex_client = web_client_factory(cmd.cli_ctx, api_version='2025-05-01')
@@ -9703,11 +9777,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
             functionapp = LongRunningOperation(cmd.cli_ctx)(poller)
         except Exception as ex:  # pylint: disable=broad-except
             client.app_service_plans.delete(resource_group_name, plan_name)
-            if is_storage_container_created:
-                delete_storage_container(cmd, resource_group_name, deployment_storage_name,
-                                         deployment_storage_container_name)
-            if is_user_assigned_identity_created:
-                delete_user_assigned_identity(cmd, resource_group_name, deployment_storage_user_assigned_identity.name)
+            _cleanup_flex_deployment_storage(cmd, resource_group_name, flex_storage_setup)
             raise ex
     else:
         poller = client.web_apps.begin_create_or_update(resource_group_name, name, functionapp_def)
@@ -9747,24 +9817,8 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
                                               registry_password)
 
     if flexconsumption_location is not None:
-        if deployment_storage_auth_type == 'UserAssignedIdentity':
-            assign_identity(cmd, resource_group_name, name, [deployment_storage_auth_value])
-            if not _has_deployment_storage_role_assignment_on_resource(
-                    cmd.cli_ctx,
-                    deployment_storage,
-                    deployment_storage_user_assigned_identity.principal_id):
-                _assign_deployment_storage_managed_identity_role(
-                    cmd.cli_ctx,
-                    deployment_storage,
-                    deployment_storage_user_assigned_identity.principal_id)
-            else:
-                logger.warning("User assigned identity '%s' already has the role assignment on "
-                               "the storage account '%s'",
-                               deployment_storage_user_assigned_identity.principal_id, deployment_storage_name)
-
-        elif deployment_storage_auth_type == 'SystemAssignedIdentity':
-            assign_identity(cmd, resource_group_name, name, ['[system]'], 'Storage Blob Data Contributor',
-                            None, deployment_storage.id)
+        _prepare_flex_deployment_storage_identity(
+            cmd, resource_group_name, name, flex_storage_setup)
 
     if assign_identities is not None:
         identity = assign_identity(cmd, resource_group_name, name, assign_identities,
@@ -10091,8 +10145,8 @@ def _assign_deployment_storage_managed_identity_role(cli_ctx, deployment_storage
                                              mod='models', operation_group='role_assignments')
     parameters = RoleAssignmentCreateParameters(role_definition_id=role_definition_id, principal_id=principal_id,
                                                 principal_type='ServicePrincipal')
-    auth_client.role_assignments.create(scope=deployment_storage_account.id,
-                                        role_assignment_name=str(uuid.uuid4()), parameters=parameters)
+    return auth_client.role_assignments.create(scope=deployment_storage_account.id,
+                                               role_assignment_name=str(uuid.uuid4()), parameters=parameters)
 
 
 def _has_deployment_storage_role_assignment_on_resource(cli_ctx, deployment_storage_account, principal_id):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_flex_migration_in_place.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_flex_migration_in_place.yaml
@@ -1,0 +1,2454 @@
+interactions:
+- request:
+    body: '{"location": "North Central US (Stage)", "kind": "linux", "sku": {"name":
+      "Y1", "tier": "Dynamic", "size": "Y1", "family": "Y", "capacity": 0}, "properties":
+      {"reserved": true}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --method --url --body
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","name":"inplace-plan000004","type":"Microsoft.Web/serverfarms","kind":"functionapp","location":"North
+        Central US (Stage)","properties":{"serverFarmId":3749,"name":"inplace-plan000004","sku":{"name":"Y1","tier":"Dynamic","size":"Y1","family":"Y","capacity":0},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":0,"status":"Ready","webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dynamic","siteMode":null,"geoRegion":"North
+        Central US (Stage)","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"functionapp","resourceGroup":"clitest.rg000001","reserved":true,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-msftintch1-503_3749","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":1,"currentNumberOfZonesUtilized":0,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2026-09-08T09:24:57.81","asyncScalingEnabled":false,"isCustomMode":false,"powerState":"Running","eligibleLogCategories":"","activeBackupHomeServerFarmName":null,"allowEquivalentSku":false},"sku":{"name":"Y1","tier":"Dynamic","size":"Y1","family":"Y","capacity":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1911'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:24:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/westindia/8b913bfb-e538-4406-91cd-b3fa08816163
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: A647657F0C3542A78A16D6835A69378E Ref B: PNQ231110907062 Ref C: 2026-09-08T09:24:53Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account show-connection-string
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --query -o
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2025-08-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2026-09-08T09:24:30.8584755Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2026-09-08T09:24:30.8584755Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:24:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/3288459a-c185-4c1c-9468-e90280d9f841
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: BA3C0503F11E4C04A70343D6EBEEAEA7 Ref B: PNQ231110908023 Ref C: 2026-09-08T09:24:58Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account show-connection-string
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --query -o
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002?api-version=2025-08-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:24:30.8584755Z","key2":"2026-09-08T09:24:30.8584755Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:24:30.6373746Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1350'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:24:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: AE9AF099A45A4051B180CF1F6374B5F2 Ref B: PNQ231110906034 Ref C: 2026-09-08T09:24:58Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --name --connection-string
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-storage-blob/12.29.0b1 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+      x-ms-date:
+      - Tue, 08 Sep 2026 09:24:59 GMT
+      x-ms-version:
+      - '2026-04-06'
+    method: PUT
+    uri: https://clitest000002.blob.core.windows.net/source-packages?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:25:00 GMT
+      etag:
+      - '"0x8DF0D8B0EB826A5"'
+      last-modified:
+      - Tue, 08 Sep 2026 09:25:00 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2026-04-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"location": "North Central US (Stage)", "kind": "functionapp,linux", "properties":
+      {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004",
+      "reserved": true, "httpsOnly": true, "siteConfig": {"linuxFxVersion": "Node|22",
+      "appSettings": [{"name": "AzureWebJobsStorage", "value": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/"},
+      {"name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", "value": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/"},
+      {"name": "WEBSITE_CONTENTSHARE", "value": "inplace-func000003"}, {"name": "FUNCTIONS_EXTENSION_VERSION",
+      "value": "~4"}, {"name": "FUNCTIONS_WORKER_RUNTIME", "value": "node"}, {"name":
+      "WEBSITE_RUN_FROM_PACKAGE", "value": "https://clitest000002.blob.core.windows.net/source-packages/inplace-func000003.zip?se=2026-09-09T09%3A24Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1560'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --method --url --body
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:05.6666667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":null,"platformVersion":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9214'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:23 GMT
+      etag:
+      - 1DD3F73EF2C5AF5,1DD3F73EF7AAF0B,1DD3F73EF911035
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/ab5a222a-7f95-4cb0-a94b-0ccd66788975
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+      x-msedge-ref:
+      - 'Ref A: BAEC130DEB6342FE908132A90CB51250 Ref B: PNQ231110909034 Ref C: 2026-09-08T09:25:02Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8945'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:25 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3E30CA60435A4A7599B2E2913B8D7EB8 Ref B: PNQ231110907062 Ref C: 2026-09-08T09:25:25Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9011'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:25 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: AEBF3CD2A8114BFAA94536CDD224A23F Ref B: PNQ231110907042 Ref C: 2026-09-08T09:25:25Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/web?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/web","name":"inplace-func000003","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","powerShellVersion":"","linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":[],"requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"REDACTED","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","vnetRouteAllEnabled":false,"vnetPrivatePortsCount":0,"publicNetworkAccess":null,"siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":null},"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":false,"http20Enabled":false,"minTlsVersion":"1.2","minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":"1.2","ftpsState":"FtpsOnly","preWarmedInstanceCount":0,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":false,"functionsRuntimeScaleMonitoringEnabled":false,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":{},"http20ProxyFlag":0,"sitePort":null,"antivirusScanEnabled":false,"storageType":"StorageVolume","sitePrivateLinkHostEnabled":false,"clusteringEnabled":false,"webJobsEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4157'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/b6973859-34aa-4052-a103-1771b92e5a8c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C06592FA959E46C4B05974575ED01246 Ref B: PNQ231110908052 Ref C: 2026-09-08T09:25:26Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9011'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:27 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6D6160376EE54F3F88718D273DCAE759 Ref B: PNQ231110907042 Ref C: 2026-09-08T09:25:27Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"format": "WebDeploy"}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp show
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/publishxml?api-version=2025-05-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="inplace-func000003 - Web Deploy"
+        publishMethod="MSDeploy" publishUrl="inplace-func000003.scm.azurewebsites.net:443"
+        msdeploySite="inplace-func000003" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://inplace-func000003.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="inplace-func000003 - FTP"
+        publishMethod="FTP" publishUrl="ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://inplace-func000003.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="inplace-func000003 - Zip Deploy"
+        publishMethod="ZipDeploy" publishUrl="inplace-func000003.scm.azurewebsites.net:443"
+        userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://inplace-func000003.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1416'
+      content-type:
+      - application/xml
+      date:
+      - Tue, 08 Sep 2026 09:25:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/5b377a35-14ad-416f-9ff9-21c687985269
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: 642E9C09254B41B396AA01A762B185D1 Ref B: PNQ231110906034 Ref C: 2026-09-08T09:25:27Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --account-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2025-08-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testfc-rg/providers/Microsoft.Storage/storageAccounts/ssadtestfcrgbf33","name":"ssadtestfcrgbf33","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-08-14T17:40:52.1006887Z","key2":"2026-08-14T17:40:52.1006887Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:40:52.1108751Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:40:52.1108751Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-14T17:40:51.6335566Z","primaryEndpoints":{"dfs":"https://ssadtestfcrgbf33.dfs.core.windows.net/","web":"https://ssadtestfcrgbf33.z13.web.core.windows.net/","blob":"https://ssadtestfcrgbf33.blob.core.windows.net/","queue":"https://ssadtestfcrgbf33.queue.core.windows.net/","table":"https://ssadtestfcrgbf33.table.core.windows.net/","file":"https://ssadtestfcrgbf33.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609021516/providers/Microsoft.Storage/storageAccounts/stcv12609021516ssad","name":"stcv12609021516ssad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-02T09:48:20.2889824Z","key2":"2026-09-02T09:48:20.2889824Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:48:20.2991634Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:48:20.2991634Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-02T09:48:19.7198285Z","primaryEndpoints":{"dfs":"https://stcv12609021516ssad.dfs.core.windows.net/","web":"https://stcv12609021516ssad.z13.web.core.windows.net/","blob":"https://stcv12609021516ssad.blob.core.windows.net/","queue":"https://stcv12609021516ssad.queue.core.windows.net/","table":"https://stcv12609021516ssad.table.core.windows.net/","file":"https://stcv12609021516ssad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-upgrade-2609081000/providers/Microsoft.Storage/storageAccounts/stcv12609081000ssad","name":"stcv12609081000ssad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T04:28:17.6594428Z","key2":"2026-09-08T04:28:17.6594428Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:28:17.6696309Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:28:17.6696309Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-08T04:28:17.2207871Z","primaryEndpoints":{"dfs":"https://stcv12609081000ssad.dfs.core.windows.net/","web":"https://stcv12609081000ssad.z13.web.core.windows.net/","blob":"https://stcv12609081000ssad.blob.core.windows.net/","queue":"https://stcv12609081000ssad.queue.core.windows.net/","table":"https://stcv12609081000ssad.table.core.windows.net/","file":"https://stcv12609081000ssad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-final/providers/Microsoft.Storage/storageAccounts/stcv1flexfinal","name":"stcv1flexfinal","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T15:18:20.0917511Z","key2":"2026-08-17T15:18:20.0917511Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:18:20.1022539Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:18:20.1022539Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T15:18:19.6376869Z","primaryEndpoints":{"dfs":"https://stcv1flexfinal.dfs.core.windows.net/","web":"https://stcv1flexfinal.z13.web.core.windows.net/","blob":"https://stcv1flexfinal.blob.core.windows.net/","queue":"https://stcv1flexfinal.queue.core.windows.net/","table":"https://stcv1flexfinal.table.core.windows.net/","file":"https://stcv1flexfinal.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-validate/providers/Microsoft.Storage/storageAccounts/stcv1flexvalidate","name":"stcv1flexvalidate","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T14:50:32.1896537Z","key2":"2026-08-17T14:50:32.1896537Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T14:50:32.1998443Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T14:50:32.1998443Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T14:50:31.5600467Z","primaryEndpoints":{"dfs":"https://stcv1flexvalidate.dfs.core.windows.net/","web":"https://stcv1flexvalidate.z13.web.core.windows.net/","blob":"https://stcv1flexvalidate.blob.core.windows.net/","queue":"https://stcv1flexvalidate.queue.core.windows.net/","table":"https://stcv1flexvalidate.table.core.windows.net/","file":"https://stcv1flexvalidate.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-verify2/providers/Microsoft.Storage/storageAccounts/stcv1flexverify2","name":"stcv1flexverify2","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T15:26:59.1470621Z","key2":"2026-08-17T15:26:59.1470621Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:26:59.1572382Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:26:59.1572382Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T15:26:58.6821307Z","primaryEndpoints":{"dfs":"https://stcv1flexverify2.dfs.core.windows.net/","web":"https://stcv1flexverify2.z13.web.core.windows.net/","blob":"https://stcv1flexverify2.blob.core.windows.net/","queue":"https://stcv1flexverify2.queue.core.windows.net/","table":"https://stcv1flexverify2.table.core.windows.net/","file":"https://stcv1flexverify2.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-verify3/providers/Microsoft.Storage/storageAccounts/stcv1flexverify3","name":"stcv1flexverify3","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T16:24:16.5365114Z","key2":"2026-08-17T16:24:16.5365114Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T16:24:16.5472362Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T16:24:16.5472362Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T16:24:15.9617890Z","primaryEndpoints":{"dfs":"https://stcv1flexverify3.dfs.core.windows.net/","web":"https://stcv1flexverify3.z13.web.core.windows.net/","blob":"https://stcv1flexverify3.blob.core.windows.net/","queue":"https://stcv1flexverify3.queue.core.windows.net/","table":"https://stcv1flexverify3.table.core.windows.net/","file":"https://stcv1flexverify3.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-java11-ev4-eastus-260821/providers/Microsoft.Storage/storageAccounts/stjava11ev4eus260821","name":"stjava11ev4eus260821","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-21T09:19:16.9072257Z","key2":"2026-08-21T09:19:16.9072257Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-21T09:19:16.9183601Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-21T09:19:16.9183601Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-21T09:19:16.2279491Z","primaryEndpoints":{"dfs":"https://stjava11ev4eus260821.dfs.core.windows.net/","web":"https://stjava11ev4eus260821.z13.web.core.windows.net/","blob":"https://stjava11ev4eus260821.blob.core.windows.net/","queue":"https://stjava11ev4eus260821.queue.core.windows.net/","table":"https://stjava11ev4eus260821.table.core.windows.net/","file":"https://stjava11ev4eus260821.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-noble-chiselled-test/providers/Microsoft.Storage/storageAccounts/stnoblechiselledtest","name":"stnoblechiselledtest","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-30T12:51:39.4772724Z","key2":"2026-07-30T12:51:39.4772724Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-30T12:51:39.4848803Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-30T12:51:39.4848803Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-30T12:51:39.0839685Z","primaryEndpoints":{"dfs":"https://stnoblechiselledtest.dfs.core.windows.net/","web":"https://stnoblechiselledtest.z13.web.core.windows.net/","blob":"https://stnoblechiselledtest.blob.core.windows.net/","queue":"https://stnoblechiselledtest.queue.core.windows.net/","table":"https://stnoblechiselledtest.table.core.windows.net/","file":"https://stnoblechiselledtest.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lgn-rg-023b5-001/providers/Microsoft.Storage/storageAccounts/lgnsa9f37b6001","name":"lgnsa9f37b6001","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{"ms-resiliency-classification":"Test
+        Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T06:57:22.2491935Z","key2":"2026-07-29T06:57:22.2491935Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T06:57:22.2491935Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T06:57:22.2491935Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T06:57:21.8861123Z","primaryEndpoints":{"dfs":"https://lgnsa9f37b6001.dfs.core.windows.net/","web":"https://lgnsa9f37b6001.z20.web.core.windows.net/","blob":"https://lgnsa9f37b6001.blob.core.windows.net/","queue":"https://lgnsa9f37b6001.queue.core.windows.net/","table":"https://lgnsa9f37b6001.table.core.windows.net/","file":"https://lgnsa9f37b6001.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:24:30.8584755Z","key2":"2026-09-08T09:24:30.8584755Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:24:30.6373746Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-icm51000001721680-repro/providers/Microsoft.Storage/storageAccounts/ssadicm172168009011523","name":"ssadicm172168009011523","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"Purpose":"IcMRepro","IcM":"51000001721680"},"properties":{"allowCrossTenantDelegationSas":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-09-01T09:57:43.8010747Z","key2":"2026-09-01T09:57:43.8010747Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T09:57:43.8112536Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T09:57:43.8112536Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-01T09:57:43.5975609Z","primaryEndpoints":{"dfs":"https://ssadicm172168009011523.dfs.core.windows.net/","web":"https://ssadicm172168009011523.z22.web.core.windows.net/","blob":"https://ssadicm172168009011523.blob.core.windows.net/","queue":"https://ssadicm172168009011523.queue.core.windows.net/","table":"https://ssadicm172168009011523.table.core.windows.net/","file":"https://ssadicm172168009011523.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-icm51000001721680-repro/providers/Microsoft.Storage/storageAccounts/ssadicm172168009011524","name":"ssadicm172168009011524","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"Purpose":"IcMRepro","IcM":"51000001721680"},"properties":{"allowCrossTenantDelegationSas":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-09-01T10:06:54.1120733Z","key2":"2026-09-01T10:06:54.1120733Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T10:06:54.1201972Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T10:06:54.1201972Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-01T10:06:53.8946751Z","primaryEndpoints":{"dfs":"https://ssadicm172168009011524.dfs.core.windows.net/","web":"https://ssadicm172168009011524.z22.web.core.windows.net/","blob":"https://ssadicm172168009011524.blob.core.windows.net/","queue":"https://ssadicm172168009011524.queue.core.windows.net/","table":"https://ssadicm172168009011524.table.core.windows.net/","file":"https://ssadicm172168009011524.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-icm51000001721680-repro/providers/Microsoft.Storage/storageAccounts/ssadicm172168009021437","name":"ssadicm172168009021437","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"Purpose":"IcMRepro","IcM":"51000001721680","Topology":"CustomerPrivateDNS"},"properties":{"allowCrossTenantDelegationSas":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-09-02T09:17:28.2379300Z","key2":"2026-09-02T09:17:28.2379300Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:17:28.2482120Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:17:28.2482120Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-02T09:17:28.0299842Z","primaryEndpoints":{"dfs":"https://ssadicm172168009021437.dfs.core.windows.net/","web":"https://ssadicm172168009021437.z22.web.core.windows.net/","blob":"https://ssadicm172168009021437.blob.core.windows.net/","queue":"https://ssadicm172168009021437.queue.core.windows.net/","table":"https://ssadicm172168009021437.table.core.windows.net/","file":"https://ssadicm172168009021437.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609021728/providers/Microsoft.Storage/storageAccounts/stcv12609021728ssad","name":"stcv12609021728ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-02T12:03:34.8664576Z","key2":"2026-09-02T12:03:34.8664576Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T12:03:34.8766783Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T12:03:34.8766783Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-02T12:03:34.7117132Z","primaryEndpoints":{"dfs":"https://stcv12609021728ssad.dfs.core.windows.net/","web":"https://stcv12609021728ssad.z14.web.core.windows.net/","blob":"https://stcv12609021728ssad.blob.core.windows.net/","queue":"https://stcv12609021728ssad.queue.core.windows.net/","table":"https://stcv12609021728ssad.table.core.windows.net/","file":"https://stcv12609021728ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609041615/providers/Microsoft.Storage/storageAccounts/stcv12609041615ssad","name":"stcv12609041615ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-04T10:46:35.8074619Z","key2":"2026-09-04T10:46:35.8074619Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-04T10:46:35.8166910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-04T10:46:35.8166910Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-04T10:46:35.6522961Z","primaryEndpoints":{"dfs":"https://stcv12609041615ssad.dfs.core.windows.net/","web":"https://stcv12609041615ssad.z14.web.core.windows.net/","blob":"https://stcv12609041615ssad.blob.core.windows.net/","queue":"https://stcv12609041615ssad.queue.core.windows.net/","table":"https://stcv12609041615ssad.table.core.windows.net/","file":"https://stcv12609041615ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609080945/providers/Microsoft.Storage/storageAccounts/stcv12609080945ssad","name":"stcv12609080945ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T04:14:34.6728996Z","key2":"2026-09-08T04:14:34.6728996Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:14:34.6831630Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:14:34.6831630Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-08T04:14:34.4706147Z","primaryEndpoints":{"dfs":"https://stcv12609080945ssad.dfs.core.windows.net/","web":"https://stcv12609080945ssad.z14.web.core.windows.net/","blob":"https://stcv12609080945ssad.blob.core.windows.net/","queue":"https://stcv12609080945ssad.queue.core.windows.net/","table":"https://stcv12609080945ssad.table.core.windows.net/","file":"https://stcv12609080945ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609081035/providers/Microsoft.Storage/storageAccounts/stcv12609081035ssad","name":"stcv12609081035ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T05:06:42.4763493Z","key2":"2026-09-08T05:06:42.4763493Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T05:06:42.4824986Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T05:06:42.4824986Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-08T05:06:42.3194770Z","primaryEndpoints":{"dfs":"https://stcv12609081035ssad.dfs.core.windows.net/","web":"https://stcv12609081035ssad.z14.web.core.windows.net/","blob":"https://stcv12609081035ssad.blob.core.windows.net/","queue":"https://stcv12609081035ssad.queue.core.windows.net/","table":"https://stcv12609081035ssad.table.core.windows.net/","file":"https://stcv12609081035ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-e2e-20260831-1535/providers/Microsoft.Storage/storageAccounts/stcv1flex8311535ssad","name":"stcv1flex8311535ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T10:11:27.9431336Z","key2":"2026-08-31T10:11:27.9431336Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:11:27.9568233Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:11:27.9568233Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T10:11:27.7695087Z","primaryEndpoints":{"dfs":"https://stcv1flex8311535ssad.dfs.core.windows.net/","web":"https://stcv1flex8311535ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311535ssad.blob.core.windows.net/","queue":"https://stcv1flex8311535ssad.queue.core.windows.net/","table":"https://stcv1flex8311535ssad.table.core.windows.net/","file":"https://stcv1flex8311535ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-e2e-20260831-1605/providers/Microsoft.Storage/storageAccounts/stcv1flex8311605ssad","name":"stcv1flex8311605ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T10:37:04.8139467Z","key2":"2026-08-31T10:37:04.8139467Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:37:04.8165565Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:37:04.8165565Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T10:37:04.6295879Z","primaryEndpoints":{"dfs":"https://stcv1flex8311605ssad.dfs.core.windows.net/","web":"https://stcv1flex8311605ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311605ssad.blob.core.windows.net/","queue":"https://stcv1flex8311605ssad.queue.core.windows.net/","table":"https://stcv1flex8311605ssad.table.core.windows.net/","file":"https://stcv1flex8311605ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-revert-8311655/providers/Microsoft.Storage/storageAccounts/stcv1flex8311655ssad","name":"stcv1flex8311655ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T11:28:10.2521326Z","key2":"2026-08-31T11:28:10.2521326Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T11:28:10.2643180Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T11:28:10.2643180Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T11:28:10.0676114Z","primaryEndpoints":{"dfs":"https://stcv1flex8311655ssad.dfs.core.windows.net/","web":"https://stcv1flex8311655ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311655ssad.blob.core.windows.net/","queue":"https://stcv1flex8311655ssad.queue.core.windows.net/","table":"https://stcv1flex8311655ssad.table.core.windows.net/","file":"https://stcv1flex8311655ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-clean-8311812/providers/Microsoft.Storage/storageAccounts/stcv1flex8311812ssad","name":"stcv1flex8311812ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T12:48:10.3584039Z","key2":"2026-08-31T12:48:10.3584039Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T12:48:10.3691228Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T12:48:10.3691228Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T12:48:10.1692169Z","primaryEndpoints":{"dfs":"https://stcv1flex8311812ssad.dfs.core.windows.net/","web":"https://stcv1flex8311812ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311812ssad.blob.core.windows.net/","queue":"https://stcv1flex8311812ssad.queue.core.windows.net/","table":"https://stcv1flex8311812ssad.table.core.windows.net/","file":"https://stcv1flex8311812ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test/providers/Microsoft.Storage/storageAccounts/stcv1flexncusstg26","name":"stcv1flexncusstg26","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-12T10:01:48.3426426Z","key2":"2026-08-12T10:01:48.3426426Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T10:01:48.3569664Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T10:01:48.3569664Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-12T10:01:48.1829642Z","primaryEndpoints":{"dfs":"https://stcv1flexncusstg26.dfs.core.windows.net/","web":"https://stcv1flexncusstg26.z14.web.core.windows.net/","blob":"https://stcv1flexncusstg26.blob.core.windows.net/","queue":"https://stcv1flexncusstg26.queue.core.windows.net/","table":"https://stcv1flexncusstg26.table.core.windows.net/","file":"https://stcv1flexncusstg26.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test3/providers/Microsoft.Storage/storageAccounts/stcv1flextest3","name":"stcv1flextest3","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-13T14:21:26.3612760Z","key2":"2026-08-13T14:21:26.3612760Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:21:26.3716602Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:21:26.3716602Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-13T14:21:26.1863955Z","primaryEndpoints":{"dfs":"https://stcv1flextest3.dfs.core.windows.net/","web":"https://stcv1flextest3.z14.web.core.windows.net/","blob":"https://stcv1flextest3.blob.core.windows.net/","queue":"https://stcv1flextest3.queue.core.windows.net/","table":"https://stcv1flextest3.table.core.windows.net/","file":"https://stcv1flextest3.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test4/providers/Microsoft.Storage/storageAccounts/stcv1flextest4","name":"stcv1flextest4","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-13T14:47:32.4837972Z","key2":"2026-08-13T14:47:32.4837972Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:47:32.4940386Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:47:32.4940386Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-13T14:47:32.2492766Z","primaryEndpoints":{"dfs":"https://stcv1flextest4.dfs.core.windows.net/","web":"https://stcv1flextest4.z14.web.core.windows.net/","blob":"https://stcv1flextest4.blob.core.windows.net/","queue":"https://stcv1flextest4.queue.core.windows.net/","table":"https://stcv1flextest4.table.core.windows.net/","file":"https://stcv1flextest4.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test5/providers/Microsoft.Storage/storageAccounts/stcv1flextest5","name":"stcv1flextest5","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T12:56:01.4346751Z","key2":"2026-08-17T12:56:01.4346751Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T12:56:01.4504502Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T12:56:01.4504502Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T12:56:01.2815957Z","primaryEndpoints":{"dfs":"https://stcv1flextest5.dfs.core.windows.net/","web":"https://stcv1flextest5.z14.web.core.windows.net/","blob":"https://stcv1flextest5.blob.core.windows.net/","queue":"https://stcv1flextest5.queue.core.windows.net/","table":"https://stcv1flextest5.table.core.windows.net/","file":"https://stcv1flextest5.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-placeholder-stage-260814/providers/Microsoft.Storage/storageAccounts/steolstage260814","name":"steolstage260814","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-14T12:17:06.5420966Z","key2":"2026-08-14T12:17:06.5420966Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T12:17:06.5467088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T12:17:06.5467088Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-14T12:17:06.3844796Z","primaryEndpoints":{"dfs":"https://steolstage260814.dfs.core.windows.net/","web":"https://steolstage260814.z14.web.core.windows.net/","blob":"https://steolstage260814.blob.core.windows.net/","queue":"https://steolstage260814.queue.core.windows.net/","table":"https://steolstage260814.table.core.windows.net/","file":"https://steolstage260814.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-child-260901180101/providers/Microsoft.Storage/storageAccounts/stfx260901180101","name":"stfx260901180101","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-01T12:31:16.9923878Z","key2":"2026-09-01T12:31:16.9923878Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T12:31:17.0025482Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T12:31:17.0025482Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-01T12:31:16.8086635Z","primaryEndpoints":{"dfs":"https://stfx260901180101.dfs.core.windows.net/","web":"https://stfx260901180101.z14.web.core.windows.net/","blob":"https://stfx260901180101.blob.core.windows.net/","queue":"https://stfx260901180101.queue.core.windows.net/","table":"https://stfx260901180101.table.core.windows.net/","file":"https://stfx260901180101.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test/providers/Microsoft.Storage/storageAccounts/stcv1flexcusstg26","name":"stcv1flexcusstg26","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-12T09:59:15.8556478Z","key2":"2026-08-12T09:59:15.8556478Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:59:15.8662589Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:59:15.8662589Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-12T09:59:15.5371530Z","primaryEndpoints":{"dfs":"https://stcv1flexcusstg26.dfs.core.windows.net/","web":"https://stcv1flexcusstg26.z19.web.core.windows.net/","blob":"https://stcv1flexcusstg26.blob.core.windows.net/","queue":"https://stcv1flexcusstg26.queue.core.windows.net/","table":"https://stcv1flexcusstg26.table.core.windows.net/","file":"https://stcv1flexcusstg26.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lgn-rcp-rg-ssad1lclgn1-australiaeast/providers/Microsoft.Storage/storageAccounts/lgnrcpsa1f6f0","name":"lgnrcpsa1f6f0","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"ms-resiliency-classification":"Test
+        Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T18:11:51.4203689Z","key2":"2026-07-29T18:11:51.4203689Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:11:51.4305668Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:11:51.4305668Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T18:11:51.2401872Z","primaryEndpoints":{"dfs":"https://lgnrcpsa1f6f0.dfs.core.windows.net/","web":"https://lgnrcpsa1f6f0.z8.web.core.windows.net/","blob":"https://lgnrcpsa1f6f0.blob.core.windows.net/","queue":"https://lgnrcpsa1f6f0.queue.core.windows.net/","table":"https://lgnrcpsa1f6f0.table.core.windows.net/","file":"https://lgnrcpsa1f6f0.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lgn-rg-1f6f0-001/providers/Microsoft.Storage/storageAccounts/lgnsace8b35001","name":"lgnsace8b35001","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"ms-resiliency-classification":"Test
+        Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T19:46:02.6381356Z","key2":"2026-07-29T19:46:02.6381356Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T19:46:02.6477689Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T19:46:02.6477689Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T19:46:02.4799856Z","primaryEndpoints":{"dfs":"https://lgnsace8b35001.dfs.core.windows.net/","web":"https://lgnsace8b35001.z8.web.core.windows.net/","blob":"https://lgnsace8b35001.blob.core.windows.net/","queue":"https://lgnsace8b35001.queue.core.windows.net/","table":"https://lgnsace8b35001.table.core.windows.net/","file":"https://lgnsace8b35001.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PodRunnerRG-australiaeast-ssad1lclgn1/providers/Microsoft.Storage/storageAccounts/podrunnerlghvvfy2mqbok","name":"podrunnerlghvvfy2mqbok","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"ms-azores-classification":"Synthetic
+        Runner","ms-resiliency-classification":"Test Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T18:06:39.7189380Z","key2":"2026-07-29T18:06:39.7189380Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:06:39.7291120Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:06:39.7291120Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T18:06:39.5497176Z","primaryEndpoints":{"dfs":"https://podrunnerlghvvfy2mqbok.dfs.core.windows.net/","web":"https://podrunnerlghvvfy2mqbok.z8.web.core.windows.net/","blob":"https://podrunnerlghvvfy2mqbok.blob.core.windows.net/","queue":"https://podrunnerlghvvfy2mqbok.queue.core.windows.net/","table":"https://podrunnerlghvvfy2mqbok.table.core.windows.net/","file":"https://podrunnerlghvvfy2mqbok.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lc-rg/providers/Microsoft.Storage/storageAccounts/ssad1lc","name":"ssad1lc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lc","created.username":"cloudtest","created.machinename":"58c56411c000000","created.utc":"7/24/2026
+        9:43:23 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:07:14.7522434Z","key2":"2026-07-23T07:07:14.7522434Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:14.7624658Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:14.7624658Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:07:14.5674652Z","primaryEndpoints":{"dfs":"https://ssad1lc.dfs.core.windows.net/","web":"https://ssad1lc.z8.web.core.windows.net/","blob":"https://ssad1lc.blob.core.windows.net/","queue":"https://ssad1lc.queue.core.windows.net/","table":"https://ssad1lc.table.core.windows.net/","file":"https://ssad1lc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lcgeo-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcgeo","name":"ssad1lcgeo","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lcgeo","created.username":"cloudtest","created.machinename":"5ef2c1a2c000000","created.utc":"7/24/2026
+        9:43:18 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:12:09.1214338Z","key2":"2026-07-23T07:12:09.1214338Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:09.1296575Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:09.1296575Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:12:08.9146578Z","primaryEndpoints":{"dfs":"https://ssad1lcgeo.dfs.core.windows.net/","web":"https://ssad1lcgeo.z8.web.core.windows.net/","blob":"https://ssad1lcgeo.blob.core.windows.net/","queue":"https://ssad1lcgeo.queue.core.windows.net/","table":"https://ssad1lcgeo.table.core.windows.net/","file":"https://ssad1lcgeo.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lcgeo-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcgeobak","name":"ssad1lcgeobak","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T09:18:11.2180583Z","key2":"2026-07-23T09:18:11.2180583Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"isLocalUserEnabled":false,"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T09:18:11.2282815Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T09:18:11.2282815Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T09:18:11.0271066Z","primaryEndpoints":{"dfs":"https://ssad1lcgeobak.dfs.core.windows.net/","web":"https://ssad1lcgeobak.z8.web.core.windows.net/","blob":"https://ssad1lcgeobak.blob.core.windows.net/","queue":"https://ssad1lcgeobak.queue.core.windows.net/","table":"https://ssad1lcgeobak.table.core.windows.net/","file":"https://ssad1lcgeobak.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lcgeo-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcgeoinfra","name":"ssad1lcgeoinfra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lcgeo","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/23/2026
+        7:12:37 AM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-23T07:12:37.5587675Z","key2":"2026-07-23T07:12:37.5587675Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:37.5690451Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:37.5690451Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:12:37.3385633Z","primaryEndpoints":{"dfs":"https://ssad1lcgeoinfra.dfs.core.windows.net/","web":"https://ssad1lcgeoinfra.z8.web.core.windows.net/","blob":"https://ssad1lcgeoinfra.blob.core.windows.net/","queue":"https://ssad1lcgeoinfra.queue.core.windows.net/","table":"https://ssad1lcgeoinfra.table.core.windows.net/","file":"https://ssad1lcgeoinfra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lc-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcinfra","name":"ssad1lcinfra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lc","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/23/2026
+        7:07:39 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:07:40.2872457Z","key2":"2026-07-23T07:07:40.2872457Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:40.2975341Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:40.2975341Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:07:40.0819824Z","primaryEndpoints":{"dfs":"https://ssad1lcinfra.dfs.core.windows.net/","web":"https://ssad1lcinfra.z8.web.core.windows.net/","blob":"https://ssad1lcinfra.blob.core.windows.net/","queue":"https://ssad1lcinfra.queue.core.windows.net/","table":"https://ssad1lcinfra.table.core.windows.net/","file":"https://ssad1lcinfra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Premium_ZRS","tier":"Premium"},"kind":"FileStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lc-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcmaf","name":"ssad1lcmaf","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lc","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/23/2026
+        7:08:05 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:08:06.2152327Z","key2":"2026-07-23T07:08:06.2152327Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"isLocalUserEnabled":true,"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"largeFileSharesState":"Enabled","networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:08:06.2276050Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:08:06.2276050Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-07-23T07:08:06.0227971Z","primaryEndpoints":{"file":"https://ssad1lcmaf.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1","name":"ssadlc1","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:44:31 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:44:32.2396250Z","key2":"2026-07-22T12:44:32.2396250Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:44:32.2554997Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:44:32.2554997Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T12:44:32.0179283Z","primaryEndpoints":{"dfs":"https://ssadlc1.dfs.core.windows.net/","web":"https://ssadlc1.z8.web.core.windows.net/","blob":"https://ssadlc1.blob.core.windows.net/","queue":"https://ssadlc1.queue.core.windows.net/","table":"https://ssadlc1.table.core.windows.net/","file":"https://ssadlc1.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1geo-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1geo","name":"ssadlc1geo","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1geo","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:49:42 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:49:43.0905769Z","key2":"2026-07-22T12:49:43.0905769Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:49:43.1110302Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:49:43.1110302Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T12:49:42.8735627Z","primaryEndpoints":{"dfs":"https://ssadlc1geo.dfs.core.windows.net/","web":"https://ssadlc1geo.z8.web.core.windows.net/","blob":"https://ssadlc1geo.blob.core.windows.net/","queue":"https://ssadlc1geo.queue.core.windows.net/","table":"https://ssadlc1geo.table.core.windows.net/","file":"https://ssadlc1geo.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1geo-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1geoinfra","name":"ssadlc1geoinfra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1geo","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:50:12 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:50:12.7455762Z","key2":"2026-07-22T12:50:12.7455762Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:50:12.7615773Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:50:12.7615773Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T12:50:12.5555903Z","primaryEndpoints":{"dfs":"https://ssadlc1geoinfra.dfs.core.windows.net/","web":"https://ssadlc1geoinfra.z8.web.core.windows.net/","blob":"https://ssadlc1geoinfra.blob.core.windows.net/","queue":"https://ssadlc1geoinfra.queue.core.windows.net/","table":"https://ssadlc1geoinfra.table.core.windows.net/","file":"https://ssadlc1geoinfra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1infra","name":"ssadlc1infra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        9:31:33 AM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T09:31:33.9921012Z","key2":"2026-07-22T09:31:33.9921012Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T09:31:34.0039829Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T09:31:34.0039829Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T09:31:33.7970377Z","primaryEndpoints":{"dfs":"https://ssadlc1infra.dfs.core.windows.net/","web":"https://ssadlc1infra.z8.web.core.windows.net/","blob":"https://ssadlc1infra.blob.core.windows.net/","queue":"https://ssadlc1infra.queue.core.windows.net/","table":"https://ssadlc1infra.table.core.windows.net/","file":"https://ssadlc1infra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Premium_ZRS","tier":"Premium"},"kind":"FileStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1maf","name":"ssadlc1maf","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:45:04 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:45:04.6730936Z","key2":"2026-07-22T12:45:04.6730936Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"isLocalUserEnabled":true,"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"largeFileSharesState":"Enabled","networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:45:04.6833159Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:45:04.6833159Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-07-22T12:45:04.4772833Z","primaryEndpoints":{"file":"https://ssadlc1maf.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrg9022","name":"ssaddistrolessrg9022","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-06-16T09:25:01.7551381Z","key2":"2026-06-16T09:25:01.7551381Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-06-16T09:25:01.7654797Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-06-16T09:25:01.7654797Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-06-16T09:25:01.5810660Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrg9022.dfs.core.windows.net/","web":"https://ssaddistrolessrg9022.z9.web.core.windows.net/","blob":"https://ssaddistrolessrg9022.blob.core.windows.net/","queue":"https://ssaddistrolessrg9022.queue.core.windows.net/","table":"https://ssaddistrolessrg9022.table.core.windows.net/","file":"https://ssaddistrolessrg9022.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrg9a5a","name":"ssaddistrolessrg9a5a","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-08T09:14:22.6192433Z","key2":"2026-04-08T09:14:22.6192433Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-08T09:14:22.6294917Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-08T09:14:22.6294917Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-08T09:14:22.4756042Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrg9a5a.dfs.core.windows.net/","web":"https://ssaddistrolessrg9a5a.z9.web.core.windows.net/","blob":"https://ssaddistrolessrg9a5a.blob.core.windows.net/","queue":"https://ssaddistrolessrg9a5a.queue.core.windows.net/","table":"https://ssaddistrolessrg9a5a.table.core.windows.net/","file":"https://ssaddistrolessrg9a5a.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrg9ae1","name":"ssaddistrolessrg9ae1","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-10T11:31:38.7376511Z","key2":"2026-04-10T11:31:38.7376511Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-10T11:31:38.7450107Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-10T11:31:38.7450107Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-10T11:31:38.5957967Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrg9ae1.dfs.core.windows.net/","web":"https://ssaddistrolessrg9ae1.z9.web.core.windows.net/","blob":"https://ssaddistrolessrg9ae1.blob.core.windows.net/","queue":"https://ssaddistrolessrg9ae1.queue.core.windows.net/","table":"https://ssaddistrolessrg9ae1.table.core.windows.net/","file":"https://ssaddistrolessrg9ae1.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrga56f","name":"ssaddistrolessrga56f","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-11T10:30:48.3007805Z","key2":"2026-03-11T10:30:48.3007805Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T10:30:48.3007805Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T10:30:48.3007805Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-11T10:30:48.1757816Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrga56f.dfs.core.windows.net/","web":"https://ssaddistrolessrga56f.z9.web.core.windows.net/","blob":"https://ssaddistrolessrga56f.blob.core.windows.net/","queue":"https://ssaddistrolessrga56f.queue.core.windows.net/","table":"https://ssaddistrolessrga56f.table.core.windows.net/","file":"https://ssaddistrolessrga56f.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrgae0e","name":"ssaddistrolessrgae0e","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T09:02:07.3875504Z","key2":"2026-04-21T09:02:07.3875504Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T09:02:07.4028667Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T09:02:07.4028667Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T09:02:07.2291668Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrgae0e.dfs.core.windows.net/","web":"https://ssaddistrolessrgae0e.z9.web.core.windows.net/","blob":"https://ssaddistrolessrgae0e.blob.core.windows.net/","queue":"https://ssaddistrolessrgae0e.queue.core.windows.net/","table":"https://ssaddistrolessrgae0e.table.core.windows.net/","file":"https://ssaddistrolessrgae0e.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrgb101","name":"ssaddistrolessrgb101","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T13:09:02.5932991Z","key2":"2026-04-21T13:09:02.5932991Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T13:09:02.6024827Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T13:09:02.6024827Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T13:09:02.4285171Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrgb101.dfs.core.windows.net/","web":"https://ssaddistrolessrgb101.z9.web.core.windows.net/","blob":"https://ssaddistrolessrgb101.blob.core.windows.net/","queue":"https://ssaddistrolessrgb101.queue.core.windows.net/","table":"https://ssaddistrolessrgb101.table.core.windows.net/","file":"https://ssaddistrolessrgb101.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorg8c6c","name":"ssadtestdistrorg8c6c","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-11T09:41:04.6570736Z","key2":"2026-03-11T09:41:04.6570736Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T09:41:04.6570736Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T09:41:04.6570736Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-11T09:41:04.5008282Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorg8c6c.dfs.core.windows.net/","web":"https://ssadtestdistrorg8c6c.z9.web.core.windows.net/","blob":"https://ssadtestdistrorg8c6c.blob.core.windows.net/","queue":"https://ssadtestdistrorg8c6c.queue.core.windows.net/","table":"https://ssadtestdistrorg8c6c.table.core.windows.net/","file":"https://ssadtestdistrorg8c6c.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorg9699","name":"ssadtestdistrorg9699","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T05:44:16.8755150Z","key2":"2026-04-21T05:44:16.8755150Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T05:44:16.8857035Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T05:44:16.8857035Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T05:44:16.7215379Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorg9699.dfs.core.windows.net/","web":"https://ssadtestdistrorg9699.z9.web.core.windows.net/","blob":"https://ssadtestdistrorg9699.blob.core.windows.net/","queue":"https://ssadtestdistrorg9699.queue.core.windows.net/","table":"https://ssadtestdistrorg9699.table.core.windows.net/","file":"https://ssadtestdistrorg9699.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorga90c","name":"ssadtestdistrorga90c","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-09T09:06:45.1637940Z","key2":"2026-04-09T09:06:45.1637940Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-09T09:06:45.1729212Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-09T09:06:45.1729212Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-09T09:06:45.0228932Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorga90c.dfs.core.windows.net/","web":"https://ssadtestdistrorga90c.z9.web.core.windows.net/","blob":"https://ssadtestdistrorga90c.blob.core.windows.net/","queue":"https://ssadtestdistrorga90c.queue.core.windows.net/","table":"https://ssadtestdistrorga90c.table.core.windows.net/","file":"https://ssadtestdistrorga90c.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorgacf8","name":"ssadtestdistrorgacf8","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T08:49:16.2585818Z","key2":"2026-04-21T08:49:16.2585818Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T08:49:16.2738791Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T08:49:16.2738791Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T08:49:16.0839845Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorgacf8.dfs.core.windows.net/","web":"https://ssadtestdistrorgacf8.z9.web.core.windows.net/","blob":"https://ssadtestdistrorgacf8.blob.core.windows.net/","queue":"https://ssadtestdistrorgacf8.queue.core.windows.net/","table":"https://ssadtestdistrorgacf8.table.core.windows.net/","file":"https://ssadtestdistrorgacf8.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorgb9f9","name":"ssadtestdistrorgb9f9","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-31T11:43:06.4138941Z","key2":"2026-03-31T11:43:06.4138941Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:43:06.4220454Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:43:06.4220454Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-31T11:43:06.2794062Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorgb9f9.dfs.core.windows.net/","web":"https://ssadtestdistrorgb9f9.z9.web.core.windows.net/","blob":"https://ssadtestdistrorgb9f9.blob.core.windows.net/","queue":"https://ssadtestdistrorgb9f9.queue.core.windows.net/","table":"https://ssadtestdistrorgb9f9.table.core.windows.net/","file":"https://ssadtestdistrorgb9f9.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorgbd3d","name":"ssadtestdistrorgbd3d","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-31T11:36:57.1269274Z","key2":"2026-03-31T11:36:57.1269274Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:36:57.1340963Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:36:57.1340963Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-31T11:36:57.0036301Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorgbd3d.dfs.core.windows.net/","web":"https://ssadtestdistrorgbd3d.z9.web.core.windows.net/","blob":"https://ssadtestdistrorgbd3d.blob.core.windows.net/","queue":"https://ssadtestdistrorgbd3d.queue.core.windows.net/","table":"https://ssadtestdistrorgbd3d.table.core.windows.net/","file":"https://ssadtestdistrorgbd3d.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testfc-rg/providers/Microsoft.Storage/storageAccounts/ssadteststorage","name":"ssadteststorage","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"dualStackEndpointPreference":{"defaultDualStackEndpoints":false,"publishIpv4Endpoint":false,"publishIpv6Endpoint":false},"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-08-14T17:38:09.5110844Z","key2":"2026-08-14T17:38:09.5110844Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:38:09.5212896Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:38:09.5212896Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-14T17:38:09.3364661Z","primaryEndpoints":{"dfs":"https://ssadteststorage.dfs.core.windows.net/","web":"https://ssadteststorage.z9.web.core.windows.net/","blob":"https://ssadteststorage.blob.core.windows.net/","queue":"https://ssadteststorage.queue.core.windows.net/","table":"https://ssadteststorage.table.core.windows.net/","file":"https://ssadteststorage.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available","secondaryLocation":"canadaeast","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://ssadteststorage-secondary.dfs.core.windows.net/","web":"https://ssadteststorage-secondary.z9.web.core.windows.net/","blob":"https://ssadteststorage-secondary.blob.core.windows.net/","queue":"https://ssadteststorage-secondary.queue.core.windows.net/","table":"https://ssadteststorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testfc-rg/providers/Microsoft.Storage/storageAccounts/ssadtestfcrgaad6","name":"ssadtestfcrgaad6","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-08-07T06:55:46.9815080Z","key2":"2026-08-07T06:55:46.9815080Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-07T06:55:46.9918260Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-07T06:55:46.9918260Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-07T06:55:46.8580996Z","primaryEndpoints":{"dfs":"https://ssadtestfcrgaad6.dfs.core.windows.net/","web":"https://ssadtestfcrgaad6.z3.web.core.windows.net/","blob":"https://ssadtestfcrgaad6.blob.core.windows.net/","queue":"https://ssadtestfcrgaad6.queue.core.windows.net/","table":"https://ssadtestfcrgaad6.table.core.windows.net/","file":"https://ssadtestfcrgaad6.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test/providers/Microsoft.Storage/storageAccounts/stcv1flextest26","name":"stcv1flextest26","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-12T09:08:48.0485548Z","key2":"2026-08-12T09:08:48.0485548Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:08:48.0587837Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:08:48.0587837Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-12T09:08:47.9062481Z","primaryEndpoints":{"dfs":"https://stcv1flextest26.dfs.core.windows.net/","web":"https://stcv1flextest26.z3.web.core.windows.net/","blob":"https://stcv1flextest26.blob.core.windows.net/","queue":"https://stcv1flextest26.queue.core.windows.net/","table":"https://stcv1flextest26.table.core.windows.net/","file":"https://stcv1flextest26.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-existing-euap-260815/providers/Microsoft.Storage/storageAccounts/steoleuap260815","name":"steoleuap260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:38:11.1935326Z","key2":"2026-08-15T07:38:11.1935326Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:38:11.2036815Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:38:11.2036815Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:38:11.0718055Z","primaryEndpoints":{"dfs":"https://steoleuap260815.dfs.core.windows.net/","web":"https://steoleuap260815.z3.web.core.windows.net/","blob":"https://steoleuap260815.blob.core.windows.net/","queue":"https://steoleuap260815.queue.core.windows.net/","table":"https://steoleuap260815.table.core.windows.net/","file":"https://steoleuap260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s1-260815/providers/Microsoft.Storage/storageAccounts/steols1260815","name":"steols1260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:23.0600826Z","key2":"2026-08-15T07:51:23.0600826Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:23.0672332Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:23.0672332Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:22.8939543Z","primaryEndpoints":{"dfs":"https://steols1260815.dfs.core.windows.net/","web":"https://steols1260815.z3.web.core.windows.net/","blob":"https://steols1260815.blob.core.windows.net/","queue":"https://steols1260815.queue.core.windows.net/","table":"https://steols1260815.table.core.windows.net/","file":"https://steols1260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s2-260815/providers/Microsoft.Storage/storageAccounts/steols2260815","name":"steols2260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:53:30.9714021Z","key2":"2026-08-15T07:53:30.9714021Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:30.9714021Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:30.9714021Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:53:30.8016916Z","primaryEndpoints":{"dfs":"https://steols2260815.dfs.core.windows.net/","web":"https://steols2260815.z3.web.core.windows.net/","blob":"https://steols2260815.blob.core.windows.net/","queue":"https://steols2260815.queue.core.windows.net/","table":"https://steols2260815.table.core.windows.net/","file":"https://steols2260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s3-260815/providers/Microsoft.Storage/storageAccounts/steols3260815","name":"steols3260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:20.2867714Z","key2":"2026-08-15T07:51:20.2867714Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:20.2969815Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:20.2969815Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:20.1333607Z","primaryEndpoints":{"dfs":"https://steols3260815.dfs.core.windows.net/","web":"https://steols3260815.z3.web.core.windows.net/","blob":"https://steols3260815.blob.core.windows.net/","queue":"https://steols3260815.queue.core.windows.net/","table":"https://steols3260815.table.core.windows.net/","file":"https://steols3260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s4-260815/providers/Microsoft.Storage/storageAccounts/steols4260815","name":"steols4260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:24.7632986Z","key2":"2026-08-15T07:51:24.7632986Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:24.7694855Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:24.7694855Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:24.6058750Z","primaryEndpoints":{"dfs":"https://steols4260815.dfs.core.windows.net/","web":"https://steols4260815.z3.web.core.windows.net/","blob":"https://steols4260815.blob.core.windows.net/","queue":"https://steols4260815.queue.core.windows.net/","table":"https://steols4260815.table.core.windows.net/","file":"https://steols4260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s5-260815/providers/Microsoft.Storage/storageAccounts/steols5260815","name":"steols5260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:53.6060939Z","key2":"2026-08-15T07:51:53.6060939Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:53.6101241Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:53.6101241Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:53.4538100Z","primaryEndpoints":{"dfs":"https://steols5260815.dfs.core.windows.net/","web":"https://steols5260815.z3.web.core.windows.net/","blob":"https://steols5260815.blob.core.windows.net/","queue":"https://steols5260815.queue.core.windows.net/","table":"https://steols5260815.table.core.windows.net/","file":"https://steols5260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s6-260815/providers/Microsoft.Storage/storageAccounts/steols6260815","name":"steols6260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:53:31.1245122Z","key2":"2026-08-15T07:53:31.1245122Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:31.1401439Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:31.1401439Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:53:30.9714021Z","primaryEndpoints":{"dfs":"https://steols6260815.dfs.core.windows.net/","web":"https://steols6260815.z3.web.core.windows.net/","blob":"https://steols6260815.blob.core.windows.net/","queue":"https://steols6260815.queue.core.windows.net/","table":"https://steols6260815.table.core.windows.net/","file":"https://steols6260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '103209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:25:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 8faea38f-892b-452b-ab71-e040b3170ff8
+      - 52ad2c96-3543-434e-acb8-f6ab3197e970
+      - 12d22c90-98a7-4229-9779-250b791850c9
+      - 1b5c1247-2d5c-4794-9663-0aa2755203b7
+      - ad8b6153-b1b1-4bab-9521-15ae96af7bdc
+      - 6d211a71-7690-421f-a72b-5b4f0d632868
+      - b3b57afd-7054-45ec-b637-811801c408e0
+      - 5610ea5f-9dac-456f-aa6e-07795b0eb777
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 917EC77F349242D5A2C3F1968F2C2581 Ref B: PNQ231110907036 Ref C: 2026-09-08T09:25:28Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --account-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2025-08-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2026-09-08T09:24:30.8584755Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2026-09-08T09:24:30.8584755Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/dc07fcda-76ac-42b8-938b-d060c431ad04
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 6278F1D2CC57482B84145EE2E5F9EEDD Ref B: PNQ231110907031 Ref C: 2026-09-08T09:25:31Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --account-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-storage-blob/12.29.0b1 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+      x-ms-date:
+      - Tue, 08 Sep 2026 09:25:31 GMT
+      x-ms-version:
+      - '2026-04-06'
+    method: PUT
+    uri: https://clitest000002.blob.core.windows.net/defaultcontainer?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:25:31 GMT
+      etag:
+      - '"0x8DF0D8B21D61B43"'
+      last-modified:
+      - Tue, 08 Sep 2026 09:25:32 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2026-04-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9011'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:33 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5E3F51AE6A7743059E4E201B65EAF2CC Ref B: PNQ231110909040 Ref C: 2026-09-08T09:25:33Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8945'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:35 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5675D6104D7F470F86294BA9145F8B7C Ref B: PNQ231110908023 Ref C: 2026-09-08T09:25:33Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","name":"inplace-plan000004","type":"Microsoft.Web/serverfarms","kind":"functionapp","location":"North
+        Central US (Stage)","properties":{"serverFarmId":3749,"name":"inplace-plan000004","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":0,"status":"Ready","webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dynamic","siteMode":null,"geoRegion":"North
+        Central US (Stage)","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":1,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"functionapp","resourceGroup":"clitest.rg000001","reserved":true,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-msftintch1-503_3749","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":1,"currentNumberOfZonesUtilized":0,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2026-09-08T09:24:57.81","asyncScalingEnabled":false,"isCustomMode":false,"powerState":"Running","eligibleLogCategories":"","activeBackupHomeServerFarmName":null,"allowEquivalentSku":false},"sku":{"name":"Y1","tier":"Dynamic","size":"Y1","family":"Y","capacity":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1830'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 1908FE80F39E489CA93FBCDEE13DDA07 Ref B: PNQ231110909029 Ref C: 2026-09-08T09:25:35Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/locations?api-version=2022-12-01
+  response:
+    body:
+      string: "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus\",\"name\":\"eastus\",\"type\":\"Region\",\"displayName\":\"East
+        US\",\"regionalDisplayName\":\"(US) East US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-79.8164\",\"latitude\":\"37.3719\",\"physicalLocation\":\"Virginia\",\"pairedRegion\":[{\"name\":\"westus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastus-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastus-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastus-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2\",\"name\":\"westus2\",\"type\":\"Region\",\"displayName\":\"West
+        US 2\",\"regionalDisplayName\":\"(US) West US 2\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-119.852\",\"latitude\":\"47.233\",\"physicalLocation\":\"Washington\",\"pairedRegion\":[{\"name\":\"westcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"westus2-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"westus2-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"westus2-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast\",\"name\":\"australiaeast\",\"type\":\"Region\",\"displayName\":\"Australia
+        East\",\"regionalDisplayName\":\"(Asia Pacific) Australia East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"151.2094\",\"latitude\":\"-33.86\",\"physicalLocation\":\"New
+        South Wales\",\"pairedRegion\":[{\"name\":\"australiasoutheast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"australiaeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"australiaeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"australiaeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia\",\"name\":\"southeastasia\",\"type\":\"Region\",\"displayName\":\"Southeast
+        Asia\",\"regionalDisplayName\":\"(Asia Pacific) Southeast Asia\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Asia
+        Pacific\",\"geographyGroup\":\"Asia Pacific\",\"longitude\":\"103.833\",\"latitude\":\"1.283\",\"physicalLocation\":\"Singapore\",\"pairedRegion\":[{\"name\":\"eastasia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"southeastasia-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"southeastasia-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"southeastasia-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope\",\"name\":\"northeurope\",\"type\":\"Region\",\"displayName\":\"North
+        Europe\",\"regionalDisplayName\":\"(Europe) North Europe\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Europe\",\"geographyGroup\":\"Europe\",\"longitude\":\"-6.2597\",\"latitude\":\"53.3478\",\"physicalLocation\":\"Ireland\",\"pairedRegion\":[{\"name\":\"westeurope\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"northeurope-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"northeurope-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"northeurope-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/swedencentral\",\"name\":\"swedencentral\",\"type\":\"Region\",\"displayName\":\"Sweden
+        Central\",\"regionalDisplayName\":\"(Europe) Sweden Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Sweden\",\"geographyGroup\":\"Europe\",\"longitude\":\"17.14127\",\"latitude\":\"60.67488\",\"physicalLocation\":\"G\xE4vle\",\"pairedRegion\":[{\"name\":\"swedensouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/swedensouth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"swedencentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"swedencentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"swedencentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope\",\"name\":\"westeurope\",\"type\":\"Region\",\"displayName\":\"West
+        Europe\",\"regionalDisplayName\":\"(Europe) West Europe\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Europe\",\"geographyGroup\":\"Europe\",\"longitude\":\"4.9\",\"latitude\":\"52.3667\",\"physicalLocation\":\"Netherlands\",\"pairedRegion\":[{\"name\":\"northeurope\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"westeurope-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"westeurope-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"westeurope-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth\",\"name\":\"uksouth\",\"type\":\"Region\",\"displayName\":\"UK
+        South\",\"regionalDisplayName\":\"(UK) UK South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        Kingdom\",\"geographyGroup\":\"UK\",\"longitude\":\"-0.799\",\"latitude\":\"50.941\",\"physicalLocation\":\"London\",\"pairedRegion\":[{\"name\":\"ukwest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"uksouth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"uksouth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"uksouth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus\",\"name\":\"centralus\",\"type\":\"Region\",\"displayName\":\"Central
+        US\",\"regionalDisplayName\":\"(US) Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-93.6208\",\"latitude\":\"41.5908\",\"physicalLocation\":\"Iowa\",\"pairedRegion\":[{\"name\":\"eastus2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"centralus-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"centralus-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"centralus-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricanorth\",\"name\":\"southafricanorth\",\"type\":\"Region\",\"displayName\":\"South
+        Africa North\",\"regionalDisplayName\":\"(Africa) South Africa North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"South
+        Africa\",\"geographyGroup\":\"Africa\",\"longitude\":\"28.21837\",\"latitude\":\"-25.73134\",\"physicalLocation\":\"Johannesburg\",\"pairedRegion\":[{\"name\":\"southafricawest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricawest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"southafricanorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"southafricanorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"southafricanorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia\",\"name\":\"centralindia\",\"type\":\"Region\",\"displayName\":\"Central
+        India\",\"regionalDisplayName\":\"(Asia Pacific) Central India\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"73.9197\",\"latitude\":\"18.5822\",\"physicalLocation\":\"Pune\",\"pairedRegion\":[{\"name\":\"southindia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"centralindia-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"centralindia-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"centralindia-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia\",\"name\":\"eastasia\",\"type\":\"Region\",\"displayName\":\"East
+        Asia\",\"regionalDisplayName\":\"(Asia Pacific) East Asia\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Asia
+        Pacific\",\"geographyGroup\":\"Asia Pacific\",\"longitude\":\"114.188\",\"latitude\":\"22.267\",\"physicalLocation\":\"Hong
+        Kong\",\"pairedRegion\":[{\"name\":\"southeastasia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastasia-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastasia-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastasia-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/indiasouthcentral\",\"name\":\"indiasouthcentral\",\"type\":\"Region\",\"displayName\":\"India
+        South Central\",\"regionalDisplayName\":\"(Asia Pacific) India South Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"78.47599792\",\"latitude\":\"17.36599922\",\"physicalLocation\":\"Hyderabad\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"indiasouthcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"indiasouthcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"indiasouthcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/indonesiacentral\",\"name\":\"indonesiacentral\",\"type\":\"Region\",\"displayName\":\"Indonesia
+        Central\",\"regionalDisplayName\":\"(Asia Pacific) Indonesia Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Indonesia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"106.816666\",\"latitude\":\"-6.2\",\"physicalLocation\":\"Jakarta\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"indonesiacentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"indonesiacentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"indonesiacentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast\",\"name\":\"japaneast\",\"type\":\"Region\",\"displayName\":\"Japan
+        East\",\"regionalDisplayName\":\"(Asia Pacific) Japan East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Japan\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"139.77\",\"latitude\":\"35.68\",\"physicalLocation\":\"Tokyo,
+        Saitama\",\"pairedRegion\":[{\"name\":\"japanwest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"japaneast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"japaneast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"japaneast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest\",\"name\":\"japanwest\",\"type\":\"Region\",\"displayName\":\"Japan
+        West\",\"regionalDisplayName\":\"(Asia Pacific) Japan West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Japan\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"135.5022\",\"latitude\":\"34.6939\",\"physicalLocation\":\"Osaka\",\"pairedRegion\":[{\"name\":\"japaneast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"japanwest-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"japanwest-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"japanwest-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral\",\"name\":\"koreacentral\",\"type\":\"Region\",\"displayName\":\"Korea
+        Central\",\"regionalDisplayName\":\"(Asia Pacific) Korea Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Korea\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"126.978\",\"latitude\":\"37.5665\",\"physicalLocation\":\"Seoul\",\"pairedRegion\":[{\"name\":\"koreasouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"koreacentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"koreacentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"koreacentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/malaysiawest\",\"name\":\"malaysiawest\",\"type\":\"Region\",\"displayName\":\"Malaysia
+        West\",\"regionalDisplayName\":\"(Asia Pacific) Malaysia West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Malaysia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"101.693207\",\"latitude\":\"3.140853\",\"physicalLocation\":\"Kuala
+        Lumpur\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"malaysiawest-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"malaysiawest-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"malaysiawest-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/newzealandnorth\",\"name\":\"newzealandnorth\",\"type\":\"Region\",\"displayName\":\"New
+        Zealand North\",\"regionalDisplayName\":\"(Asia Pacific) New Zealand North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"New
+        Zealand\",\"geographyGroup\":\"Asia Pacific\",\"longitude\":\"174.76349\",\"latitude\":\"-36.84853\",\"physicalLocation\":\"Auckland\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"newzealandnorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"newzealandnorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"newzealandnorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral\",\"name\":\"canadacentral\",\"type\":\"Region\",\"displayName\":\"Canada
+        Central\",\"regionalDisplayName\":\"(Canada) Canada Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Canada\",\"geographyGroup\":\"Canada\",\"longitude\":\"-79.383\",\"latitude\":\"43.653\",\"physicalLocation\":\"Toronto\",\"pairedRegion\":[{\"name\":\"canadaeast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"canadacentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"canadacentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"canadacentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/austriaeast\",\"name\":\"austriaeast\",\"type\":\"Region\",\"displayName\":\"Austria
+        East\",\"regionalDisplayName\":\"(Europe) Austria East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Austria\",\"geographyGroup\":\"Europe\",\"longitude\":\"16.3727779\",\"latitude\":\"48.2092056\",\"physicalLocation\":\"Vienna\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"austriaeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"austriaeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"austriaeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/belgiumcentral\",\"name\":\"belgiumcentral\",\"type\":\"Region\",\"displayName\":\"Belgium
+        Central\",\"regionalDisplayName\":\"(Europe) Belgium Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Belgium\",\"geographyGroup\":\"Europe\",\"longitude\":\"4.355707169\",\"latitude\":\"50.84553528\",\"physicalLocation\":\"Brussels\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"belgiumcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"belgiumcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"belgiumcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/denmarkeast\",\"name\":\"denmarkeast\",\"type\":\"Region\",\"displayName\":\"Denmark
+        East\",\"regionalDisplayName\":\"(Europe) Denmark East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Denmark\",\"geographyGroup\":\"Europe\",\"longitude\":\"12.56553\",\"latitude\":\"55.67594\",\"physicalLocation\":\"Copenhagen\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"denmarkeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"denmarkeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"denmarkeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francecentral\",\"name\":\"francecentral\",\"type\":\"Region\",\"displayName\":\"France
+        Central\",\"regionalDisplayName\":\"(Europe) France Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"France\",\"geographyGroup\":\"Europe\",\"longitude\":\"2.373\",\"latitude\":\"46.3772\",\"physicalLocation\":\"Paris\",\"pairedRegion\":[{\"name\":\"francesouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francesouth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"francecentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"francecentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"francecentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanywestcentral\",\"name\":\"germanywestcentral\",\"type\":\"Region\",\"displayName\":\"Germany
+        West Central\",\"regionalDisplayName\":\"(Europe) Germany West Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Germany\",\"geographyGroup\":\"Europe\",\"longitude\":\"8.682127\",\"latitude\":\"50.110924\",\"physicalLocation\":\"Frankfurt\",\"pairedRegion\":[{\"name\":\"germanynorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanynorth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"germanywestcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"germanywestcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"germanywestcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/italynorth\",\"name\":\"italynorth\",\"type\":\"Region\",\"displayName\":\"Italy
+        North\",\"regionalDisplayName\":\"(Europe) Italy North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Italy\",\"geographyGroup\":\"Europe\",\"longitude\":\"9.18109\",\"latitude\":\"45.46888\",\"physicalLocation\":\"Milan\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"italynorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"italynorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"italynorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwayeast\",\"name\":\"norwayeast\",\"type\":\"Region\",\"displayName\":\"Norway
+        East\",\"regionalDisplayName\":\"(Europe) Norway East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Norway\",\"geographyGroup\":\"Europe\",\"longitude\":\"10.752245\",\"latitude\":\"59.913868\",\"physicalLocation\":\"Norway\",\"pairedRegion\":[{\"name\":\"norwaywest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwaywest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"norwayeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"norwayeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"norwayeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/polandcentral\",\"name\":\"polandcentral\",\"type\":\"Region\",\"displayName\":\"Poland
+        Central\",\"regionalDisplayName\":\"(Europe) Poland Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Poland\",\"geographyGroup\":\"Europe\",\"longitude\":\"21.01666\",\"latitude\":\"52.23334\",\"physicalLocation\":\"Warsaw\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"polandcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"polandcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"polandcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/spaincentral\",\"name\":\"spaincentral\",\"type\":\"Region\",\"displayName\":\"Spain
+        Central\",\"regionalDisplayName\":\"(Europe) Spain Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Spain\",\"geographyGroup\":\"Europe\",\"longitude\":\"3.4209\",\"latitude\":\"40.4259\",\"physicalLocation\":\"Madrid\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"spaincentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"spaincentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"spaincentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandnorth\",\"name\":\"switzerlandnorth\",\"type\":\"Region\",\"displayName\":\"Switzerland
+        North\",\"regionalDisplayName\":\"(Europe) Switzerland North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Switzerland\",\"geographyGroup\":\"Europe\",\"longitude\":\"8.564572\",\"latitude\":\"47.451542\",\"physicalLocation\":\"Zurich\",\"pairedRegion\":[{\"name\":\"switzerlandwest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandwest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"switzerlandnorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"switzerlandnorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"switzerlandnorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/mexicocentral\",\"name\":\"mexicocentral\",\"type\":\"Region\",\"displayName\":\"Mexico
+        Central\",\"regionalDisplayName\":\"(Mexico) Mexico Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Mexico\",\"geographyGroup\":\"Mexico\",\"longitude\":\"-100.389888\",\"latitude\":\"20.588818\",\"physicalLocation\":\"Quer\xE9taro
+        State\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"mexicocentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"mexicocentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"mexicocentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaenorth\",\"name\":\"uaenorth\",\"type\":\"Region\",\"displayName\":\"UAE
+        North\",\"regionalDisplayName\":\"(Middle East) UAE North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"UAE\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"55.316666\",\"latitude\":\"25.266666\",\"physicalLocation\":\"Dubai\",\"pairedRegion\":[{\"name\":\"uaecentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaecentral\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"uaenorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"uaenorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"uaenorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth\",\"name\":\"brazilsouth\",\"type\":\"Region\",\"displayName\":\"Brazil
+        South\",\"regionalDisplayName\":\"(South America) Brazil South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Brazil\",\"geographyGroup\":\"South
+        America\",\"longitude\":\"-46.633\",\"latitude\":\"-23.55\",\"physicalLocation\":\"Sao
+        Paulo State\",\"pairedRegion\":[{\"name\":\"southcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"brazilsouth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"brazilsouth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"brazilsouth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/chilecentral\",\"name\":\"chilecentral\",\"type\":\"Region\",\"displayName\":\"Chile
+        Central\",\"regionalDisplayName\":\"(South America) Chile Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Chile\",\"geographyGroup\":\"South
+        America\",\"longitude\":\"-70.673676\",\"latitude\":\"-33.447487\",\"physicalLocation\":\"Santiago\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"chilecentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"chilecentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"chilecentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2euap\",\"name\":\"eastus2euap\",\"type\":\"Region\",\"displayName\":\"East
+        US 2 EUAP\",\"regionalDisplayName\":\"(US) East US 2 EUAP\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Canary
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-78.3889\",\"latitude\":\"36.6681\",\"physicalLocation\":\"\",\"pairedRegion\":[{\"name\":\"centraluseuap\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centraluseuap\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastus2euap-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastus2euap-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastus2euap-az1\"},{\"logicalZone\":\"4\",\"physicalZone\":\"eastus2euap-az4\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/israelcentral\",\"name\":\"israelcentral\",\"type\":\"Region\",\"displayName\":\"Israel
+        Central\",\"regionalDisplayName\":\"(Middle East) Israel Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Israel\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"33.4506633\",\"latitude\":\"31.2655698\",\"physicalLocation\":\"Israel\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"israelcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"israelcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"israelcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/qatarcentral\",\"name\":\"qatarcentral\",\"type\":\"Region\",\"displayName\":\"Qatar
+        Central\",\"regionalDisplayName\":\"(Middle East) Qatar Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Qatar\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"51.439327\",\"latitude\":\"25.551462\",\"physicalLocation\":\"Doha\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"qatarcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"qatarcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"qatarcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralusstage\",\"name\":\"centralusstage\",\"type\":\"Region\",\"displayName\":\"Central
+        US (Stage)\",\"regionalDisplayName\":\"(US) Central US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastusstage\",\"name\":\"eastusstage\",\"type\":\"Region\",\"displayName\":\"East
+        US (Stage)\",\"regionalDisplayName\":\"(US) East US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2stage\",\"name\":\"eastus2stage\",\"type\":\"Region\",\"displayName\":\"East
+        US 2 (Stage)\",\"regionalDisplayName\":\"(US) East US 2 (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralusstage\",\"name\":\"northcentralusstage\",\"type\":\"Region\",\"displayName\":\"North
+        Central US (Stage)\",\"regionalDisplayName\":\"(US) North Central US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralusstage\",\"name\":\"southcentralusstage\",\"type\":\"Region\",\"displayName\":\"South
+        Central US (Stage)\",\"regionalDisplayName\":\"(US) South Central US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westusstage\",\"name\":\"westusstage\",\"type\":\"Region\",\"displayName\":\"West
+        US (Stage)\",\"regionalDisplayName\":\"(US) West US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2stage\",\"name\":\"westus2stage\",\"type\":\"Region\",\"displayName\":\"West
+        US 2 (Stage)\",\"regionalDisplayName\":\"(US) West US 2 (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/asia\",\"name\":\"asia\",\"type\":\"Region\",\"displayName\":\"Asia\",\"regionalDisplayName\":\"Asia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/asiapacific\",\"name\":\"asiapacific\",\"type\":\"Region\",\"displayName\":\"Asia
+        Pacific\",\"regionalDisplayName\":\"Asia Pacific\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australia\",\"name\":\"australia\",\"type\":\"Region\",\"displayName\":\"Australia\",\"regionalDisplayName\":\"Australia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/austria\",\"name\":\"austria\",\"type\":\"Region\",\"displayName\":\"Austria\",\"regionalDisplayName\":\"Austria\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/belgium\",\"name\":\"belgium\",\"type\":\"Region\",\"displayName\":\"Belgium\",\"regionalDisplayName\":\"Belgium\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazil\",\"name\":\"brazil\",\"type\":\"Region\",\"displayName\":\"Brazil\",\"regionalDisplayName\":\"Brazil\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canada\",\"name\":\"canada\",\"type\":\"Region\",\"displayName\":\"Canada\",\"regionalDisplayName\":\"Canada\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/chile\",\"name\":\"chile\",\"type\":\"Region\",\"displayName\":\"Chile\",\"regionalDisplayName\":\"Chile\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/denmark\",\"name\":\"denmark\",\"type\":\"Region\",\"displayName\":\"Denmark\",\"regionalDisplayName\":\"Denmark\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/europe\",\"name\":\"europe\",\"type\":\"Region\",\"displayName\":\"Europe\",\"regionalDisplayName\":\"Europe\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/finland\",\"name\":\"finland\",\"type\":\"Region\",\"displayName\":\"Finland\",\"regionalDisplayName\":\"Finland\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/france\",\"name\":\"france\",\"type\":\"Region\",\"displayName\":\"France\",\"regionalDisplayName\":\"France\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germany\",\"name\":\"germany\",\"type\":\"Region\",\"displayName\":\"Germany\",\"regionalDisplayName\":\"Germany\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/global\",\"name\":\"global\",\"type\":\"Region\",\"displayName\":\"Global\",\"regionalDisplayName\":\"Global\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/india\",\"name\":\"india\",\"type\":\"Region\",\"displayName\":\"India\",\"regionalDisplayName\":\"India\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/indonesia\",\"name\":\"indonesia\",\"type\":\"Region\",\"displayName\":\"Indonesia\",\"regionalDisplayName\":\"Indonesia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/israel\",\"name\":\"israel\",\"type\":\"Region\",\"displayName\":\"Israel\",\"regionalDisplayName\":\"Israel\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/italy\",\"name\":\"italy\",\"type\":\"Region\",\"displayName\":\"Italy\",\"regionalDisplayName\":\"Italy\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japan\",\"name\":\"japan\",\"type\":\"Region\",\"displayName\":\"Japan\",\"regionalDisplayName\":\"Japan\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/korea\",\"name\":\"korea\",\"type\":\"Region\",\"displayName\":\"Korea\",\"regionalDisplayName\":\"Korea\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/malaysia\",\"name\":\"malaysia\",\"type\":\"Region\",\"displayName\":\"Malaysia\",\"regionalDisplayName\":\"Malaysia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/mexico\",\"name\":\"mexico\",\"type\":\"Region\",\"displayName\":\"Mexico\",\"regionalDisplayName\":\"Mexico\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/newzealand\",\"name\":\"newzealand\",\"type\":\"Region\",\"displayName\":\"New
+        Zealand\",\"regionalDisplayName\":\"New Zealand\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norway\",\"name\":\"norway\",\"type\":\"Region\",\"displayName\":\"Norway\",\"regionalDisplayName\":\"Norway\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/poland\",\"name\":\"poland\",\"type\":\"Region\",\"displayName\":\"Poland\",\"regionalDisplayName\":\"Poland\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/qatar\",\"name\":\"qatar\",\"type\":\"Region\",\"displayName\":\"Qatar\",\"regionalDisplayName\":\"Qatar\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/saudiarabia\",\"name\":\"saudiarabia\",\"type\":\"Region\",\"displayName\":\"Saudi
+        Arabia\",\"regionalDisplayName\":\"Saudi Arabia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/singapore\",\"name\":\"singapore\",\"type\":\"Region\",\"displayName\":\"Singapore\",\"regionalDisplayName\":\"Singapore\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafrica\",\"name\":\"southafrica\",\"type\":\"Region\",\"displayName\":\"South
+        Africa\",\"regionalDisplayName\":\"South Africa\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/spain\",\"name\":\"spain\",\"type\":\"Region\",\"displayName\":\"Spain\",\"regionalDisplayName\":\"Spain\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/sweden\",\"name\":\"sweden\",\"type\":\"Region\",\"displayName\":\"Sweden\",\"regionalDisplayName\":\"Sweden\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerland\",\"name\":\"switzerland\",\"type\":\"Region\",\"displayName\":\"Switzerland\",\"regionalDisplayName\":\"Switzerland\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/taiwan\",\"name\":\"taiwan\",\"type\":\"Region\",\"displayName\":\"Taiwan\",\"regionalDisplayName\":\"Taiwan\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uae\",\"name\":\"uae\",\"type\":\"Region\",\"displayName\":\"United
+        Arab Emirates\",\"regionalDisplayName\":\"United Arab Emirates\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uk\",\"name\":\"uk\",\"type\":\"Region\",\"displayName\":\"United
+        Kingdom\",\"regionalDisplayName\":\"United Kingdom\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/unitedstates\",\"name\":\"unitedstates\",\"type\":\"Region\",\"displayName\":\"United
+        States\",\"regionalDisplayName\":\"United States\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/unitedstateseuap\",\"name\":\"unitedstateseuap\",\"type\":\"Region\",\"displayName\":\"United
+        States EUAP\",\"regionalDisplayName\":\"United States EUAP\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasiastage\",\"name\":\"eastasiastage\",\"type\":\"Region\",\"displayName\":\"East
+        Asia (Stage)\",\"regionalDisplayName\":\"(Asia Pacific) East Asia (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"asia\",\"geographyGroup\":\"Asia
+        Pacific\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasiastage\",\"name\":\"southeastasiastage\",\"type\":\"Region\",\"displayName\":\"Southeast
+        Asia (Stage)\",\"regionalDisplayName\":\"(Asia Pacific) Southeast Asia (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"asia\",\"geographyGroup\":\"Asia
+        Pacific\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2\",\"name\":\"eastus2\",\"type\":\"Region\",\"displayName\":\"East
+        US 2\",\"regionalDisplayName\":\"(US) East US 2\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-78.3889\",\"latitude\":\"36.6681\",\"physicalLocation\":\"Virginia\",\"pairedRegion\":[{\"name\":\"centralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastus2-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastus2-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastus2-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastusstg\",\"name\":\"eastusstg\",\"type\":\"Region\",\"displayName\":\"East
+        US STG\",\"regionalDisplayName\":\"(US) East US STG\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Stage
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-79.8164\",\"latitude\":\"37.3719\",\"physicalLocation\":\"Virginia\",\"pairedRegion\":[{\"name\":\"southcentralusstg\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralusstg\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus\",\"name\":\"southcentralus\",\"type\":\"Region\",\"displayName\":\"South
+        Central US\",\"regionalDisplayName\":\"(US) South Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-98.5\",\"latitude\":\"29.4167\",\"physicalLocation\":\"Texas\",\"pairedRegion\":[{\"name\":\"northcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"southcentralus-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"southcentralus-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"southcentralus-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus3\",\"name\":\"westus3\",\"type\":\"Region\",\"displayName\":\"West
+        US 3\",\"regionalDisplayName\":\"(US) West US 3\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-112.074036\",\"latitude\":\"33.448376\",\"physicalLocation\":\"Phoenix\",\"pairedRegion\":[{\"name\":\"eastus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"westus3-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"westus3-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"westus3-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus\",\"name\":\"northcentralus\",\"type\":\"Region\",\"displayName\":\"North
+        Central US\",\"regionalDisplayName\":\"(US) North Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-87.6278\",\"latitude\":\"41.8819\",\"physicalLocation\":\"Illinois\",\"pairedRegion\":[{\"name\":\"southcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus\",\"name\":\"westus\",\"type\":\"Region\",\"displayName\":\"West
+        US\",\"regionalDisplayName\":\"(US) West US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-122.417\",\"latitude\":\"37.783\",\"physicalLocation\":\"California\",\"pairedRegion\":[{\"name\":\"eastus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiawest\",\"name\":\"jioindiawest\",\"type\":\"Region\",\"displayName\":\"Jio
+        India West\",\"regionalDisplayName\":\"(Asia Pacific) Jio India West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"70.05773\",\"latitude\":\"22.470701\",\"physicalLocation\":\"Jamnagar\",\"pairedRegion\":[{\"name\":\"jioindiacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centraluseuap\",\"name\":\"centraluseuap\",\"type\":\"Region\",\"displayName\":\"Central
+        US EUAP\",\"regionalDisplayName\":\"(US) Central US EUAP\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Canary
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-93.6208\",\"latitude\":\"41.5908\",\"physicalLocation\":\"\",\"pairedRegion\":[{\"name\":\"eastus2euap\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2euap\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralusstg\",\"name\":\"southcentralusstg\",\"type\":\"Region\",\"displayName\":\"South
+        Central US STG\",\"regionalDisplayName\":\"(US) South Central US STG\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Stage
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-98.5\",\"latitude\":\"29.4167\",\"physicalLocation\":\"Texas\",\"pairedRegion\":[{\"name\":\"eastusstg\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastusstg\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus\",\"name\":\"westcentralus\",\"type\":\"Region\",\"displayName\":\"West
+        Central US\",\"regionalDisplayName\":\"(US) West Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-110.234\",\"latitude\":\"40.89\",\"physicalLocation\":\"Wyoming\",\"pairedRegion\":[{\"name\":\"westus2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricawest\",\"name\":\"southafricawest\",\"type\":\"Region\",\"displayName\":\"South
+        Africa West\",\"regionalDisplayName\":\"(Africa) South Africa West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"South
+        Africa\",\"geographyGroup\":\"Africa\",\"longitude\":\"18.843266\",\"latitude\":\"-34.075691\",\"physicalLocation\":\"Cape
+        Town\",\"pairedRegion\":[{\"name\":\"southafricanorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricanorth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral\",\"name\":\"australiacentral\",\"type\":\"Region\",\"displayName\":\"Australia
+        Central\",\"regionalDisplayName\":\"(Asia Pacific) Australia Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"149.1244\",\"latitude\":\"-35.3075\",\"physicalLocation\":\"Canberra\",\"pairedRegion\":[{\"name\":\"australiacentral2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral2\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral2\",\"name\":\"australiacentral2\",\"type\":\"Region\",\"displayName\":\"Australia
+        Central 2\",\"regionalDisplayName\":\"(Asia Pacific) Australia Central 2\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"149.1244\",\"latitude\":\"-35.3075\",\"physicalLocation\":\"Canberra\",\"pairedRegion\":[{\"name\":\"australiacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast\",\"name\":\"australiasoutheast\",\"type\":\"Region\",\"displayName\":\"Australia
+        Southeast\",\"regionalDisplayName\":\"(Asia Pacific) Australia Southeast\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"144.9631\",\"latitude\":\"-37.8136\",\"physicalLocation\":\"Victoria\",\"pairedRegion\":[{\"name\":\"australiaeast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiacentral\",\"name\":\"jioindiacentral\",\"type\":\"Region\",\"displayName\":\"Jio
+        India Central\",\"regionalDisplayName\":\"(Asia Pacific) Jio India Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"79.08886\",\"latitude\":\"21.146633\",\"physicalLocation\":\"Nagpur\",\"pairedRegion\":[{\"name\":\"jioindiawest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiawest\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth\",\"name\":\"koreasouth\",\"type\":\"Region\",\"displayName\":\"Korea
+        South\",\"regionalDisplayName\":\"(Asia Pacific) Korea South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Korea\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"129.0756\",\"latitude\":\"35.1796\",\"physicalLocation\":\"Busan\",\"pairedRegion\":[{\"name\":\"koreacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia\",\"name\":\"southindia\",\"type\":\"Region\",\"displayName\":\"South
+        India\",\"regionalDisplayName\":\"(Asia Pacific) South India\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"80.1636\",\"latitude\":\"12.9822\",\"physicalLocation\":\"Chennai\",\"pairedRegion\":[{\"name\":\"centralindia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westindia\",\"name\":\"westindia\",\"type\":\"Region\",\"displayName\":\"West
+        India\",\"regionalDisplayName\":\"(Asia Pacific) West India\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"72.868\",\"latitude\":\"19.088\",\"physicalLocation\":\"Mumbai\",\"pairedRegion\":[{\"name\":\"southindia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast\",\"name\":\"canadaeast\",\"type\":\"Region\",\"displayName\":\"Canada
+        East\",\"regionalDisplayName\":\"(Canada) Canada East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Canada\",\"geographyGroup\":\"Canada\",\"longitude\":\"-71.217\",\"latitude\":\"46.817\",\"physicalLocation\":\"Quebec\",\"pairedRegion\":[{\"name\":\"canadacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francesouth\",\"name\":\"francesouth\",\"type\":\"Region\",\"displayName\":\"France
+        South\",\"regionalDisplayName\":\"(Europe) France South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"France\",\"geographyGroup\":\"Europe\",\"longitude\":\"2.1972\",\"latitude\":\"43.8345\",\"physicalLocation\":\"Marseille\",\"pairedRegion\":[{\"name\":\"francecentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francecentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanynorth\",\"name\":\"germanynorth\",\"type\":\"Region\",\"displayName\":\"Germany
+        North\",\"regionalDisplayName\":\"(Europe) Germany North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Germany\",\"geographyGroup\":\"Europe\",\"longitude\":\"8.806422\",\"latitude\":\"53.073635\",\"physicalLocation\":\"Berlin\",\"pairedRegion\":[{\"name\":\"germanywestcentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanywestcentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwaywest\",\"name\":\"norwaywest\",\"type\":\"Region\",\"displayName\":\"Norway
+        West\",\"regionalDisplayName\":\"(Europe) Norway West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Norway\",\"geographyGroup\":\"Europe\",\"longitude\":\"5.733107\",\"latitude\":\"58.969975\",\"physicalLocation\":\"Norway\",\"pairedRegion\":[{\"name\":\"norwayeast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwayeast\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandwest\",\"name\":\"switzerlandwest\",\"type\":\"Region\",\"displayName\":\"Switzerland
+        West\",\"regionalDisplayName\":\"(Europe) Switzerland West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Switzerland\",\"geographyGroup\":\"Europe\",\"longitude\":\"6.143158\",\"latitude\":\"46.204391\",\"physicalLocation\":\"Geneva\",\"pairedRegion\":[{\"name\":\"switzerlandnorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandnorth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaecentral\",\"name\":\"uaecentral\",\"type\":\"Region\",\"displayName\":\"UAE
+        Central\",\"regionalDisplayName\":\"(Middle East) UAE Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"UAE\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"54.366669\",\"latitude\":\"24.466667\",\"physicalLocation\":\"Abu
+        Dhabi\",\"pairedRegion\":[{\"name\":\"uaenorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaenorth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsoutheast\",\"name\":\"brazilsoutheast\",\"type\":\"Region\",\"displayName\":\"Brazil
+        Southeast\",\"regionalDisplayName\":\"(South America) Brazil Southeast\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Brazil\",\"geographyGroup\":\"South
+        America\",\"longitude\":\"-43.2075\",\"latitude\":\"-22.90278\",\"physicalLocation\":\"Rio\",\"pairedRegion\":[{\"name\":\"brazilsouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest\",\"name\":\"ukwest\",\"type\":\"Region\",\"displayName\":\"UK
+        West\",\"regionalDisplayName\":\"(UK) UK West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        Kingdom\",\"geographyGroup\":\"UK\",\"longitude\":\"-3.084\",\"latitude\":\"53.427\",\"physicalLocation\":\"Cardiff\",\"pairedRegion\":[{\"name\":\"uksouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth\"}]}}]}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '49905'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:25:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EB88F4F01D9B4989B9A713AB72EF69F2 Ref B: PNQ231110907040 Ref C: 2026-09-08T09:25:36Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/web?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/web","name":"inplace-func000003","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","powerShellVersion":"","linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":[],"requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"REDACTED","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","vnetRouteAllEnabled":false,"vnetPrivatePortsCount":0,"publicNetworkAccess":null,"siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":null},"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":false,"http20Enabled":false,"minTlsVersion":"1.2","minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":"1.2","ftpsState":"FtpsOnly","preWarmedInstanceCount":0,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":false,"functionsRuntimeScaleMonitoringEnabled":false,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":{},"http20ProxyFlag":0,"sitePort":null,"antivirusScanEnabled":false,"storageType":"StorageVolume","sitePrivateLinkHostEnabled":false,"clusteringEnabled":false,"webJobsEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4157'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/0a0667d0-e352-4922-9de3-ecd4243879b2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 50149A6DD2E14F0A8B1B1BCD6201813B Ref B: PNQ231110907029 Ref C: 2026-09-08T09:25:40Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Web/locations/northcentralusstage/functionAppStacks?api-version=2020-10-01&removeHiddenStacks=true&removeDeprecatedStacks=true&stack=node&sku=FC1
+  response:
+    body:
+      string: '{"value":[{"id":null,"name":"node","type":"Microsoft.Web/locations/functionAppStacks?stackOsType=All","location":"northcentralusstage","properties":{"displayText":"Node.js","value":"node","preferredOs":"windows","majorVersions":[{"displayText":"Node.js
+        24","value":"24","minorVersions":[{"displayText":"Node.js 24","value":"24
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|24","isPreview":false,"isDefault":false,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"24.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|24"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"24"}}}],"endOfLifeDate":"Mon
+        Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        22","value":"22","minorVersions":[{"displayText":"Node.js 22","value":"22
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|22","isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|22"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"22"}}}],"endOfLifeDate":"Fri
+        Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        20","value":"20","minorVersions":[{"displayText":"Node.js 20 LTS","value":"20
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|20"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"20"}}}],"endOfLifeDate":"Thu
+        Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]}]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3613'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: E10868A441E346919626A5924E5E63C9 Ref B: PNQ231110906029 Ref C: 2026-09-08T09:25:41Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/appsettings/list?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTSHARE":"inplace-func000003","FUNCTIONS_EXTENSION_VERSION":"~4","FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_RUN_FROM_PACKAGE":"https://clitest000002.blob.core.windows.net/source-packages/inplace-func000003.zip?se=2026-09-09T09%3A24Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1362'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/783f3300-55e9-4fb1-9b2f-eeabc07e516e
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: A468C7AAF4714D708A00EE84F8E8476E Ref B: PNQ231110908040 Ref C: 2026-09-08T09:25:41Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9011'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:42 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F66B93EAEA8F4B2BA06FF2DEA098D031 Ref B: PNQ231110908060 Ref C: 2026-09-08T09:25:42Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8945'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:43 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 411017FDFB524F34B02CB0DD7638E843 Ref B: PNQ231110906060 Ref C: 2026-09-08T09:25:43Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/slotConfigNames?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":null,"name":"inplace-func000003","type":"Microsoft.Web/sites","location":"North
+        Central US (Stage)","properties":{"connectionStringNames":null,"appSettingNames":null,"azureStorageConfigNames":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '204'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/70829c25-5989-46fd-99c5-6b8167874185
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4A2173487A1549AAAE2A1D3AD63F88AE Ref B: PNQ231110909034 Ref C: 2026-09-08T09:25:43Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/slots?api-version=2025-05-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:25:44 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 1baae517-a15a-4f40-92f7-bef97b3631f5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 94700A860DCE4FF2895D560F0BF005D6 Ref B: PNQ231110907042 Ref C: 2026-09-08T09:25:44Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/web?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/web","name":"inplace-func000003","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","powerShellVersion":"","linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":[],"requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"REDACTED","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","vnetRouteAllEnabled":false,"vnetPrivatePortsCount":0,"publicNetworkAccess":null,"siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":null},"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":false,"http20Enabled":false,"minTlsVersion":"1.2","minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":"1.2","ftpsState":"FtpsOnly","preWarmedInstanceCount":0,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":false,"functionsRuntimeScaleMonitoringEnabled":false,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":{},"http20ProxyFlag":0,"sitePort":null,"antivirusScanEnabled":false,"storageType":"StorageVolume","sitePrivateLinkHostEnabled":false,"clusteringEnabled":false,"webJobsEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4157'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/9d4988c6-7249-4efc-afbc-8197966ca13d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C77E5D4654D845C1AFD30D199FB87269 Ref B: PNQ231110906054 Ref C: 2026-09-08T09:25:44Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/appsettings/list?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTSHARE":"inplace-func000003","FUNCTIONS_EXTENSION_VERSION":"~4","FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_RUN_FROM_PACKAGE":"https://clitest000002.blob.core.windows.net/source-packages/inplace-func000003.zip?se=2026-09-09T09%3A24Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1362'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/ff6f9c99-1902-47ce-ab6c-8152db55bf5e
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: 81E603DC53A1462B80807184ADDFA1DD Ref B: PNQ231110906025 Ref C: 2026-09-08T09:25:45Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9011'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:46 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8D512305C7974E3E88B2E7377A357BE8 Ref B: PNQ231110908040 Ref C: 2026-09-08T09:25:46Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:24.0233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8945'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:48 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 70038D9CBA974A79AA5D875EF2E92069 Ref B: PNQ231110909023 Ref C: 2026-09-08T09:25:46Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/slotConfigNames?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":null,"name":"inplace-func000003","type":"Microsoft.Web/sites","location":"North
+        Central US (Stage)","properties":{"connectionStringNames":null,"appSettingNames":null,"azureStorageConfigNames":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '204'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/77bb3b37-5294-4a39-b9ae-befb719c7c2b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3136B899777946E3A05B6A71114F035D Ref B: PNQ231110909025 Ref C: 2026-09-08T09:25:49Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts?api-version=2025-08-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:24:30.8584755Z","key2":"2026-09-08T09:24:30.8584755Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:24:30.6373746Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1362'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:25:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - f7d6e0bd-67fa-4315-82f1-4afc82b7c8e5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8E25593AE38D45959E9569C3E65C0881 Ref B: PNQ231110908029 Ref C: 2026-09-08T09:25:49Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Web/locations/North%20Central%20US%20(Stage)/functionAppStacks?api-version=2020-10-01&removeHiddenStacks=true&removeDeprecatedStacks=true&stack=node&sku=FC1
+  response:
+    body:
+      string: '{"value":[{"id":null,"name":"node","type":"Microsoft.Web/locations/functionAppStacks?stackOsType=All","location":"North
+        Central US (Stage)","properties":{"displayText":"Node.js","value":"node","preferredOs":"windows","majorVersions":[{"displayText":"Node.js
+        24","value":"24","minorVersions":[{"displayText":"Node.js 24","value":"24
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|24","isPreview":false,"isDefault":false,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"24.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|24"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"24"}}}],"endOfLifeDate":"Mon
+        Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        22","value":"22","minorVersions":[{"displayText":"Node.js 22","value":"22
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|22","isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|22"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"22"}}}],"endOfLifeDate":"Fri
+        Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        20","value":"20","minorVersions":[{"displayText":"Node.js 20 LTS","value":"20
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|20"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"20"}}}],"endOfLifeDate":"Thu
+        Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]}]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3618'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: 76E5770814164C728CA650ED25735B2D Ref B: PNQ231110907031 Ref C: 2026-09-08T09:25:50Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/appsettings/list?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTSHARE":"inplace-func000003","FUNCTIONS_EXTENSION_VERSION":"~4","FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_RUN_FROM_PACKAGE":"https://clitest000002.blob.core.windows.net/source-packages/inplace-func000003.zip?se=2026-09-09T09%3A24Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1362'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/8fdf3c3e-96dc-4db2-b8d1-c6c65a381dc7
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: B54D26CFF82D44AC92B4C423D4FDE32E Ref B: PNQ231110908042 Ref C: 2026-09-08T09:25:50Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002?api-version=2025-08-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:24:30.8584755Z","key2":"2026-09-08T09:24:30.8584755Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:24:30.8686135Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:24:30.6373746Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1350'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 42A46488452A4964A6923ACC322B21EB Ref B: PNQ231110909042 Ref C: 2026-09-08T09:25:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/blobServices/default/containers/defaultcontainer?api-version=2025-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/blobServices/default/containers/defaultcontainer","name":"defaultcontainer","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8DF0D8B21D61B43\"","properties":{"deleted":false,"remainingRetentionDays":0,"defaultEncryptionScope":"$account-encryption-key","denyEncryptionScopeOverride":false,"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2026-09-08T09:25:32.0000000Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '686'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:25:52 GMT
+      etag:
+      - '"0x8DF0D8B21D61B43"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/7a73cc04-0a20-436b-b5d5-0cac70ba755a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3ABDCD911CDD4B36869980222F89D331 Ref B: PNQ231110907034 Ref C: 2026-09-08T09:25:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "North Central US (Stage)", "sku": {"name": "FlexConsumption"},
+      "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004",
+      "functionAppConfig": {"deployment": {"storage": {"type": "blobContainer", "value":
+      "https://clitest000002.blob.core.windows.net/defaultcontainer", "authentication":
+      {"type": "StorageAccountConnectionString", "storageAccountConnectionStringName":
+      "AzureWebJobsStorage"}}}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '523'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:25:56 GMT
+      etag:
+      - 1DD3F73FA11A975
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563572662268&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=yIXdeDG2VV4-1djSKhZiHXAlNNAEQ31Bw6uRDc1pt6jrdM4aa2iorWuS60IvNjH8sDoA7lKdtGjrCAQafQ_lpCalgY4luh0wrnl1WbS3q_twduI54sjjrnyoQjo7YNrl-yBRmbmkO8Qmy9dUepj_b16BhzXtDjA9jbHMdWdkmbMNzDnExC_YdiJzMPuV97F6OEVK-ZEYpWCAOztMaQo8Y6K6UN48BtzKmFjHsii60Tdaz4Il8vb4BN5YNSxvj7NRmcEwL83v4VmhQLzCl8eKquyLrSnMwqBe1ndbsgx1QvVpCOyrq8POBudBz6HGa-k1l8H0pWPnI8b6cAspA985pA&h=1BtmzHz4hPsjp58xmsCEEfLwi0djG3CDtL0Wqkcp6uo
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/fd547df6-3d46-4d7a-b6e2-e1e73b9223cc
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+      x-msedge-ref:
+      - 'Ref A: 50ACFA8E2E7846E0B4A9F7A6452B872C Ref B: PNQ231110906034 Ref C: 2026-09-08T09:25:53Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563572662268&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=yIXdeDG2VV4-1djSKhZiHXAlNNAEQ31Bw6uRDc1pt6jrdM4aa2iorWuS60IvNjH8sDoA7lKdtGjrCAQafQ_lpCalgY4luh0wrnl1WbS3q_twduI54sjjrnyoQjo7YNrl-yBRmbmkO8Qmy9dUepj_b16BhzXtDjA9jbHMdWdkmbMNzDnExC_YdiJzMPuV97F6OEVK-ZEYpWCAOztMaQo8Y6K6UN48BtzKmFjHsii60Tdaz4Il8vb4BN5YNSxvj7NRmcEwL83v4VmhQLzCl8eKquyLrSnMwqBe1ndbsgx1QvVpCOyrq8POBudBz6HGa-k1l8H0pWPnI8b6cAspA985pA&h=1BtmzHz4hPsjp58xmsCEEfLwi0djG3CDtL0Wqkcp6uo
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:26:00 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563605422134&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=VOBh94u_N1gwccDxr3iXpIRrW9dApjgTUxHcihp7zSxt0YJ_hBRQbWEuVLqbn3N_oRA_0Zyw-GsQQM_Ac2S6JnRypjeNWMgv8an4NKgAQpKT3mlms0cAUXLFvxGHxYl5I_Cga7TqDn59DhjnFNJu_EnKkgZVH30KrJYq1OkwlgNFDDm5mI0Qu8GLKciPccZTlCYzzmDERxnpN9komhOTuDaF4aH9bZM6GB4x_xqORMUPNWPXR0cCEqCz6f8b0CmrTfCVEfOFf_c5vDlDSGdLB1-O2ZTeIXV5Ba-N9QchrKYxUDL_3s2KTzIJobbO7Kr9UysLX-EItzvDuN8kA15zUA&h=ax6hyM94b_0GQMdCFibTiQxU3DV-_UCHMCAyg49mmgY
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/87bab0c8-8508-4793-82bb-9d6e1e0389ea
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8170353EC021491BB81625D26019763C Ref B: PNQ231110906060 Ref C: 2026-09-08T09:25:57Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563605422134&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=VOBh94u_N1gwccDxr3iXpIRrW9dApjgTUxHcihp7zSxt0YJ_hBRQbWEuVLqbn3N_oRA_0Zyw-GsQQM_Ac2S6JnRypjeNWMgv8an4NKgAQpKT3mlms0cAUXLFvxGHxYl5I_Cga7TqDn59DhjnFNJu_EnKkgZVH30KrJYq1OkwlgNFDDm5mI0Qu8GLKciPccZTlCYzzmDERxnpN9komhOTuDaF4aH9bZM6GB4x_xqORMUPNWPXR0cCEqCz6f8b0CmrTfCVEfOFf_c5vDlDSGdLB1-O2ZTeIXV5Ba-N9QchrKYxUDL_3s2KTzIJobbO7Kr9UysLX-EItzvDuN8kA15zUA&h=ax6hyM94b_0GQMdCFibTiQxU3DV-_UCHMCAyg49mmgY
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:26:16 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563766693537&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=BNmpbeyzgZlE0wQkssulLj10cKLfk6vbokZrAZg1sPQB82deRcUtYYlZ_iza5bow9uUHqWS8cgD9SnBMXgJLORJ6lZPKLydlWyI41jgJvezdY8jTpVEE1MueK9OF3eV3Vsk7I1170RzgielvXqJU-9kiV9e3jhVXu8ds6unIixoamJO31eHdEExL4No7MIZruwyjFcri0_mROnMfdljpsNS6l9jBWqPrh4ghIoms-i6dh4Wf4xF8AVRhhqIWfGDTQ6RTy0ADUUeZGueQEVWYbcoli1KHRvEMZU5h5S1qghbC3B-0k5ct_8NteTKXisYkb67Ej-Kj4Oi7pxBTze2wLw&h=rm4xTR_Y7I91IswBw1nsBOgEIDmkuqaBMoGXnmzvx9I
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/dc50241b-dfc4-4e86-b0f5-ddd197a7f324
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2FDC8667149743F08A06CF1320874457 Ref B: PNQ231110909036 Ref C: 2026-09-08T09:26:15Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563766693537&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=BNmpbeyzgZlE0wQkssulLj10cKLfk6vbokZrAZg1sPQB82deRcUtYYlZ_iza5bow9uUHqWS8cgD9SnBMXgJLORJ6lZPKLydlWyI41jgJvezdY8jTpVEE1MueK9OF3eV3Vsk7I1170RzgielvXqJU-9kiV9e3jhVXu8ds6unIixoamJO31eHdEExL4No7MIZruwyjFcri0_mROnMfdljpsNS6l9jBWqPrh4ghIoms-i6dh4Wf4xF8AVRhhqIWfGDTQ6RTy0ADUUeZGueQEVWYbcoli1KHRvEMZU5h5S1qghbC3B-0k5ct_8NteTKXisYkb67Ej-Kj4Oi7pxBTze2wLw&h=rm4xTR_Y7I91IswBw1nsBOgEIDmkuqaBMoGXnmzvx9I
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:26:31 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563927532419&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=sJcPNuqbbEJ6pKVgbGHL5ougLOXhRNh0QqUxz8M0xLFIlKFp0EXRhIC1DoBqcSuC0Ob7Ke3sroUkKKMZj901yCvkbX0yF1-6dHyrbAXjDsEpW36CaJ0WxvANF4hDfOMy934ynYuSZY9Gowc3ElmNiy0CPgsqHtCiNkbFk-dD9gvPT9uK4rf-3pyjWYAucKQPQchuy7YnRMR1ehWI6y1vqmUQU3L6dgc28dRNxPWgX0pWna15lhtJ1wPvFDejqYVn9FoxVL4AjRBOMyLXOUB0I2GyyP0J7XvcLqS6flqbBsGM8uvNmm9_yQ-Stt0o31YUqSAaHjFg7q_jeYZM5ifjgQ&h=VslpMs91xw9KDWJGpypYyd1zpE4iN-QO5Kn-mzbHnnQ
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/43100626-c2aa-4096-b920-4e7fa50fefd9
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 69B2FDD6204043D5B53C455E24074465 Ref B: PNQ231110909031 Ref C: 2026-09-08T09:26:32Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244563927532419&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=sJcPNuqbbEJ6pKVgbGHL5ougLOXhRNh0QqUxz8M0xLFIlKFp0EXRhIC1DoBqcSuC0Ob7Ke3sroUkKKMZj901yCvkbX0yF1-6dHyrbAXjDsEpW36CaJ0WxvANF4hDfOMy934ynYuSZY9Gowc3ElmNiy0CPgsqHtCiNkbFk-dD9gvPT9uK4rf-3pyjWYAucKQPQchuy7YnRMR1ehWI6y1vqmUQU3L6dgc28dRNxPWgX0pWna15lhtJ1wPvFDejqYVn9FoxVL4AjRBOMyLXOUB0I2GyyP0J7XvcLqS6flqbBsGM8uvNmm9_yQ-Stt0o31YUqSAaHjFg7q_jeYZM5ifjgQ&h=VslpMs91xw9KDWJGpypYyd1zpE4iN-QO5Kn-mzbHnnQ
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:26:49 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244564098911610&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=fOfkyJRX_T55786PqAmBrspgTcv6nY82CUn9Fm0fDlnUB8_FXp2V4iReXW8Bcg1Ln4JsycbUTTTfbq9AVPZ5UXfcD-PFGzJInM8R46NvR2S0iBfcVmgx0RINvxtcoh99M5y5BsqWMnP1HNpVbbI2Ofm-3-6qhbHG9iiqKs5BK3FwOi0MhFgL-tRpCLf-bbvtrzYvc8Q9VWYIwh7eyDX_mQPbxzh7qxOHFDACiV9Y0mFpLSp3ri47SLCYM6ZPveE9Ph7belmX1kC2CMwiu-qKkfrlvVD-j80ProKx2wHU-EqVimUFdpoFhMU-T167zCGfr6HHFbU_IzjUpwyRCLfoVg&h=ZJDuAj6elMLZcjHNURw82uG61CIRK73T0ZGrADYQUIA
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/b94b9b98-050f-4576-ba17-85251e31eea9
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8A26D54D60604AD6878A89AC276BCD58 Ref B: PNQ231110908036 Ref C: 2026-09-08T09:26:48Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244564098911610&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=fOfkyJRX_T55786PqAmBrspgTcv6nY82CUn9Fm0fDlnUB8_FXp2V4iReXW8Bcg1Ln4JsycbUTTTfbq9AVPZ5UXfcD-PFGzJInM8R46NvR2S0iBfcVmgx0RINvxtcoh99M5y5BsqWMnP1HNpVbbI2Ofm-3-6qhbHG9iiqKs5BK3FwOi0MhFgL-tRpCLf-bbvtrzYvc8Q9VWYIwh7eyDX_mQPbxzh7qxOHFDACiV9Y0mFpLSp3ri47SLCYM6ZPveE9Ph7belmX1kC2CMwiu-qKkfrlvVD-j80ProKx2wHU-EqVimUFdpoFhMU-T167zCGfr6HHFbU_IzjUpwyRCLfoVg&h=ZJDuAj6elMLZcjHNURw82uG61CIRK73T0ZGrADYQUIA
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:27:05 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244564259925113&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=BwiOO1cDDa6qw142diot0eYukEotGO5pQ79aYnFzKDC2kFcnqkJ3a78PqfW2OBLfqmWymx3AB0wlmICi3rKXtz7-RU-uGwfTVG2DjKj23EPLYznm40u3lkkkt6jBsGNsj2h3LVe4tgMxzapMfqgjFju_oO8axqJNtz82rv0UCo_ZKiCKejy674oa8RP0H_vPwBhwrK0G6JpmIZKRQiNKp3HTkAq_mJOxllp-JAScjKoqDY9SZIZ9RYO-zEGToM9noBuWKedClRL8gvjYe3Otj4cuVIxkYelaqHcW7t4wR__Jz2eDa3Pt0uCeB1sMPogNIYAj1NLJUuYPOmipk2VJxQ&h=iReb8Iod6pYpV6qbbPxh37LZCtZs_hYVSsU4S6eUvUc
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/011564aa-a8e8-4bbf-ad44-4233cc0a75e7
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 491E34EF79B146629813436CA80E805D Ref B: PNQ231110906054 Ref C: 2026-09-08T09:27:05Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003/operationresults/1fe41a12-89e4-4541-9351-ca524f0f3853?api-version=2025-05-01&t=639244564259925113&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=BwiOO1cDDa6qw142diot0eYukEotGO5pQ79aYnFzKDC2kFcnqkJ3a78PqfW2OBLfqmWymx3AB0wlmICi3rKXtz7-RU-uGwfTVG2DjKj23EPLYznm40u3lkkkt6jBsGNsj2h3LVe4tgMxzapMfqgjFju_oO8axqJNtz82rv0UCo_ZKiCKejy674oa8RP0H_vPwBhwrK0G6JpmIZKRQiNKp3HTkAq_mJOxllp-JAScjKoqDY9SZIZ9RYO-zEGToM9noBuWKedClRL8gvjYe3Otj4cuVIxkYelaqHcW7t4wR__Jz2eDa3Pt0uCeB1sMPogNIYAj1NLJUuYPOmipk2VJxQ&h=iReb8Iod6pYpV6qbbPxh37LZCtZs_hYVSsU4S6eUvUc
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ASP-clitestrgwuteie6d4po-fc-f0ec","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:56.0866667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":{"deployment":{"storage":{"type":"blobContainer","value":"https://clitest000002.blob.core.windows.net/defaultcontainer","authentication":{"type":"StorageAccountConnectionString","userAssignedIdentityResourceId":null,"storageAccountConnectionStringName":"AzureWebJobsStorage"}}},"runtime":{"name":"node","version":"22"},"scaleAndConcurrency":{"alwaysReady":null,"maximumInstanceCount":100,"instanceMemoryMB":2048,"triggers":null},"siteUpdateStrategy":{"type":"Recreate"}},"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"FlexConsumption","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":1536,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9502'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:27:21 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/cc0382be-9546-4eac-be8c-72419c0418d8
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F0B625DE07A1428FAEC727DA07E90614 Ref B: PNQ231110906031 Ref C: 2026-09-08T09:27:21Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"Message":"An error has occurred."}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '36'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:27:23 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - service
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 069FA40F76FF42A6A751F65B0C0F7E7A Ref B: PNQ231110909052 Ref C: 2026-09-08T09:27:22Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-func000003","name":"inplace-func000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-func000003","state":"Running","hostNames":["inplace-func000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-func000003","repositorySiteName":"inplace-func000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-func000003.azurewebsites.net","inplace-func000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-func000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-func000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ASP-clitestrgwuteie6d4po-fc-f0ec","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:25:56.0866667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":{"deployment":{"storage":{"type":"blobContainer","value":"https://clitest000002.blob.core.windows.net/defaultcontainer","authentication":{"type":"StorageAccountConnectionString","userAssignedIdentityResourceId":null,"storageAccountConnectionStringName":"AzureWebJobsStorage"}}},"runtime":{"name":"node","version":"22"},"scaleAndConcurrency":{"alwaysReady":null,"maximumInstanceCount":100,"instanceMemoryMB":2048,"triggers":null},"siteUpdateStrategy":{"type":"Recreate"}},"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-func000003","slotName":null,"trafficManagerHostNames":null,"sku":"FlexConsumption","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-func000003\\$inplace-func000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":1536,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-func000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9502'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:27:23 GMT
+      etag:
+      - 1DD3F740D2E236B
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BF8849F8185E414DA921CEF08CE0678C Ref B: PNQ231110907034 Ref C: 2026-09-08T09:27:23Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_flex_migration_in_place_with_deployment_storage.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_flex_migration_in_place_with_deployment_storage.yaml
@@ -1,0 +1,2273 @@
+interactions:
+- request:
+    body: '{"location": "North Central US (Stage)", "kind": "linux", "sku": {"name":
+      "Y1", "tier": "Dynamic", "size": "Y1", "family": "Y", "capacity": 0}, "properties":
+      {"reserved": true}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --method --url --body
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","name":"inplace-plan000004","type":"Microsoft.Web/serverfarms","kind":"functionapp","location":"North
+        Central US (Stage)","properties":{"serverFarmId":3751,"name":"inplace-plan000004","sku":{"name":"Y1","tier":"Dynamic","size":"Y1","family":"Y","capacity":0},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":0,"status":"Ready","webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dynamic","siteMode":null,"geoRegion":"North
+        Central US (Stage)","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"functionapp","resourceGroup":"clitest.rg000001","reserved":true,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-msftintch1-503_3751","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":1,"currentNumberOfZonesUtilized":0,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2026-09-08T09:28:31.02","asyncScalingEnabled":false,"isCustomMode":false,"powerState":"Running","eligibleLogCategories":"","activeBackupHomeServerFarmName":null,"allowEquivalentSku":false},"sku":{"name":"Y1","tier":"Dynamic","size":"Y1","family":"Y","capacity":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1911'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:28:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/e79b4404-861f-409f-95a3-e4246619f823
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: EA1A4A597133478582367356D3EA764A Ref B: PNQ231110906034 Ref C: 2026-09-08T09:28:28Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account show-connection-string
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --query -o
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2025-08-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2026-09-08T09:28:04.4044395Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2026-09-08T09:28:04.4044395Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:28:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/e286a4d6-654d-4ab1-98cd-29928448d8f3
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: FCBFEA11B261408FACAFB8D7638FA13E Ref B: PNQ231110906040 Ref C: 2026-09-08T09:28:31Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account show-connection-string
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --query -o
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002?api-version=2025-08-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:28:04.4044395Z","key2":"2026-09-08T09:28:04.4044395Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:28:04.1782735Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1350'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:28:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: A81925D1647748A6BA23E3DE36C5411B Ref B: PNQ231110909060 Ref C: 2026-09-08T09:28:31Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --name --connection-string
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-storage-blob/12.29.0b1 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+      x-ms-date:
+      - Tue, 08 Sep 2026 09:28:32 GMT
+      x-ms-version:
+      - '2026-04-06'
+    method: PUT
+    uri: https://clitest000002.blob.core.windows.net/source-packages?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:28:32 GMT
+      etag:
+      - '"0x8DF0D8B8D6CC07C"'
+      last-modified:
+      - Tue, 08 Sep 2026 09:28:33 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2026-04-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"location": "North Central US (Stage)", "kind": "functionapp,linux", "properties":
+      {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004",
+      "reserved": true, "httpsOnly": true, "siteConfig": {"linuxFxVersion": "Node|22",
+      "appSettings": [{"name": "AzureWebJobsStorage", "value": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/"},
+      {"name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", "value": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/"},
+      {"name": "WEBSITE_CONTENTSHARE", "value": "inplace-ds000003"}, {"name": "FUNCTIONS_EXTENSION_VERSION",
+      "value": "~4"}, {"name": "FUNCTIONS_WORKER_RUNTIME", "value": "node"}, {"name":
+      "WEBSITE_RUN_FROM_PACKAGE", "value": "https://clitest000002.blob.core.windows.net/source-packages/inplace-ds000003.zip?se=2026-09-09T09%3A28Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1556'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --method --url --body
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:02.9166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":null,"platformVersion":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9186'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:22 GMT
+      etag:
+      - 1DD3F747CC93420,1DD3F747D1B17AB,1DD3F747D327D40
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/daff3ac8-58ee-4989-80a1-8dd1ab82e951
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+      x-msedge-ref:
+      - 'Ref A: 146AB283A72D450D86001330EBCA70E9 Ref B: PNQ231110908060 Ref C: 2026-09-08T09:28:34Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --account-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2025-08-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testfc-rg/providers/Microsoft.Storage/storageAccounts/ssadtestfcrgbf33","name":"ssadtestfcrgbf33","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-08-14T17:40:52.1006887Z","key2":"2026-08-14T17:40:52.1006887Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:40:52.1108751Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:40:52.1108751Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-14T17:40:51.6335566Z","primaryEndpoints":{"dfs":"https://ssadtestfcrgbf33.dfs.core.windows.net/","web":"https://ssadtestfcrgbf33.z13.web.core.windows.net/","blob":"https://ssadtestfcrgbf33.blob.core.windows.net/","queue":"https://ssadtestfcrgbf33.queue.core.windows.net/","table":"https://ssadtestfcrgbf33.table.core.windows.net/","file":"https://ssadtestfcrgbf33.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609021516/providers/Microsoft.Storage/storageAccounts/stcv12609021516ssad","name":"stcv12609021516ssad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-02T09:48:20.2889824Z","key2":"2026-09-02T09:48:20.2889824Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:48:20.2991634Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:48:20.2991634Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-02T09:48:19.7198285Z","primaryEndpoints":{"dfs":"https://stcv12609021516ssad.dfs.core.windows.net/","web":"https://stcv12609021516ssad.z13.web.core.windows.net/","blob":"https://stcv12609021516ssad.blob.core.windows.net/","queue":"https://stcv12609021516ssad.queue.core.windows.net/","table":"https://stcv12609021516ssad.table.core.windows.net/","file":"https://stcv12609021516ssad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-upgrade-2609081000/providers/Microsoft.Storage/storageAccounts/stcv12609081000ssad","name":"stcv12609081000ssad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T04:28:17.6594428Z","key2":"2026-09-08T04:28:17.6594428Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:28:17.6696309Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:28:17.6696309Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-08T04:28:17.2207871Z","primaryEndpoints":{"dfs":"https://stcv12609081000ssad.dfs.core.windows.net/","web":"https://stcv12609081000ssad.z13.web.core.windows.net/","blob":"https://stcv12609081000ssad.blob.core.windows.net/","queue":"https://stcv12609081000ssad.queue.core.windows.net/","table":"https://stcv12609081000ssad.table.core.windows.net/","file":"https://stcv12609081000ssad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-final/providers/Microsoft.Storage/storageAccounts/stcv1flexfinal","name":"stcv1flexfinal","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T15:18:20.0917511Z","key2":"2026-08-17T15:18:20.0917511Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:18:20.1022539Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:18:20.1022539Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T15:18:19.6376869Z","primaryEndpoints":{"dfs":"https://stcv1flexfinal.dfs.core.windows.net/","web":"https://stcv1flexfinal.z13.web.core.windows.net/","blob":"https://stcv1flexfinal.blob.core.windows.net/","queue":"https://stcv1flexfinal.queue.core.windows.net/","table":"https://stcv1flexfinal.table.core.windows.net/","file":"https://stcv1flexfinal.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-validate/providers/Microsoft.Storage/storageAccounts/stcv1flexvalidate","name":"stcv1flexvalidate","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T14:50:32.1896537Z","key2":"2026-08-17T14:50:32.1896537Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T14:50:32.1998443Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T14:50:32.1998443Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T14:50:31.5600467Z","primaryEndpoints":{"dfs":"https://stcv1flexvalidate.dfs.core.windows.net/","web":"https://stcv1flexvalidate.z13.web.core.windows.net/","blob":"https://stcv1flexvalidate.blob.core.windows.net/","queue":"https://stcv1flexvalidate.queue.core.windows.net/","table":"https://stcv1flexvalidate.table.core.windows.net/","file":"https://stcv1flexvalidate.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-verify2/providers/Microsoft.Storage/storageAccounts/stcv1flexverify2","name":"stcv1flexverify2","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T15:26:59.1470621Z","key2":"2026-08-17T15:26:59.1470621Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:26:59.1572382Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T15:26:59.1572382Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T15:26:58.6821307Z","primaryEndpoints":{"dfs":"https://stcv1flexverify2.dfs.core.windows.net/","web":"https://stcv1flexverify2.z13.web.core.windows.net/","blob":"https://stcv1flexverify2.blob.core.windows.net/","queue":"https://stcv1flexverify2.queue.core.windows.net/","table":"https://stcv1flexverify2.table.core.windows.net/","file":"https://stcv1flexverify2.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-verify3/providers/Microsoft.Storage/storageAccounts/stcv1flexverify3","name":"stcv1flexverify3","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T16:24:16.5365114Z","key2":"2026-08-17T16:24:16.5365114Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T16:24:16.5472362Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T16:24:16.5472362Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T16:24:15.9617890Z","primaryEndpoints":{"dfs":"https://stcv1flexverify3.dfs.core.windows.net/","web":"https://stcv1flexverify3.z13.web.core.windows.net/","blob":"https://stcv1flexverify3.blob.core.windows.net/","queue":"https://stcv1flexverify3.queue.core.windows.net/","table":"https://stcv1flexverify3.table.core.windows.net/","file":"https://stcv1flexverify3.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-java11-ev4-eastus-260821/providers/Microsoft.Storage/storageAccounts/stjava11ev4eus260821","name":"stjava11ev4eus260821","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-21T09:19:16.9072257Z","key2":"2026-08-21T09:19:16.9072257Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-21T09:19:16.9183601Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-21T09:19:16.9183601Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-21T09:19:16.2279491Z","primaryEndpoints":{"dfs":"https://stjava11ev4eus260821.dfs.core.windows.net/","web":"https://stjava11ev4eus260821.z13.web.core.windows.net/","blob":"https://stjava11ev4eus260821.blob.core.windows.net/","queue":"https://stjava11ev4eus260821.queue.core.windows.net/","table":"https://stjava11ev4eus260821.table.core.windows.net/","file":"https://stjava11ev4eus260821.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-noble-chiselled-test/providers/Microsoft.Storage/storageAccounts/stnoblechiselledtest","name":"stnoblechiselledtest","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-30T12:51:39.4772724Z","key2":"2026-07-30T12:51:39.4772724Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-30T12:51:39.4848803Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-30T12:51:39.4848803Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-30T12:51:39.0839685Z","primaryEndpoints":{"dfs":"https://stnoblechiselledtest.dfs.core.windows.net/","web":"https://stnoblechiselledtest.z13.web.core.windows.net/","blob":"https://stnoblechiselledtest.blob.core.windows.net/","queue":"https://stnoblechiselledtest.queue.core.windows.net/","table":"https://stnoblechiselledtest.table.core.windows.net/","file":"https://stnoblechiselledtest.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lgn-rg-023b5-001/providers/Microsoft.Storage/storageAccounts/lgnsa9f37b6001","name":"lgnsa9f37b6001","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{"ms-resiliency-classification":"Test
+        Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T06:57:22.2491935Z","key2":"2026-07-29T06:57:22.2491935Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T06:57:22.2491935Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T06:57:22.2491935Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T06:57:21.8861123Z","primaryEndpoints":{"dfs":"https://lgnsa9f37b6001.dfs.core.windows.net/","web":"https://lgnsa9f37b6001.z20.web.core.windows.net/","blob":"https://lgnsa9f37b6001.blob.core.windows.net/","queue":"https://lgnsa9f37b6001.queue.core.windows.net/","table":"https://lgnsa9f37b6001.table.core.windows.net/","file":"https://lgnsa9f37b6001.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:28:04.4044395Z","key2":"2026-09-08T09:28:04.4044395Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:28:04.1782735Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-icm51000001721680-repro/providers/Microsoft.Storage/storageAccounts/ssadicm172168009011523","name":"ssadicm172168009011523","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"Purpose":"IcMRepro","IcM":"51000001721680"},"properties":{"allowCrossTenantDelegationSas":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-09-01T09:57:43.8010747Z","key2":"2026-09-01T09:57:43.8010747Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T09:57:43.8112536Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T09:57:43.8112536Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-01T09:57:43.5975609Z","primaryEndpoints":{"dfs":"https://ssadicm172168009011523.dfs.core.windows.net/","web":"https://ssadicm172168009011523.z22.web.core.windows.net/","blob":"https://ssadicm172168009011523.blob.core.windows.net/","queue":"https://ssadicm172168009011523.queue.core.windows.net/","table":"https://ssadicm172168009011523.table.core.windows.net/","file":"https://ssadicm172168009011523.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-icm51000001721680-repro/providers/Microsoft.Storage/storageAccounts/ssadicm172168009011524","name":"ssadicm172168009011524","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"Purpose":"IcMRepro","IcM":"51000001721680"},"properties":{"allowCrossTenantDelegationSas":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-09-01T10:06:54.1120733Z","key2":"2026-09-01T10:06:54.1120733Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T10:06:54.1201972Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T10:06:54.1201972Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-01T10:06:53.8946751Z","primaryEndpoints":{"dfs":"https://ssadicm172168009011524.dfs.core.windows.net/","web":"https://ssadicm172168009011524.z22.web.core.windows.net/","blob":"https://ssadicm172168009011524.blob.core.windows.net/","queue":"https://ssadicm172168009011524.queue.core.windows.net/","table":"https://ssadicm172168009011524.table.core.windows.net/","file":"https://ssadicm172168009011524.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-icm51000001721680-repro/providers/Microsoft.Storage/storageAccounts/ssadicm172168009021437","name":"ssadicm172168009021437","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"Purpose":"IcMRepro","IcM":"51000001721680","Topology":"CustomerPrivateDNS"},"properties":{"allowCrossTenantDelegationSas":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-09-02T09:17:28.2379300Z","key2":"2026-09-02T09:17:28.2379300Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:17:28.2482120Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T09:17:28.2482120Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-02T09:17:28.0299842Z","primaryEndpoints":{"dfs":"https://ssadicm172168009021437.dfs.core.windows.net/","web":"https://ssadicm172168009021437.z22.web.core.windows.net/","blob":"https://ssadicm172168009021437.blob.core.windows.net/","queue":"https://ssadicm172168009021437.queue.core.windows.net/","table":"https://ssadicm172168009021437.table.core.windows.net/","file":"https://ssadicm172168009021437.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609021728/providers/Microsoft.Storage/storageAccounts/stcv12609021728ssad","name":"stcv12609021728ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-02T12:03:34.8664576Z","key2":"2026-09-02T12:03:34.8664576Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T12:03:34.8766783Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-02T12:03:34.8766783Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-02T12:03:34.7117132Z","primaryEndpoints":{"dfs":"https://stcv12609021728ssad.dfs.core.windows.net/","web":"https://stcv12609021728ssad.z14.web.core.windows.net/","blob":"https://stcv12609021728ssad.blob.core.windows.net/","queue":"https://stcv12609021728ssad.queue.core.windows.net/","table":"https://stcv12609021728ssad.table.core.windows.net/","file":"https://stcv12609021728ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609041615/providers/Microsoft.Storage/storageAccounts/stcv12609041615ssad","name":"stcv12609041615ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-04T10:46:35.8074619Z","key2":"2026-09-04T10:46:35.8074619Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-04T10:46:35.8166910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-04T10:46:35.8166910Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-04T10:46:35.6522961Z","primaryEndpoints":{"dfs":"https://stcv12609041615ssad.dfs.core.windows.net/","web":"https://stcv12609041615ssad.z14.web.core.windows.net/","blob":"https://stcv12609041615ssad.blob.core.windows.net/","queue":"https://stcv12609041615ssad.queue.core.windows.net/","table":"https://stcv12609041615ssad.table.core.windows.net/","file":"https://stcv12609041615ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609080945/providers/Microsoft.Storage/storageAccounts/stcv12609080945ssad","name":"stcv12609080945ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T04:14:34.6728996Z","key2":"2026-09-08T04:14:34.6728996Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:14:34.6831630Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T04:14:34.6831630Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-08T04:14:34.4706147Z","primaryEndpoints":{"dfs":"https://stcv12609080945ssad.dfs.core.windows.net/","web":"https://stcv12609080945ssad.z14.web.core.windows.net/","blob":"https://stcv12609080945ssad.blob.core.windows.net/","queue":"https://stcv12609080945ssad.queue.core.windows.net/","table":"https://stcv12609080945ssad.table.core.windows.net/","file":"https://stcv12609080945ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-stage-2609081035/providers/Microsoft.Storage/storageAccounts/stcv12609081035ssad","name":"stcv12609081035ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T05:06:42.4763493Z","key2":"2026-09-08T05:06:42.4763493Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T05:06:42.4824986Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T05:06:42.4824986Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-08T05:06:42.3194770Z","primaryEndpoints":{"dfs":"https://stcv12609081035ssad.dfs.core.windows.net/","web":"https://stcv12609081035ssad.z14.web.core.windows.net/","blob":"https://stcv12609081035ssad.blob.core.windows.net/","queue":"https://stcv12609081035ssad.queue.core.windows.net/","table":"https://stcv12609081035ssad.table.core.windows.net/","file":"https://stcv12609081035ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-e2e-20260831-1535/providers/Microsoft.Storage/storageAccounts/stcv1flex8311535ssad","name":"stcv1flex8311535ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T10:11:27.9431336Z","key2":"2026-08-31T10:11:27.9431336Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:11:27.9568233Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:11:27.9568233Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T10:11:27.7695087Z","primaryEndpoints":{"dfs":"https://stcv1flex8311535ssad.dfs.core.windows.net/","web":"https://stcv1flex8311535ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311535ssad.blob.core.windows.net/","queue":"https://stcv1flex8311535ssad.queue.core.windows.net/","table":"https://stcv1flex8311535ssad.table.core.windows.net/","file":"https://stcv1flex8311535ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-e2e-20260831-1605/providers/Microsoft.Storage/storageAccounts/stcv1flex8311605ssad","name":"stcv1flex8311605ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T10:37:04.8139467Z","key2":"2026-08-31T10:37:04.8139467Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:37:04.8165565Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T10:37:04.8165565Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T10:37:04.6295879Z","primaryEndpoints":{"dfs":"https://stcv1flex8311605ssad.dfs.core.windows.net/","web":"https://stcv1flex8311605ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311605ssad.blob.core.windows.net/","queue":"https://stcv1flex8311605ssad.queue.core.windows.net/","table":"https://stcv1flex8311605ssad.table.core.windows.net/","file":"https://stcv1flex8311605ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-revert-8311655/providers/Microsoft.Storage/storageAccounts/stcv1flex8311655ssad","name":"stcv1flex8311655ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T11:28:10.2521326Z","key2":"2026-08-31T11:28:10.2521326Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T11:28:10.2643180Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T11:28:10.2643180Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T11:28:10.0676114Z","primaryEndpoints":{"dfs":"https://stcv1flex8311655ssad.dfs.core.windows.net/","web":"https://stcv1flex8311655ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311655ssad.blob.core.windows.net/","queue":"https://stcv1flex8311655ssad.queue.core.windows.net/","table":"https://stcv1flex8311655ssad.table.core.windows.net/","file":"https://stcv1flex8311655ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-clean-8311812/providers/Microsoft.Storage/storageAccounts/stcv1flex8311812ssad","name":"stcv1flex8311812ssad","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-31T12:48:10.3584039Z","key2":"2026-08-31T12:48:10.3584039Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T12:48:10.3691228Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-31T12:48:10.3691228Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-31T12:48:10.1692169Z","primaryEndpoints":{"dfs":"https://stcv1flex8311812ssad.dfs.core.windows.net/","web":"https://stcv1flex8311812ssad.z14.web.core.windows.net/","blob":"https://stcv1flex8311812ssad.blob.core.windows.net/","queue":"https://stcv1flex8311812ssad.queue.core.windows.net/","table":"https://stcv1flex8311812ssad.table.core.windows.net/","file":"https://stcv1flex8311812ssad.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test/providers/Microsoft.Storage/storageAccounts/stcv1flexncusstg26","name":"stcv1flexncusstg26","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-12T10:01:48.3426426Z","key2":"2026-08-12T10:01:48.3426426Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T10:01:48.3569664Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T10:01:48.3569664Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-12T10:01:48.1829642Z","primaryEndpoints":{"dfs":"https://stcv1flexncusstg26.dfs.core.windows.net/","web":"https://stcv1flexncusstg26.z14.web.core.windows.net/","blob":"https://stcv1flexncusstg26.blob.core.windows.net/","queue":"https://stcv1flexncusstg26.queue.core.windows.net/","table":"https://stcv1flexncusstg26.table.core.windows.net/","file":"https://stcv1flexncusstg26.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test3/providers/Microsoft.Storage/storageAccounts/stcv1flextest3","name":"stcv1flextest3","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-13T14:21:26.3612760Z","key2":"2026-08-13T14:21:26.3612760Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:21:26.3716602Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:21:26.3716602Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-13T14:21:26.1863955Z","primaryEndpoints":{"dfs":"https://stcv1flextest3.dfs.core.windows.net/","web":"https://stcv1flextest3.z14.web.core.windows.net/","blob":"https://stcv1flextest3.blob.core.windows.net/","queue":"https://stcv1flextest3.queue.core.windows.net/","table":"https://stcv1flextest3.table.core.windows.net/","file":"https://stcv1flextest3.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test4/providers/Microsoft.Storage/storageAccounts/stcv1flextest4","name":"stcv1flextest4","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-13T14:47:32.4837972Z","key2":"2026-08-13T14:47:32.4837972Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:47:32.4940386Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-13T14:47:32.4940386Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-13T14:47:32.2492766Z","primaryEndpoints":{"dfs":"https://stcv1flextest4.dfs.core.windows.net/","web":"https://stcv1flextest4.z14.web.core.windows.net/","blob":"https://stcv1flextest4.blob.core.windows.net/","queue":"https://stcv1flextest4.queue.core.windows.net/","table":"https://stcv1flextest4.table.core.windows.net/","file":"https://stcv1flextest4.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test5/providers/Microsoft.Storage/storageAccounts/stcv1flextest5","name":"stcv1flextest5","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-17T12:56:01.4346751Z","key2":"2026-08-17T12:56:01.4346751Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T12:56:01.4504502Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-17T12:56:01.4504502Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-17T12:56:01.2815957Z","primaryEndpoints":{"dfs":"https://stcv1flextest5.dfs.core.windows.net/","web":"https://stcv1flextest5.z14.web.core.windows.net/","blob":"https://stcv1flextest5.blob.core.windows.net/","queue":"https://stcv1flextest5.queue.core.windows.net/","table":"https://stcv1flextest5.table.core.windows.net/","file":"https://stcv1flextest5.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-placeholder-stage-260814/providers/Microsoft.Storage/storageAccounts/steolstage260814","name":"steolstage260814","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-14T12:17:06.5420966Z","key2":"2026-08-14T12:17:06.5420966Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T12:17:06.5467088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T12:17:06.5467088Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-14T12:17:06.3844796Z","primaryEndpoints":{"dfs":"https://steolstage260814.dfs.core.windows.net/","web":"https://steolstage260814.z14.web.core.windows.net/","blob":"https://steolstage260814.blob.core.windows.net/","queue":"https://steolstage260814.queue.core.windows.net/","table":"https://steolstage260814.table.core.windows.net/","file":"https://steolstage260814.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-child-260901180101/providers/Microsoft.Storage/storageAccounts/stfx260901180101","name":"stfx260901180101","type":"Microsoft.Storage/storageAccounts","location":"northcentralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-01T12:31:16.9923878Z","key2":"2026-09-01T12:31:16.9923878Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T12:31:17.0025482Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-01T12:31:17.0025482Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-09-01T12:31:16.8086635Z","primaryEndpoints":{"dfs":"https://stfx260901180101.dfs.core.windows.net/","web":"https://stfx260901180101.z14.web.core.windows.net/","blob":"https://stfx260901180101.blob.core.windows.net/","queue":"https://stfx260901180101.queue.core.windows.net/","table":"https://stfx260901180101.table.core.windows.net/","file":"https://stfx260901180101.file.core.windows.net/"},"primaryLocation":"northcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test/providers/Microsoft.Storage/storageAccounts/stcv1flexcusstg26","name":"stcv1flexcusstg26","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-12T09:59:15.8556478Z","key2":"2026-08-12T09:59:15.8556478Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:59:15.8662589Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:59:15.8662589Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-12T09:59:15.5371530Z","primaryEndpoints":{"dfs":"https://stcv1flexcusstg26.dfs.core.windows.net/","web":"https://stcv1flexcusstg26.z19.web.core.windows.net/","blob":"https://stcv1flexcusstg26.blob.core.windows.net/","queue":"https://stcv1flexcusstg26.queue.core.windows.net/","table":"https://stcv1flexcusstg26.table.core.windows.net/","file":"https://stcv1flexcusstg26.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lgn-rcp-rg-ssad1lclgn1-australiaeast/providers/Microsoft.Storage/storageAccounts/lgnrcpsa1f6f0","name":"lgnrcpsa1f6f0","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"ms-resiliency-classification":"Test
+        Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T18:11:51.4203689Z","key2":"2026-07-29T18:11:51.4203689Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:11:51.4305668Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:11:51.4305668Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T18:11:51.2401872Z","primaryEndpoints":{"dfs":"https://lgnrcpsa1f6f0.dfs.core.windows.net/","web":"https://lgnrcpsa1f6f0.z8.web.core.windows.net/","blob":"https://lgnrcpsa1f6f0.blob.core.windows.net/","queue":"https://lgnrcpsa1f6f0.queue.core.windows.net/","table":"https://lgnrcpsa1f6f0.table.core.windows.net/","file":"https://lgnrcpsa1f6f0.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lgn-rg-1f6f0-001/providers/Microsoft.Storage/storageAccounts/lgnsace8b35001","name":"lgnsace8b35001","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"ms-resiliency-classification":"Test
+        Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T19:46:02.6381356Z","key2":"2026-07-29T19:46:02.6381356Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T19:46:02.6477689Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T19:46:02.6477689Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T19:46:02.4799856Z","primaryEndpoints":{"dfs":"https://lgnsace8b35001.dfs.core.windows.net/","web":"https://lgnsace8b35001.z8.web.core.windows.net/","blob":"https://lgnsace8b35001.blob.core.windows.net/","queue":"https://lgnsace8b35001.queue.core.windows.net/","table":"https://lgnsace8b35001.table.core.windows.net/","file":"https://lgnsace8b35001.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PodRunnerRG-australiaeast-ssad1lclgn1/providers/Microsoft.Storage/storageAccounts/podrunnerlghvvfy2mqbok","name":"podrunnerlghvvfy2mqbok","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"ms-azores-classification":"Synthetic
+        Runner","ms-resiliency-classification":"Test Resource"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-29T18:06:39.7189380Z","key2":"2026-07-29T18:06:39.7189380Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:06:39.7291120Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-29T18:06:39.7291120Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-29T18:06:39.5497176Z","primaryEndpoints":{"dfs":"https://podrunnerlghvvfy2mqbok.dfs.core.windows.net/","web":"https://podrunnerlghvvfy2mqbok.z8.web.core.windows.net/","blob":"https://podrunnerlghvvfy2mqbok.blob.core.windows.net/","queue":"https://podrunnerlghvvfy2mqbok.queue.core.windows.net/","table":"https://podrunnerlghvvfy2mqbok.table.core.windows.net/","file":"https://podrunnerlghvvfy2mqbok.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lc-rg/providers/Microsoft.Storage/storageAccounts/ssad1lc","name":"ssad1lc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lc","created.username":"cloudtest","created.machinename":"58c56411c000000","created.utc":"7/24/2026
+        9:43:23 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:07:14.7522434Z","key2":"2026-07-23T07:07:14.7522434Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:14.7624658Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:14.7624658Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:07:14.5674652Z","primaryEndpoints":{"dfs":"https://ssad1lc.dfs.core.windows.net/","web":"https://ssad1lc.z8.web.core.windows.net/","blob":"https://ssad1lc.blob.core.windows.net/","queue":"https://ssad1lc.queue.core.windows.net/","table":"https://ssad1lc.table.core.windows.net/","file":"https://ssad1lc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lcgeo-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcgeo","name":"ssad1lcgeo","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lcgeo","created.username":"cloudtest","created.machinename":"5ef2c1a2c000000","created.utc":"7/24/2026
+        9:43:18 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:12:09.1214338Z","key2":"2026-07-23T07:12:09.1214338Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:09.1296575Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:09.1296575Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:12:08.9146578Z","primaryEndpoints":{"dfs":"https://ssad1lcgeo.dfs.core.windows.net/","web":"https://ssad1lcgeo.z8.web.core.windows.net/","blob":"https://ssad1lcgeo.blob.core.windows.net/","queue":"https://ssad1lcgeo.queue.core.windows.net/","table":"https://ssad1lcgeo.table.core.windows.net/","file":"https://ssad1lcgeo.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_ZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lcgeo-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcgeobak","name":"ssad1lcgeobak","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T09:18:11.2180583Z","key2":"2026-07-23T09:18:11.2180583Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"isLocalUserEnabled":false,"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T09:18:11.2282815Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T09:18:11.2282815Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T09:18:11.0271066Z","primaryEndpoints":{"dfs":"https://ssad1lcgeobak.dfs.core.windows.net/","web":"https://ssad1lcgeobak.z8.web.core.windows.net/","blob":"https://ssad1lcgeobak.blob.core.windows.net/","queue":"https://ssad1lcgeobak.queue.core.windows.net/","table":"https://ssad1lcgeobak.table.core.windows.net/","file":"https://ssad1lcgeobak.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lcgeo-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcgeoinfra","name":"ssad1lcgeoinfra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lcgeo","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/23/2026
+        7:12:37 AM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-23T07:12:37.5587675Z","key2":"2026-07-23T07:12:37.5587675Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:37.5690451Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:12:37.5690451Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:12:37.3385633Z","primaryEndpoints":{"dfs":"https://ssad1lcgeoinfra.dfs.core.windows.net/","web":"https://ssad1lcgeoinfra.z8.web.core.windows.net/","blob":"https://ssad1lcgeoinfra.blob.core.windows.net/","queue":"https://ssad1lcgeoinfra.queue.core.windows.net/","table":"https://ssad1lcgeoinfra.table.core.windows.net/","file":"https://ssad1lcgeoinfra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lc-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcinfra","name":"ssad1lcinfra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lc","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/23/2026
+        7:07:39 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:07:40.2872457Z","key2":"2026-07-23T07:07:40.2872457Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:40.2975341Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:07:40.2975341Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-23T07:07:40.0819824Z","primaryEndpoints":{"dfs":"https://ssad1lcinfra.dfs.core.windows.net/","web":"https://ssad1lcinfra.z8.web.core.windows.net/","blob":"https://ssad1lcinfra.blob.core.windows.net/","queue":"https://ssad1lcinfra.queue.core.windows.net/","table":"https://ssad1lcinfra.table.core.windows.net/","file":"https://ssad1lcinfra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Premium_ZRS","tier":"Premium"},"kind":"FileStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad1lc-rg/providers/Microsoft.Storage/storageAccounts/ssad1lcmaf","name":"ssad1lcmaf","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssad1lc","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/23/2026
+        7:08:05 AM"},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"keyCreationTime":{"key1":"2026-07-23T07:08:06.2152327Z","key2":"2026-07-23T07:08:06.2152327Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"isLocalUserEnabled":true,"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"largeFileSharesState":"Enabled","networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:08:06.2276050Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-23T07:08:06.2276050Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-07-23T07:08:06.0227971Z","primaryEndpoints":{"file":"https://ssad1lcmaf.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1","name":"ssadlc1","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:44:31 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:44:32.2396250Z","key2":"2026-07-22T12:44:32.2396250Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:44:32.2554997Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:44:32.2554997Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T12:44:32.0179283Z","primaryEndpoints":{"dfs":"https://ssadlc1.dfs.core.windows.net/","web":"https://ssadlc1.z8.web.core.windows.net/","blob":"https://ssadlc1.blob.core.windows.net/","queue":"https://ssadlc1.queue.core.windows.net/","table":"https://ssadlc1.table.core.windows.net/","file":"https://ssadlc1.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1geo-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1geo","name":"ssadlc1geo","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1geo","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:49:42 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:49:43.0905769Z","key2":"2026-07-22T12:49:43.0905769Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:49:43.1110302Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:49:43.1110302Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T12:49:42.8735627Z","primaryEndpoints":{"dfs":"https://ssadlc1geo.dfs.core.windows.net/","web":"https://ssadlc1geo.z8.web.core.windows.net/","blob":"https://ssadlc1geo.blob.core.windows.net/","queue":"https://ssadlc1geo.queue.core.windows.net/","table":"https://ssadlc1geo.table.core.windows.net/","file":"https://ssadlc1geo.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1geo-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1geoinfra","name":"ssadlc1geoinfra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1geo","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:50:12 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:50:12.7455762Z","key2":"2026-07-22T12:50:12.7455762Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:50:12.7615773Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:50:12.7615773Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T12:50:12.5555903Z","primaryEndpoints":{"dfs":"https://ssadlc1geoinfra.dfs.core.windows.net/","web":"https://ssadlc1geoinfra.z8.web.core.windows.net/","blob":"https://ssadlc1geoinfra.blob.core.windows.net/","queue":"https://ssadlc1geoinfra.queue.core.windows.net/","table":"https://ssadlc1geoinfra.table.core.windows.net/","file":"https://ssadlc1geoinfra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Standard_GZRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1infra","name":"ssadlc1infra","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        9:31:33 AM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T09:31:33.9921012Z","key2":"2026-07-22T09:31:33.9921012Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T09:31:34.0039829Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T09:31:34.0039829Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-07-22T09:31:33.7970377Z","primaryEndpoints":{"dfs":"https://ssadlc1infra.dfs.core.windows.net/","web":"https://ssadlc1infra.z8.web.core.windows.net/","blob":"https://ssadlc1infra.blob.core.windows.net/","queue":"https://ssadlc1infra.queue.core.windows.net/","table":"https://ssadlc1infra.table.core.windows.net/","file":"https://ssadlc1infra.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available","secondaryLocation":"australiasoutheast","statusOfSecondary":"available"}},{"sku":{"name":"Premium_ZRS","tier":"Premium"},"kind":"FileStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssadlc1-rg/providers/Microsoft.Storage/storageAccounts/ssadlc1maf","name":"ssadlc1maf","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{"created.stampname":"ssadlc1","created.username":"ssadhukhan","created.machinename":"CPC-ssadh-UYXY0","created.utc":"7/22/2026
+        12:45:04 PM"},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-07-22T12:45:04.6730936Z","key2":"2026-07-22T12:45:04.6730936Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"isLocalUserEnabled":true,"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":false,"largeFileSharesState":"Enabled","networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:45:04.6833159Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-07-22T12:45:04.6833159Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-07-22T12:45:04.4772833Z","primaryEndpoints":{"file":"https://ssadlc1maf.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrg9022","name":"ssaddistrolessrg9022","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-06-16T09:25:01.7551381Z","key2":"2026-06-16T09:25:01.7551381Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-06-16T09:25:01.7654797Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-06-16T09:25:01.7654797Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-06-16T09:25:01.5810660Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrg9022.dfs.core.windows.net/","web":"https://ssaddistrolessrg9022.z9.web.core.windows.net/","blob":"https://ssaddistrolessrg9022.blob.core.windows.net/","queue":"https://ssaddistrolessrg9022.queue.core.windows.net/","table":"https://ssaddistrolessrg9022.table.core.windows.net/","file":"https://ssaddistrolessrg9022.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrg9a5a","name":"ssaddistrolessrg9a5a","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-08T09:14:22.6192433Z","key2":"2026-04-08T09:14:22.6192433Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-08T09:14:22.6294917Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-08T09:14:22.6294917Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-08T09:14:22.4756042Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrg9a5a.dfs.core.windows.net/","web":"https://ssaddistrolessrg9a5a.z9.web.core.windows.net/","blob":"https://ssaddistrolessrg9a5a.blob.core.windows.net/","queue":"https://ssaddistrolessrg9a5a.queue.core.windows.net/","table":"https://ssaddistrolessrg9a5a.table.core.windows.net/","file":"https://ssaddistrolessrg9a5a.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrg9ae1","name":"ssaddistrolessrg9ae1","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-10T11:31:38.7376511Z","key2":"2026-04-10T11:31:38.7376511Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-10T11:31:38.7450107Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-10T11:31:38.7450107Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-10T11:31:38.5957967Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrg9ae1.dfs.core.windows.net/","web":"https://ssaddistrolessrg9ae1.z9.web.core.windows.net/","blob":"https://ssaddistrolessrg9ae1.blob.core.windows.net/","queue":"https://ssaddistrolessrg9ae1.queue.core.windows.net/","table":"https://ssaddistrolessrg9ae1.table.core.windows.net/","file":"https://ssaddistrolessrg9ae1.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrga56f","name":"ssaddistrolessrga56f","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-11T10:30:48.3007805Z","key2":"2026-03-11T10:30:48.3007805Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T10:30:48.3007805Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T10:30:48.3007805Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-11T10:30:48.1757816Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrga56f.dfs.core.windows.net/","web":"https://ssaddistrolessrga56f.z9.web.core.windows.net/","blob":"https://ssaddistrolessrga56f.blob.core.windows.net/","queue":"https://ssaddistrolessrga56f.queue.core.windows.net/","table":"https://ssaddistrolessrga56f.table.core.windows.net/","file":"https://ssaddistrolessrga56f.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrgae0e","name":"ssaddistrolessrgae0e","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T09:02:07.3875504Z","key2":"2026-04-21T09:02:07.3875504Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T09:02:07.4028667Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T09:02:07.4028667Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T09:02:07.2291668Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrgae0e.dfs.core.windows.net/","web":"https://ssaddistrolessrgae0e.z9.web.core.windows.net/","blob":"https://ssaddistrolessrgae0e.blob.core.windows.net/","queue":"https://ssaddistrolessrgae0e.queue.core.windows.net/","table":"https://ssaddistrolessrgae0e.table.core.windows.net/","file":"https://ssaddistrolessrgae0e.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-distroless-rg/providers/Microsoft.Storage/storageAccounts/ssaddistrolessrgb101","name":"ssaddistrolessrgb101","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T13:09:02.5932991Z","key2":"2026-04-21T13:09:02.5932991Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T13:09:02.6024827Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T13:09:02.6024827Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T13:09:02.4285171Z","primaryEndpoints":{"dfs":"https://ssaddistrolessrgb101.dfs.core.windows.net/","web":"https://ssaddistrolessrgb101.z9.web.core.windows.net/","blob":"https://ssaddistrolessrgb101.blob.core.windows.net/","queue":"https://ssaddistrolessrgb101.queue.core.windows.net/","table":"https://ssaddistrolessrgb101.table.core.windows.net/","file":"https://ssaddistrolessrgb101.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorg8c6c","name":"ssadtestdistrorg8c6c","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-11T09:41:04.6570736Z","key2":"2026-03-11T09:41:04.6570736Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T09:41:04.6570736Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-11T09:41:04.6570736Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-11T09:41:04.5008282Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorg8c6c.dfs.core.windows.net/","web":"https://ssadtestdistrorg8c6c.z9.web.core.windows.net/","blob":"https://ssadtestdistrorg8c6c.blob.core.windows.net/","queue":"https://ssadtestdistrorg8c6c.queue.core.windows.net/","table":"https://ssadtestdistrorg8c6c.table.core.windows.net/","file":"https://ssadtestdistrorg8c6c.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorg9699","name":"ssadtestdistrorg9699","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T05:44:16.8755150Z","key2":"2026-04-21T05:44:16.8755150Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T05:44:16.8857035Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T05:44:16.8857035Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T05:44:16.7215379Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorg9699.dfs.core.windows.net/","web":"https://ssadtestdistrorg9699.z9.web.core.windows.net/","blob":"https://ssadtestdistrorg9699.blob.core.windows.net/","queue":"https://ssadtestdistrorg9699.queue.core.windows.net/","table":"https://ssadtestdistrorg9699.table.core.windows.net/","file":"https://ssadtestdistrorg9699.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorga90c","name":"ssadtestdistrorga90c","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-09T09:06:45.1637940Z","key2":"2026-04-09T09:06:45.1637940Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-09T09:06:45.1729212Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-09T09:06:45.1729212Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-09T09:06:45.0228932Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorga90c.dfs.core.windows.net/","web":"https://ssadtestdistrorga90c.z9.web.core.windows.net/","blob":"https://ssadtestdistrorga90c.blob.core.windows.net/","queue":"https://ssadtestdistrorga90c.queue.core.windows.net/","table":"https://ssadtestdistrorga90c.table.core.windows.net/","file":"https://ssadtestdistrorga90c.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorgacf8","name":"ssadtestdistrorgacf8","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-04-21T08:49:16.2585818Z","key2":"2026-04-21T08:49:16.2585818Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T08:49:16.2738791Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-04-21T08:49:16.2738791Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-04-21T08:49:16.0839845Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorgacf8.dfs.core.windows.net/","web":"https://ssadtestdistrorgacf8.z9.web.core.windows.net/","blob":"https://ssadtestdistrorgacf8.blob.core.windows.net/","queue":"https://ssadtestdistrorgacf8.queue.core.windows.net/","table":"https://ssadtestdistrorgacf8.table.core.windows.net/","file":"https://ssadtestdistrorgacf8.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorgb9f9","name":"ssadtestdistrorgb9f9","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-31T11:43:06.4138941Z","key2":"2026-03-31T11:43:06.4138941Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:43:06.4220454Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:43:06.4220454Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-31T11:43:06.2794062Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorgb9f9.dfs.core.windows.net/","web":"https://ssadtestdistrorgb9f9.z9.web.core.windows.net/","blob":"https://ssadtestdistrorgb9f9.blob.core.windows.net/","queue":"https://ssadtestdistrorgb9f9.queue.core.windows.net/","table":"https://ssadtestdistrorgb9f9.table.core.windows.net/","file":"https://ssadtestdistrorgb9f9.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testdistro-rg/providers/Microsoft.Storage/storageAccounts/ssadtestdistrorgbd3d","name":"ssadtestdistrorgbd3d","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-03-31T11:36:57.1269274Z","key2":"2026-03-31T11:36:57.1269274Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:36:57.1340963Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-03-31T11:36:57.1340963Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-03-31T11:36:57.0036301Z","primaryEndpoints":{"dfs":"https://ssadtestdistrorgbd3d.dfs.core.windows.net/","web":"https://ssadtestdistrorgbd3d.z9.web.core.windows.net/","blob":"https://ssadtestdistrorgbd3d.blob.core.windows.net/","queue":"https://ssadtestdistrorgbd3d.queue.core.windows.net/","table":"https://ssadtestdistrorgbd3d.table.core.windows.net/","file":"https://ssadtestdistrorgbd3d.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testfc-rg/providers/Microsoft.Storage/storageAccounts/ssadteststorage","name":"ssadteststorage","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"dualStackEndpointPreference":{"defaultDualStackEndpoints":false,"publishIpv4Endpoint":false,"publishIpv6Endpoint":false},"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-08-14T17:38:09.5110844Z","key2":"2026-08-14T17:38:09.5110844Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:38:09.5212896Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-14T17:38:09.5212896Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-14T17:38:09.3364661Z","primaryEndpoints":{"dfs":"https://ssadteststorage.dfs.core.windows.net/","web":"https://ssadteststorage.z9.web.core.windows.net/","blob":"https://ssadteststorage.blob.core.windows.net/","queue":"https://ssadteststorage.queue.core.windows.net/","table":"https://ssadteststorage.table.core.windows.net/","file":"https://ssadteststorage.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available","secondaryLocation":"canadaeast","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://ssadteststorage-secondary.dfs.core.windows.net/","web":"https://ssadteststorage-secondary.z9.web.core.windows.net/","blob":"https://ssadteststorage-secondary.blob.core.windows.net/","queue":"https://ssadteststorage-secondary.queue.core.windows.net/","table":"https://ssadteststorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssad-testfc-rg/providers/Microsoft.Storage/storageAccounts/ssadtestfcrgaad6","name":"ssadtestfcrgaad6","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"defaultToOAuthAuthentication":true,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2026-08-07T06:55:46.9815080Z","key2":"2026-08-07T06:55:46.9815080Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-07T06:55:46.9918260Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-07T06:55:46.9918260Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-07T06:55:46.8580996Z","primaryEndpoints":{"dfs":"https://ssadtestfcrgaad6.dfs.core.windows.net/","web":"https://ssadtestfcrgaad6.z3.web.core.windows.net/","blob":"https://ssadtestfcrgaad6.blob.core.windows.net/","queue":"https://ssadtestfcrgaad6.queue.core.windows.net/","table":"https://ssadtestfcrgaad6.table.core.windows.net/","file":"https://ssadtestfcrgaad6.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-cv1-flex-test/providers/Microsoft.Storage/storageAccounts/stcv1flextest26","name":"stcv1flextest26","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-12T09:08:48.0485548Z","key2":"2026-08-12T09:08:48.0485548Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:08:48.0587837Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-12T09:08:48.0587837Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-12T09:08:47.9062481Z","primaryEndpoints":{"dfs":"https://stcv1flextest26.dfs.core.windows.net/","web":"https://stcv1flextest26.z3.web.core.windows.net/","blob":"https://stcv1flextest26.blob.core.windows.net/","queue":"https://stcv1flextest26.queue.core.windows.net/","table":"https://stcv1flextest26.table.core.windows.net/","file":"https://stcv1flextest26.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-existing-euap-260815/providers/Microsoft.Storage/storageAccounts/steoleuap260815","name":"steoleuap260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:38:11.1935326Z","key2":"2026-08-15T07:38:11.1935326Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:38:11.2036815Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:38:11.2036815Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:38:11.0718055Z","primaryEndpoints":{"dfs":"https://steoleuap260815.dfs.core.windows.net/","web":"https://steoleuap260815.z3.web.core.windows.net/","blob":"https://steoleuap260815.blob.core.windows.net/","queue":"https://steoleuap260815.queue.core.windows.net/","table":"https://steoleuap260815.table.core.windows.net/","file":"https://steoleuap260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s1-260815/providers/Microsoft.Storage/storageAccounts/steols1260815","name":"steols1260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:23.0600826Z","key2":"2026-08-15T07:51:23.0600826Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:23.0672332Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:23.0672332Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:22.8939543Z","primaryEndpoints":{"dfs":"https://steols1260815.dfs.core.windows.net/","web":"https://steols1260815.z3.web.core.windows.net/","blob":"https://steols1260815.blob.core.windows.net/","queue":"https://steols1260815.queue.core.windows.net/","table":"https://steols1260815.table.core.windows.net/","file":"https://steols1260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s2-260815/providers/Microsoft.Storage/storageAccounts/steols2260815","name":"steols2260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:53:30.9714021Z","key2":"2026-08-15T07:53:30.9714021Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:30.9714021Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:30.9714021Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:53:30.8016916Z","primaryEndpoints":{"dfs":"https://steols2260815.dfs.core.windows.net/","web":"https://steols2260815.z3.web.core.windows.net/","blob":"https://steols2260815.blob.core.windows.net/","queue":"https://steols2260815.queue.core.windows.net/","table":"https://steols2260815.table.core.windows.net/","file":"https://steols2260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s3-260815/providers/Microsoft.Storage/storageAccounts/steols3260815","name":"steols3260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:20.2867714Z","key2":"2026-08-15T07:51:20.2867714Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:20.2969815Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:20.2969815Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:20.1333607Z","primaryEndpoints":{"dfs":"https://steols3260815.dfs.core.windows.net/","web":"https://steols3260815.z3.web.core.windows.net/","blob":"https://steols3260815.blob.core.windows.net/","queue":"https://steols3260815.queue.core.windows.net/","table":"https://steols3260815.table.core.windows.net/","file":"https://steols3260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s4-260815/providers/Microsoft.Storage/storageAccounts/steols4260815","name":"steols4260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:24.7632986Z","key2":"2026-08-15T07:51:24.7632986Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:24.7694855Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:24.7694855Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:24.6058750Z","primaryEndpoints":{"dfs":"https://steols4260815.dfs.core.windows.net/","web":"https://steols4260815.z3.web.core.windows.net/","blob":"https://steols4260815.blob.core.windows.net/","queue":"https://steols4260815.queue.core.windows.net/","table":"https://steols4260815.table.core.windows.net/","file":"https://steols4260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s5-260815/providers/Microsoft.Storage/storageAccounts/steols5260815","name":"steols5260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:51:53.6060939Z","key2":"2026-08-15T07:51:53.6060939Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:53.6101241Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:51:53.6101241Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:51:53.4538100Z","primaryEndpoints":{"dfs":"https://steols5260815.dfs.core.windows.net/","web":"https://steols5260815.z3.web.core.windows.net/","blob":"https://steols5260815.blob.core.windows.net/","queue":"https://steols5260815.queue.core.windows.net/","table":"https://steols5260815.table.core.windows.net/","file":"https://steols5260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-eol-euap-s6-260815/providers/Microsoft.Storage/storageAccounts/steols6260815","name":"steols6260815","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-08-15T07:53:31.1245122Z","key2":"2026-08-15T07:53:31.1245122Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:31.1401439Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-08-15T07:53:31.1401439Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2026-08-15T07:53:30.9714021Z","primaryEndpoints":{"dfs":"https://steols6260815.dfs.core.windows.net/","web":"https://steols6260815.z3.web.core.windows.net/","blob":"https://steols6260815.blob.core.windows.net/","queue":"https://steols6260815.queue.core.windows.net/","table":"https://steols6260815.table.core.windows.net/","file":"https://steols6260815.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '103209'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:29:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 671fce61-991f-4dd5-aa6d-d2df80a576dc
+      - 06697bef-f75f-4f59-9e69-ad97ec2a7fd1
+      - 19ab9338-ee3b-44b8-b22b-1b6f36be2f70
+      - c70a7d1d-80e1-41c0-98ee-0de19073d313
+      - 20b16dc2-8cb7-4d11-827f-077d3a5c5ac3
+      - 323f9561-af44-40fe-83dd-7752ec4f4edc
+      - c5b32732-12e5-486d-87d0-042cf5894ff9
+      - f6101851-b867-46fc-a962-df143a115c53
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 393D4893AAE448A1A4D3ED174B67DA56 Ref B: PNQ231110906054 Ref C: 2026-09-08T09:29:23Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --account-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2025-08-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2026-09-08T09:28:04.4044395Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2026-09-08T09:28:04.4044395Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/76337693-1fe3-419c-b5be-7f1227a02d73
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: E1067CB0D48947A7895B84852A939970 Ref B: PNQ231110909029 Ref C: 2026-09-08T09:29:25Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --account-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-storage-blob/12.29.0b1 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+      x-ms-date:
+      - Tue, 08 Sep 2026 09:29:26 GMT
+      x-ms-version:
+      - '2026-04-06'
+    method: PUT
+    uri: https://clitest000002.blob.core.windows.net/mycontainer?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:29:26 GMT
+      etag:
+      - '"0x8DF0D8BAD52CD65"'
+      last-modified:
+      - Tue, 08 Sep 2026 09:29:26 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2026-04-06'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:23.2333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8983'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:27 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 833B5A76746E41F6A5FCB95AA5E7E9BA Ref B: PNQ231110906023 Ref C: 2026-09-08T09:29:27Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:23.2333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8917'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:29 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 54F80262C5C440A6A0C6A80E6AC80189 Ref B: PNQ231110909042 Ref C: 2026-09-08T09:29:28Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","name":"inplace-plan000004","type":"Microsoft.Web/serverfarms","kind":"functionapp","location":"North
+        Central US (Stage)","properties":{"serverFarmId":3751,"name":"inplace-plan000004","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":0,"status":"Ready","webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dynamic","siteMode":null,"geoRegion":"North
+        Central US (Stage)","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":1,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"functionapp","resourceGroup":"clitest.rg000001","reserved":true,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-msftintch1-503_3751","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":1,"currentNumberOfZonesUtilized":0,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2026-09-08T09:28:31.02","asyncScalingEnabled":false,"isCustomMode":false,"powerState":"Running","eligibleLogCategories":"","activeBackupHomeServerFarmName":null,"allowEquivalentSku":false},"sku":{"name":"Y1","tier":"Dynamic","size":"Y1","family":"Y","capacity":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1830'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4A9424D1B011409B9732145F757EBBE5 Ref B: PNQ231110906042 Ref C: 2026-09-08T09:29:29Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/locations?api-version=2022-12-01
+  response:
+    body:
+      string: "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus\",\"name\":\"eastus\",\"type\":\"Region\",\"displayName\":\"East
+        US\",\"regionalDisplayName\":\"(US) East US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-79.8164\",\"latitude\":\"37.3719\",\"physicalLocation\":\"Virginia\",\"pairedRegion\":[{\"name\":\"westus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastus-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastus-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastus-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2\",\"name\":\"westus2\",\"type\":\"Region\",\"displayName\":\"West
+        US 2\",\"regionalDisplayName\":\"(US) West US 2\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-119.852\",\"latitude\":\"47.233\",\"physicalLocation\":\"Washington\",\"pairedRegion\":[{\"name\":\"westcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"westus2-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"westus2-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"westus2-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast\",\"name\":\"australiaeast\",\"type\":\"Region\",\"displayName\":\"Australia
+        East\",\"regionalDisplayName\":\"(Asia Pacific) Australia East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"151.2094\",\"latitude\":\"-33.86\",\"physicalLocation\":\"New
+        South Wales\",\"pairedRegion\":[{\"name\":\"australiasoutheast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"australiaeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"australiaeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"australiaeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia\",\"name\":\"southeastasia\",\"type\":\"Region\",\"displayName\":\"Southeast
+        Asia\",\"regionalDisplayName\":\"(Asia Pacific) Southeast Asia\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Asia
+        Pacific\",\"geographyGroup\":\"Asia Pacific\",\"longitude\":\"103.833\",\"latitude\":\"1.283\",\"physicalLocation\":\"Singapore\",\"pairedRegion\":[{\"name\":\"eastasia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"southeastasia-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"southeastasia-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"southeastasia-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope\",\"name\":\"northeurope\",\"type\":\"Region\",\"displayName\":\"North
+        Europe\",\"regionalDisplayName\":\"(Europe) North Europe\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Europe\",\"geographyGroup\":\"Europe\",\"longitude\":\"-6.2597\",\"latitude\":\"53.3478\",\"physicalLocation\":\"Ireland\",\"pairedRegion\":[{\"name\":\"westeurope\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"northeurope-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"northeurope-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"northeurope-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/swedencentral\",\"name\":\"swedencentral\",\"type\":\"Region\",\"displayName\":\"Sweden
+        Central\",\"regionalDisplayName\":\"(Europe) Sweden Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Sweden\",\"geographyGroup\":\"Europe\",\"longitude\":\"17.14127\",\"latitude\":\"60.67488\",\"physicalLocation\":\"G\xE4vle\",\"pairedRegion\":[{\"name\":\"swedensouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/swedensouth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"swedencentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"swedencentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"swedencentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope\",\"name\":\"westeurope\",\"type\":\"Region\",\"displayName\":\"West
+        Europe\",\"regionalDisplayName\":\"(Europe) West Europe\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Europe\",\"geographyGroup\":\"Europe\",\"longitude\":\"4.9\",\"latitude\":\"52.3667\",\"physicalLocation\":\"Netherlands\",\"pairedRegion\":[{\"name\":\"northeurope\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"westeurope-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"westeurope-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"westeurope-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth\",\"name\":\"uksouth\",\"type\":\"Region\",\"displayName\":\"UK
+        South\",\"regionalDisplayName\":\"(UK) UK South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        Kingdom\",\"geographyGroup\":\"UK\",\"longitude\":\"-0.799\",\"latitude\":\"50.941\",\"physicalLocation\":\"London\",\"pairedRegion\":[{\"name\":\"ukwest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"uksouth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"uksouth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"uksouth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus\",\"name\":\"centralus\",\"type\":\"Region\",\"displayName\":\"Central
+        US\",\"regionalDisplayName\":\"(US) Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-93.6208\",\"latitude\":\"41.5908\",\"physicalLocation\":\"Iowa\",\"pairedRegion\":[{\"name\":\"eastus2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"centralus-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"centralus-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"centralus-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricanorth\",\"name\":\"southafricanorth\",\"type\":\"Region\",\"displayName\":\"South
+        Africa North\",\"regionalDisplayName\":\"(Africa) South Africa North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"South
+        Africa\",\"geographyGroup\":\"Africa\",\"longitude\":\"28.21837\",\"latitude\":\"-25.73134\",\"physicalLocation\":\"Johannesburg\",\"pairedRegion\":[{\"name\":\"southafricawest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricawest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"southafricanorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"southafricanorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"southafricanorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia\",\"name\":\"centralindia\",\"type\":\"Region\",\"displayName\":\"Central
+        India\",\"regionalDisplayName\":\"(Asia Pacific) Central India\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"73.9197\",\"latitude\":\"18.5822\",\"physicalLocation\":\"Pune\",\"pairedRegion\":[{\"name\":\"southindia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"centralindia-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"centralindia-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"centralindia-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia\",\"name\":\"eastasia\",\"type\":\"Region\",\"displayName\":\"East
+        Asia\",\"regionalDisplayName\":\"(Asia Pacific) East Asia\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Asia
+        Pacific\",\"geographyGroup\":\"Asia Pacific\",\"longitude\":\"114.188\",\"latitude\":\"22.267\",\"physicalLocation\":\"Hong
+        Kong\",\"pairedRegion\":[{\"name\":\"southeastasia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastasia-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastasia-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastasia-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/indiasouthcentral\",\"name\":\"indiasouthcentral\",\"type\":\"Region\",\"displayName\":\"India
+        South Central\",\"regionalDisplayName\":\"(Asia Pacific) India South Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"78.47599792\",\"latitude\":\"17.36599922\",\"physicalLocation\":\"Hyderabad\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"indiasouthcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"indiasouthcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"indiasouthcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/indonesiacentral\",\"name\":\"indonesiacentral\",\"type\":\"Region\",\"displayName\":\"Indonesia
+        Central\",\"regionalDisplayName\":\"(Asia Pacific) Indonesia Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Indonesia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"106.816666\",\"latitude\":\"-6.2\",\"physicalLocation\":\"Jakarta\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"indonesiacentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"indonesiacentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"indonesiacentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast\",\"name\":\"japaneast\",\"type\":\"Region\",\"displayName\":\"Japan
+        East\",\"regionalDisplayName\":\"(Asia Pacific) Japan East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Japan\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"139.77\",\"latitude\":\"35.68\",\"physicalLocation\":\"Tokyo,
+        Saitama\",\"pairedRegion\":[{\"name\":\"japanwest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"japaneast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"japaneast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"japaneast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest\",\"name\":\"japanwest\",\"type\":\"Region\",\"displayName\":\"Japan
+        West\",\"regionalDisplayName\":\"(Asia Pacific) Japan West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Japan\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"135.5022\",\"latitude\":\"34.6939\",\"physicalLocation\":\"Osaka\",\"pairedRegion\":[{\"name\":\"japaneast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"japanwest-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"japanwest-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"japanwest-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral\",\"name\":\"koreacentral\",\"type\":\"Region\",\"displayName\":\"Korea
+        Central\",\"regionalDisplayName\":\"(Asia Pacific) Korea Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Korea\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"126.978\",\"latitude\":\"37.5665\",\"physicalLocation\":\"Seoul\",\"pairedRegion\":[{\"name\":\"koreasouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"koreacentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"koreacentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"koreacentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/malaysiawest\",\"name\":\"malaysiawest\",\"type\":\"Region\",\"displayName\":\"Malaysia
+        West\",\"regionalDisplayName\":\"(Asia Pacific) Malaysia West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Malaysia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"101.693207\",\"latitude\":\"3.140853\",\"physicalLocation\":\"Kuala
+        Lumpur\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"malaysiawest-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"malaysiawest-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"malaysiawest-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/newzealandnorth\",\"name\":\"newzealandnorth\",\"type\":\"Region\",\"displayName\":\"New
+        Zealand North\",\"regionalDisplayName\":\"(Asia Pacific) New Zealand North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"New
+        Zealand\",\"geographyGroup\":\"Asia Pacific\",\"longitude\":\"174.76349\",\"latitude\":\"-36.84853\",\"physicalLocation\":\"Auckland\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"newzealandnorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"newzealandnorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"newzealandnorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral\",\"name\":\"canadacentral\",\"type\":\"Region\",\"displayName\":\"Canada
+        Central\",\"regionalDisplayName\":\"(Canada) Canada Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Canada\",\"geographyGroup\":\"Canada\",\"longitude\":\"-79.383\",\"latitude\":\"43.653\",\"physicalLocation\":\"Toronto\",\"pairedRegion\":[{\"name\":\"canadaeast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"canadacentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"canadacentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"canadacentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/austriaeast\",\"name\":\"austriaeast\",\"type\":\"Region\",\"displayName\":\"Austria
+        East\",\"regionalDisplayName\":\"(Europe) Austria East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Austria\",\"geographyGroup\":\"Europe\",\"longitude\":\"16.3727779\",\"latitude\":\"48.2092056\",\"physicalLocation\":\"Vienna\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"austriaeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"austriaeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"austriaeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/belgiumcentral\",\"name\":\"belgiumcentral\",\"type\":\"Region\",\"displayName\":\"Belgium
+        Central\",\"regionalDisplayName\":\"(Europe) Belgium Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Belgium\",\"geographyGroup\":\"Europe\",\"longitude\":\"4.355707169\",\"latitude\":\"50.84553528\",\"physicalLocation\":\"Brussels\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"belgiumcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"belgiumcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"belgiumcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/denmarkeast\",\"name\":\"denmarkeast\",\"type\":\"Region\",\"displayName\":\"Denmark
+        East\",\"regionalDisplayName\":\"(Europe) Denmark East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Denmark\",\"geographyGroup\":\"Europe\",\"longitude\":\"12.56553\",\"latitude\":\"55.67594\",\"physicalLocation\":\"Copenhagen\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"denmarkeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"denmarkeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"denmarkeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francecentral\",\"name\":\"francecentral\",\"type\":\"Region\",\"displayName\":\"France
+        Central\",\"regionalDisplayName\":\"(Europe) France Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"France\",\"geographyGroup\":\"Europe\",\"longitude\":\"2.373\",\"latitude\":\"46.3772\",\"physicalLocation\":\"Paris\",\"pairedRegion\":[{\"name\":\"francesouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francesouth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"francecentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"francecentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"francecentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanywestcentral\",\"name\":\"germanywestcentral\",\"type\":\"Region\",\"displayName\":\"Germany
+        West Central\",\"regionalDisplayName\":\"(Europe) Germany West Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Germany\",\"geographyGroup\":\"Europe\",\"longitude\":\"8.682127\",\"latitude\":\"50.110924\",\"physicalLocation\":\"Frankfurt\",\"pairedRegion\":[{\"name\":\"germanynorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanynorth\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"germanywestcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"germanywestcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"germanywestcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/italynorth\",\"name\":\"italynorth\",\"type\":\"Region\",\"displayName\":\"Italy
+        North\",\"regionalDisplayName\":\"(Europe) Italy North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Italy\",\"geographyGroup\":\"Europe\",\"longitude\":\"9.18109\",\"latitude\":\"45.46888\",\"physicalLocation\":\"Milan\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"italynorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"italynorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"italynorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwayeast\",\"name\":\"norwayeast\",\"type\":\"Region\",\"displayName\":\"Norway
+        East\",\"regionalDisplayName\":\"(Europe) Norway East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Norway\",\"geographyGroup\":\"Europe\",\"longitude\":\"10.752245\",\"latitude\":\"59.913868\",\"physicalLocation\":\"Norway\",\"pairedRegion\":[{\"name\":\"norwaywest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwaywest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"norwayeast-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"norwayeast-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"norwayeast-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/polandcentral\",\"name\":\"polandcentral\",\"type\":\"Region\",\"displayName\":\"Poland
+        Central\",\"regionalDisplayName\":\"(Europe) Poland Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Poland\",\"geographyGroup\":\"Europe\",\"longitude\":\"21.01666\",\"latitude\":\"52.23334\",\"physicalLocation\":\"Warsaw\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"polandcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"polandcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"polandcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/spaincentral\",\"name\":\"spaincentral\",\"type\":\"Region\",\"displayName\":\"Spain
+        Central\",\"regionalDisplayName\":\"(Europe) Spain Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Spain\",\"geographyGroup\":\"Europe\",\"longitude\":\"3.4209\",\"latitude\":\"40.4259\",\"physicalLocation\":\"Madrid\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"spaincentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"spaincentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"spaincentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandnorth\",\"name\":\"switzerlandnorth\",\"type\":\"Region\",\"displayName\":\"Switzerland
+        North\",\"regionalDisplayName\":\"(Europe) Switzerland North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Switzerland\",\"geographyGroup\":\"Europe\",\"longitude\":\"8.564572\",\"latitude\":\"47.451542\",\"physicalLocation\":\"Zurich\",\"pairedRegion\":[{\"name\":\"switzerlandwest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandwest\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"switzerlandnorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"switzerlandnorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"switzerlandnorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/mexicocentral\",\"name\":\"mexicocentral\",\"type\":\"Region\",\"displayName\":\"Mexico
+        Central\",\"regionalDisplayName\":\"(Mexico) Mexico Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Mexico\",\"geographyGroup\":\"Mexico\",\"longitude\":\"-100.389888\",\"latitude\":\"20.588818\",\"physicalLocation\":\"Quer\xE9taro
+        State\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"mexicocentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"mexicocentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"mexicocentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaenorth\",\"name\":\"uaenorth\",\"type\":\"Region\",\"displayName\":\"UAE
+        North\",\"regionalDisplayName\":\"(Middle East) UAE North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"UAE\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"55.316666\",\"latitude\":\"25.266666\",\"physicalLocation\":\"Dubai\",\"pairedRegion\":[{\"name\":\"uaecentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaecentral\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"uaenorth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"uaenorth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"uaenorth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth\",\"name\":\"brazilsouth\",\"type\":\"Region\",\"displayName\":\"Brazil
+        South\",\"regionalDisplayName\":\"(South America) Brazil South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Brazil\",\"geographyGroup\":\"South
+        America\",\"longitude\":\"-46.633\",\"latitude\":\"-23.55\",\"physicalLocation\":\"Sao
+        Paulo State\",\"pairedRegion\":[{\"name\":\"southcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"brazilsouth-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"brazilsouth-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"brazilsouth-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/chilecentral\",\"name\":\"chilecentral\",\"type\":\"Region\",\"displayName\":\"Chile
+        Central\",\"regionalDisplayName\":\"(South America) Chile Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Chile\",\"geographyGroup\":\"South
+        America\",\"longitude\":\"-70.673676\",\"latitude\":\"-33.447487\",\"physicalLocation\":\"Santiago\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"chilecentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"chilecentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"chilecentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2euap\",\"name\":\"eastus2euap\",\"type\":\"Region\",\"displayName\":\"East
+        US 2 EUAP\",\"regionalDisplayName\":\"(US) East US 2 EUAP\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Canary
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-78.3889\",\"latitude\":\"36.6681\",\"physicalLocation\":\"\",\"pairedRegion\":[{\"name\":\"centraluseuap\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centraluseuap\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastus2euap-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastus2euap-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastus2euap-az1\"},{\"logicalZone\":\"4\",\"physicalZone\":\"eastus2euap-az4\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/israelcentral\",\"name\":\"israelcentral\",\"type\":\"Region\",\"displayName\":\"Israel
+        Central\",\"regionalDisplayName\":\"(Middle East) Israel Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Israel\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"33.4506633\",\"latitude\":\"31.2655698\",\"physicalLocation\":\"Israel\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"israelcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"israelcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"israelcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/qatarcentral\",\"name\":\"qatarcentral\",\"type\":\"Region\",\"displayName\":\"Qatar
+        Central\",\"regionalDisplayName\":\"(Middle East) Qatar Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Recommended\",\"geography\":\"Qatar\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"51.439327\",\"latitude\":\"25.551462\",\"physicalLocation\":\"Doha\",\"pairedRegion\":[]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"qatarcentral-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"qatarcentral-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"qatarcentral-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralusstage\",\"name\":\"centralusstage\",\"type\":\"Region\",\"displayName\":\"Central
+        US (Stage)\",\"regionalDisplayName\":\"(US) Central US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastusstage\",\"name\":\"eastusstage\",\"type\":\"Region\",\"displayName\":\"East
+        US (Stage)\",\"regionalDisplayName\":\"(US) East US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2stage\",\"name\":\"eastus2stage\",\"type\":\"Region\",\"displayName\":\"East
+        US 2 (Stage)\",\"regionalDisplayName\":\"(US) East US 2 (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralusstage\",\"name\":\"northcentralusstage\",\"type\":\"Region\",\"displayName\":\"North
+        Central US (Stage)\",\"regionalDisplayName\":\"(US) North Central US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralusstage\",\"name\":\"southcentralusstage\",\"type\":\"Region\",\"displayName\":\"South
+        Central US (Stage)\",\"regionalDisplayName\":\"(US) South Central US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westusstage\",\"name\":\"westusstage\",\"type\":\"Region\",\"displayName\":\"West
+        US (Stage)\",\"regionalDisplayName\":\"(US) West US (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2stage\",\"name\":\"westus2stage\",\"type\":\"Region\",\"displayName\":\"West
+        US 2 (Stage)\",\"regionalDisplayName\":\"(US) West US 2 (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"usa\",\"geographyGroup\":\"US\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/asia\",\"name\":\"asia\",\"type\":\"Region\",\"displayName\":\"Asia\",\"regionalDisplayName\":\"Asia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/asiapacific\",\"name\":\"asiapacific\",\"type\":\"Region\",\"displayName\":\"Asia
+        Pacific\",\"regionalDisplayName\":\"Asia Pacific\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australia\",\"name\":\"australia\",\"type\":\"Region\",\"displayName\":\"Australia\",\"regionalDisplayName\":\"Australia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/austria\",\"name\":\"austria\",\"type\":\"Region\",\"displayName\":\"Austria\",\"regionalDisplayName\":\"Austria\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/belgium\",\"name\":\"belgium\",\"type\":\"Region\",\"displayName\":\"Belgium\",\"regionalDisplayName\":\"Belgium\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazil\",\"name\":\"brazil\",\"type\":\"Region\",\"displayName\":\"Brazil\",\"regionalDisplayName\":\"Brazil\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canada\",\"name\":\"canada\",\"type\":\"Region\",\"displayName\":\"Canada\",\"regionalDisplayName\":\"Canada\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/chile\",\"name\":\"chile\",\"type\":\"Region\",\"displayName\":\"Chile\",\"regionalDisplayName\":\"Chile\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/denmark\",\"name\":\"denmark\",\"type\":\"Region\",\"displayName\":\"Denmark\",\"regionalDisplayName\":\"Denmark\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/europe\",\"name\":\"europe\",\"type\":\"Region\",\"displayName\":\"Europe\",\"regionalDisplayName\":\"Europe\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/finland\",\"name\":\"finland\",\"type\":\"Region\",\"displayName\":\"Finland\",\"regionalDisplayName\":\"Finland\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/france\",\"name\":\"france\",\"type\":\"Region\",\"displayName\":\"France\",\"regionalDisplayName\":\"France\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germany\",\"name\":\"germany\",\"type\":\"Region\",\"displayName\":\"Germany\",\"regionalDisplayName\":\"Germany\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/global\",\"name\":\"global\",\"type\":\"Region\",\"displayName\":\"Global\",\"regionalDisplayName\":\"Global\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/india\",\"name\":\"india\",\"type\":\"Region\",\"displayName\":\"India\",\"regionalDisplayName\":\"India\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/indonesia\",\"name\":\"indonesia\",\"type\":\"Region\",\"displayName\":\"Indonesia\",\"regionalDisplayName\":\"Indonesia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/israel\",\"name\":\"israel\",\"type\":\"Region\",\"displayName\":\"Israel\",\"regionalDisplayName\":\"Israel\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/italy\",\"name\":\"italy\",\"type\":\"Region\",\"displayName\":\"Italy\",\"regionalDisplayName\":\"Italy\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japan\",\"name\":\"japan\",\"type\":\"Region\",\"displayName\":\"Japan\",\"regionalDisplayName\":\"Japan\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/korea\",\"name\":\"korea\",\"type\":\"Region\",\"displayName\":\"Korea\",\"regionalDisplayName\":\"Korea\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/malaysia\",\"name\":\"malaysia\",\"type\":\"Region\",\"displayName\":\"Malaysia\",\"regionalDisplayName\":\"Malaysia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/mexico\",\"name\":\"mexico\",\"type\":\"Region\",\"displayName\":\"Mexico\",\"regionalDisplayName\":\"Mexico\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/newzealand\",\"name\":\"newzealand\",\"type\":\"Region\",\"displayName\":\"New
+        Zealand\",\"regionalDisplayName\":\"New Zealand\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norway\",\"name\":\"norway\",\"type\":\"Region\",\"displayName\":\"Norway\",\"regionalDisplayName\":\"Norway\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/poland\",\"name\":\"poland\",\"type\":\"Region\",\"displayName\":\"Poland\",\"regionalDisplayName\":\"Poland\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/qatar\",\"name\":\"qatar\",\"type\":\"Region\",\"displayName\":\"Qatar\",\"regionalDisplayName\":\"Qatar\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/saudiarabia\",\"name\":\"saudiarabia\",\"type\":\"Region\",\"displayName\":\"Saudi
+        Arabia\",\"regionalDisplayName\":\"Saudi Arabia\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/singapore\",\"name\":\"singapore\",\"type\":\"Region\",\"displayName\":\"Singapore\",\"regionalDisplayName\":\"Singapore\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafrica\",\"name\":\"southafrica\",\"type\":\"Region\",\"displayName\":\"South
+        Africa\",\"regionalDisplayName\":\"South Africa\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/spain\",\"name\":\"spain\",\"type\":\"Region\",\"displayName\":\"Spain\",\"regionalDisplayName\":\"Spain\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/sweden\",\"name\":\"sweden\",\"type\":\"Region\",\"displayName\":\"Sweden\",\"regionalDisplayName\":\"Sweden\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerland\",\"name\":\"switzerland\",\"type\":\"Region\",\"displayName\":\"Switzerland\",\"regionalDisplayName\":\"Switzerland\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/taiwan\",\"name\":\"taiwan\",\"type\":\"Region\",\"displayName\":\"Taiwan\",\"regionalDisplayName\":\"Taiwan\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uae\",\"name\":\"uae\",\"type\":\"Region\",\"displayName\":\"United
+        Arab Emirates\",\"regionalDisplayName\":\"United Arab Emirates\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uk\",\"name\":\"uk\",\"type\":\"Region\",\"displayName\":\"United
+        Kingdom\",\"regionalDisplayName\":\"United Kingdom\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/unitedstates\",\"name\":\"unitedstates\",\"type\":\"Region\",\"displayName\":\"United
+        States\",\"regionalDisplayName\":\"United States\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/unitedstateseuap\",\"name\":\"unitedstateseuap\",\"type\":\"Region\",\"displayName\":\"United
+        States EUAP\",\"regionalDisplayName\":\"United States EUAP\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasiastage\",\"name\":\"eastasiastage\",\"type\":\"Region\",\"displayName\":\"East
+        Asia (Stage)\",\"regionalDisplayName\":\"(Asia Pacific) East Asia (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"asia\",\"geographyGroup\":\"Asia
+        Pacific\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasiastage\",\"name\":\"southeastasiastage\",\"type\":\"Region\",\"displayName\":\"Southeast
+        Asia (Stage)\",\"regionalDisplayName\":\"(Asia Pacific) Southeast Asia (Stage)\",\"metadata\":{\"regionType\":\"Logical\",\"regionCategory\":\"Other\",\"geography\":\"asia\",\"geographyGroup\":\"Asia
+        Pacific\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2\",\"name\":\"eastus2\",\"type\":\"Region\",\"displayName\":\"East
+        US 2\",\"regionalDisplayName\":\"(US) East US 2\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-78.3889\",\"latitude\":\"36.6681\",\"physicalLocation\":\"Virginia\",\"pairedRegion\":[{\"name\":\"centralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"eastus2-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"eastus2-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"eastus2-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastusstg\",\"name\":\"eastusstg\",\"type\":\"Region\",\"displayName\":\"East
+        US STG\",\"regionalDisplayName\":\"(US) East US STG\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Stage
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-79.8164\",\"latitude\":\"37.3719\",\"physicalLocation\":\"Virginia\",\"pairedRegion\":[{\"name\":\"southcentralusstg\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralusstg\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus\",\"name\":\"southcentralus\",\"type\":\"Region\",\"displayName\":\"South
+        Central US\",\"regionalDisplayName\":\"(US) South Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-98.5\",\"latitude\":\"29.4167\",\"physicalLocation\":\"Texas\",\"pairedRegion\":[{\"name\":\"northcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"southcentralus-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"southcentralus-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"southcentralus-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus3\",\"name\":\"westus3\",\"type\":\"Region\",\"displayName\":\"West
+        US 3\",\"regionalDisplayName\":\"(US) West US 3\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-112.074036\",\"latitude\":\"33.448376\",\"physicalLocation\":\"Phoenix\",\"pairedRegion\":[{\"name\":\"eastus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus\"}]},\"availabilityZoneMappings\":[{\"logicalZone\":\"1\",\"physicalZone\":\"westus3-az2\"},{\"logicalZone\":\"2\",\"physicalZone\":\"westus3-az3\"},{\"logicalZone\":\"3\",\"physicalZone\":\"westus3-az1\"}]},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus\",\"name\":\"northcentralus\",\"type\":\"Region\",\"displayName\":\"North
+        Central US\",\"regionalDisplayName\":\"(US) North Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-87.6278\",\"latitude\":\"41.8819\",\"physicalLocation\":\"Illinois\",\"pairedRegion\":[{\"name\":\"southcentralus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus\",\"name\":\"westus\",\"type\":\"Region\",\"displayName\":\"West
+        US\",\"regionalDisplayName\":\"(US) West US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-122.417\",\"latitude\":\"37.783\",\"physicalLocation\":\"California\",\"pairedRegion\":[{\"name\":\"eastus\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiawest\",\"name\":\"jioindiawest\",\"type\":\"Region\",\"displayName\":\"Jio
+        India West\",\"regionalDisplayName\":\"(Asia Pacific) Jio India West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"70.05773\",\"latitude\":\"22.470701\",\"physicalLocation\":\"Jamnagar\",\"pairedRegion\":[{\"name\":\"jioindiacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centraluseuap\",\"name\":\"centraluseuap\",\"type\":\"Region\",\"displayName\":\"Central
+        US EUAP\",\"regionalDisplayName\":\"(US) Central US EUAP\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Canary
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-93.6208\",\"latitude\":\"41.5908\",\"physicalLocation\":\"\",\"pairedRegion\":[{\"name\":\"eastus2euap\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2euap\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralusstg\",\"name\":\"southcentralusstg\",\"type\":\"Region\",\"displayName\":\"South
+        Central US STG\",\"regionalDisplayName\":\"(US) South Central US STG\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Stage
+        (US)\",\"geographyGroup\":\"US\",\"longitude\":\"-98.5\",\"latitude\":\"29.4167\",\"physicalLocation\":\"Texas\",\"pairedRegion\":[{\"name\":\"eastusstg\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastusstg\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus\",\"name\":\"westcentralus\",\"type\":\"Region\",\"displayName\":\"West
+        Central US\",\"regionalDisplayName\":\"(US) West Central US\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        States\",\"geographyGroup\":\"US\",\"longitude\":\"-110.234\",\"latitude\":\"40.89\",\"physicalLocation\":\"Wyoming\",\"pairedRegion\":[{\"name\":\"westus2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricawest\",\"name\":\"southafricawest\",\"type\":\"Region\",\"displayName\":\"South
+        Africa West\",\"regionalDisplayName\":\"(Africa) South Africa West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"South
+        Africa\",\"geographyGroup\":\"Africa\",\"longitude\":\"18.843266\",\"latitude\":\"-34.075691\",\"physicalLocation\":\"Cape
+        Town\",\"pairedRegion\":[{\"name\":\"southafricanorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricanorth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral\",\"name\":\"australiacentral\",\"type\":\"Region\",\"displayName\":\"Australia
+        Central\",\"regionalDisplayName\":\"(Asia Pacific) Australia Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"149.1244\",\"latitude\":\"-35.3075\",\"physicalLocation\":\"Canberra\",\"pairedRegion\":[{\"name\":\"australiacentral2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral2\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral2\",\"name\":\"australiacentral2\",\"type\":\"Region\",\"displayName\":\"Australia
+        Central 2\",\"regionalDisplayName\":\"(Asia Pacific) Australia Central 2\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"149.1244\",\"latitude\":\"-35.3075\",\"physicalLocation\":\"Canberra\",\"pairedRegion\":[{\"name\":\"australiacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast\",\"name\":\"australiasoutheast\",\"type\":\"Region\",\"displayName\":\"Australia
+        Southeast\",\"regionalDisplayName\":\"(Asia Pacific) Australia Southeast\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Australia\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"144.9631\",\"latitude\":\"-37.8136\",\"physicalLocation\":\"Victoria\",\"pairedRegion\":[{\"name\":\"australiaeast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiacentral\",\"name\":\"jioindiacentral\",\"type\":\"Region\",\"displayName\":\"Jio
+        India Central\",\"regionalDisplayName\":\"(Asia Pacific) Jio India Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"79.08886\",\"latitude\":\"21.146633\",\"physicalLocation\":\"Nagpur\",\"pairedRegion\":[{\"name\":\"jioindiawest\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiawest\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth\",\"name\":\"koreasouth\",\"type\":\"Region\",\"displayName\":\"Korea
+        South\",\"regionalDisplayName\":\"(Asia Pacific) Korea South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Korea\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"129.0756\",\"latitude\":\"35.1796\",\"physicalLocation\":\"Busan\",\"pairedRegion\":[{\"name\":\"koreacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia\",\"name\":\"southindia\",\"type\":\"Region\",\"displayName\":\"South
+        India\",\"regionalDisplayName\":\"(Asia Pacific) South India\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"80.1636\",\"latitude\":\"12.9822\",\"physicalLocation\":\"Chennai\",\"pairedRegion\":[{\"name\":\"centralindia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westindia\",\"name\":\"westindia\",\"type\":\"Region\",\"displayName\":\"West
+        India\",\"regionalDisplayName\":\"(Asia Pacific) West India\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"India\",\"geographyGroup\":\"Asia
+        Pacific\",\"longitude\":\"72.868\",\"latitude\":\"19.088\",\"physicalLocation\":\"Mumbai\",\"pairedRegion\":[{\"name\":\"southindia\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast\",\"name\":\"canadaeast\",\"type\":\"Region\",\"displayName\":\"Canada
+        East\",\"regionalDisplayName\":\"(Canada) Canada East\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Canada\",\"geographyGroup\":\"Canada\",\"longitude\":\"-71.217\",\"latitude\":\"46.817\",\"physicalLocation\":\"Quebec\",\"pairedRegion\":[{\"name\":\"canadacentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francesouth\",\"name\":\"francesouth\",\"type\":\"Region\",\"displayName\":\"France
+        South\",\"regionalDisplayName\":\"(Europe) France South\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"France\",\"geographyGroup\":\"Europe\",\"longitude\":\"2.1972\",\"latitude\":\"43.8345\",\"physicalLocation\":\"Marseille\",\"pairedRegion\":[{\"name\":\"francecentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/francecentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanynorth\",\"name\":\"germanynorth\",\"type\":\"Region\",\"displayName\":\"Germany
+        North\",\"regionalDisplayName\":\"(Europe) Germany North\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Germany\",\"geographyGroup\":\"Europe\",\"longitude\":\"8.806422\",\"latitude\":\"53.073635\",\"physicalLocation\":\"Berlin\",\"pairedRegion\":[{\"name\":\"germanywestcentral\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanywestcentral\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwaywest\",\"name\":\"norwaywest\",\"type\":\"Region\",\"displayName\":\"Norway
+        West\",\"regionalDisplayName\":\"(Europe) Norway West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Norway\",\"geographyGroup\":\"Europe\",\"longitude\":\"5.733107\",\"latitude\":\"58.969975\",\"physicalLocation\":\"Norway\",\"pairedRegion\":[{\"name\":\"norwayeast\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwayeast\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandwest\",\"name\":\"switzerlandwest\",\"type\":\"Region\",\"displayName\":\"Switzerland
+        West\",\"regionalDisplayName\":\"(Europe) Switzerland West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Switzerland\",\"geographyGroup\":\"Europe\",\"longitude\":\"6.143158\",\"latitude\":\"46.204391\",\"physicalLocation\":\"Geneva\",\"pairedRegion\":[{\"name\":\"switzerlandnorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandnorth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaecentral\",\"name\":\"uaecentral\",\"type\":\"Region\",\"displayName\":\"UAE
+        Central\",\"regionalDisplayName\":\"(Middle East) UAE Central\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"UAE\",\"geographyGroup\":\"Middle
+        East\",\"longitude\":\"54.366669\",\"latitude\":\"24.466667\",\"physicalLocation\":\"Abu
+        Dhabi\",\"pairedRegion\":[{\"name\":\"uaenorth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaenorth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsoutheast\",\"name\":\"brazilsoutheast\",\"type\":\"Region\",\"displayName\":\"Brazil
+        Southeast\",\"regionalDisplayName\":\"(South America) Brazil Southeast\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"Brazil\",\"geographyGroup\":\"South
+        America\",\"longitude\":\"-43.2075\",\"latitude\":\"-22.90278\",\"physicalLocation\":\"Rio\",\"pairedRegion\":[{\"name\":\"brazilsouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth\"}]}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest\",\"name\":\"ukwest\",\"type\":\"Region\",\"displayName\":\"UK
+        West\",\"regionalDisplayName\":\"(UK) UK West\",\"metadata\":{\"regionType\":\"Physical\",\"regionCategory\":\"Other\",\"geography\":\"United
+        Kingdom\",\"geographyGroup\":\"UK\",\"longitude\":\"-3.084\",\"latitude\":\"53.427\",\"physicalLocation\":\"Cardiff\",\"pairedRegion\":[{\"name\":\"uksouth\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth\"}]}}]}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '49905'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:29:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D8D852CBE90D452596B9BE821A2C71B9 Ref B: PNQ231110909023 Ref C: 2026-09-08T09:29:30Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/web?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/web","name":"inplace-ds000003","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","powerShellVersion":"","linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":[],"requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"REDACTED","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","vnetRouteAllEnabled":false,"vnetPrivatePortsCount":0,"publicNetworkAccess":null,"siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":null},"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":false,"http20Enabled":false,"minTlsVersion":"1.2","minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":"1.2","ftpsState":"FtpsOnly","preWarmedInstanceCount":0,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":false,"functionsRuntimeScaleMonitoringEnabled":false,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":{},"http20ProxyFlag":0,"sitePort":null,"antivirusScanEnabled":false,"storageType":"StorageVolume","sitePrivateLinkHostEnabled":false,"clusteringEnabled":false,"webJobsEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4153'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/7c066bba-8297-4f7d-b245-5729ffbbd52b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 137822BBA82E454D97A7958E5F172BC5 Ref B: PNQ231110907060 Ref C: 2026-09-08T09:29:33Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Web/locations/northcentralusstage/functionAppStacks?api-version=2020-10-01&removeHiddenStacks=true&removeDeprecatedStacks=true&stack=node&sku=FC1
+  response:
+    body:
+      string: '{"value":[{"id":null,"name":"node","type":"Microsoft.Web/locations/functionAppStacks?stackOsType=All","location":"northcentralusstage","properties":{"displayText":"Node.js","value":"node","preferredOs":"windows","majorVersions":[{"displayText":"Node.js
+        24","value":"24","minorVersions":[{"displayText":"Node.js 24","value":"24
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|24","isPreview":false,"isDefault":false,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"24.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|24"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"24"}}}],"endOfLifeDate":"Mon
+        Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        22","value":"22","minorVersions":[{"displayText":"Node.js 22","value":"22
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|22","isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|22"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"22"}}}],"endOfLifeDate":"Fri
+        Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        20","value":"20","minorVersions":[{"displayText":"Node.js 20 LTS","value":"20
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|20"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"20"}}}],"endOfLifeDate":"Thu
+        Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]}]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3613'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: 9AB082250F4B4E41AE3EE29C9096D33A Ref B: PNQ231110908052 Ref C: 2026-09-08T09:29:34Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/appsettings/list?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTSHARE":"inplace-ds000003","FUNCTIONS_EXTENSION_VERSION":"~4","FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_RUN_FROM_PACKAGE":"https://clitest000002.blob.core.windows.net/source-packages/inplace-ds000003.zip?se=2026-09-09T09%3A28Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1356'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/bc379960-dc26-44d0-9540-bb7d1775aa91
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: ED329C0E5B41465FB96EFB2986887494 Ref B: PNQ231110908025 Ref C: 2026-09-08T09:29:35Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:23.2333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8983'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:36 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EB274CCFBF0A4C599BD6987F2E0B7EFD Ref B: PNQ231110908031 Ref C: 2026-09-08T09:29:35Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:23.2333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8917'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:37 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 152F3567B8CC464FA66B8E5697E53CEC Ref B: PNQ231110906023 Ref C: 2026-09-08T09:29:37Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/slotConfigNames?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":null,"name":"inplace-ds000003","type":"Microsoft.Web/sites","location":"North
+        Central US (Stage)","properties":{"connectionStringNames":null,"appSettingNames":null,"azureStorageConfigNames":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '202'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/7a9650c5-0b12-471b-b934-098e17a7a10c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 020A40A8DE69448CA5A033E4F9DAD095 Ref B: PNQ231110908040 Ref C: 2026-09-08T09:29:37Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/slots?api-version=2025-05-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:29:38 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 1a4e57da-4454-4977-a585-3d7de5b480c7
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 84DAC492734E44E1BFA791A6FC27B47A Ref B: PNQ231110909025 Ref C: 2026-09-08T09:29:38Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/web?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/web","name":"inplace-ds000003","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","powerShellVersion":"","linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":[],"requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"REDACTED","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","vnetRouteAllEnabled":false,"vnetPrivatePortsCount":0,"publicNetworkAccess":null,"siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":null},"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":false,"http20Enabled":false,"minTlsVersion":"1.2","minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":"1.2","ftpsState":"FtpsOnly","preWarmedInstanceCount":0,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":false,"functionsRuntimeScaleMonitoringEnabled":false,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":{},"http20ProxyFlag":0,"sitePort":null,"antivirusScanEnabled":false,"storageType":"StorageVolume","sitePrivateLinkHostEnabled":false,"clusteringEnabled":false,"webJobsEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4153'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/70f687bc-a046-4ea6-9ba0-f4f102cee7ba
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 85D3017D89C3493BBE351D4500F1C7A0 Ref B: PNQ231110907036 Ref C: 2026-09-08T09:29:39Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/appsettings/list?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTSHARE":"inplace-ds000003","FUNCTIONS_EXTENSION_VERSION":"~4","FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_RUN_FROM_PACKAGE":"https://clitest000002.blob.core.windows.net/source-packages/inplace-ds000003.zip?se=2026-09-09T09%3A28Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1356'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/e94e7fc2-4e93-4860-b7f0-38ece280935e
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: 63AACF9239D04267A05309BDD88842F6 Ref B: PNQ231110907054 Ref C: 2026-09-08T09:29:40Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:23.2333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8983'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:41 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4DE68556A17245A7B18CB98E5E5CD6AD Ref B: PNQ231110906025 Ref C: 2026-09-08T09:29:41Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:23.2333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8917'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:42 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 62558CD7190C4A66B0E8FC6B55035118 Ref B: PNQ231110906042 Ref C: 2026-09-08T09:29:42Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/slotConfigNames?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":null,"name":"inplace-ds000003","type":"Microsoft.Web/sites","location":"North
+        Central US (Stage)","properties":{"connectionStringNames":null,"appSettingNames":null,"azureStorageConfigNames":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '202'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/c2c66b0d-d727-4b64-b3e6-769f120bc79d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6F25EAFF42864F5CB0E1EDBC308C2AB0 Ref B: PNQ231110908060 Ref C: 2026-09-08T09:29:42Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts?api-version=2025-08-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:28:04.4044395Z","key2":"2026-09-08T09:28:04.4044395Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:28:04.1782735Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1362'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:29:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 460574f7-e4aa-4b0e-8980-59afc035d4fd
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 94C430A1824A4418B87804AEC4529EDD Ref B: PNQ231110906040 Ref C: 2026-09-08T09:29:43Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - python/3.11.9 (Windows-10-10.0.26200-SP0) AZURECLI/2.89.0
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Web/locations/North%20Central%20US%20(Stage)/functionAppStacks?api-version=2020-10-01&removeHiddenStacks=true&removeDeprecatedStacks=true&stack=node&sku=FC1
+  response:
+    body:
+      string: '{"value":[{"id":null,"name":"node","type":"Microsoft.Web/locations/functionAppStacks?stackOsType=All","location":"North
+        Central US (Stage)","properties":{"displayText":"Node.js","value":"node","preferredOs":"windows","majorVersions":[{"displayText":"Node.js
+        24","value":"24","minorVersions":[{"displayText":"Node.js 24","value":"24
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|24","isPreview":false,"isDefault":false,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"24.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|24"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"24"}}}],"endOfLifeDate":"Mon
+        Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        22","value":"22","minorVersions":[{"displayText":"Node.js 22","value":"22
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|22","isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|22"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"22"}}}],"endOfLifeDate":"Fri
+        Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]},{"displayText":"Node.js
+        20","value":"20","minorVersions":[{"displayText":"Node.js 20 LTS","value":"20
+        LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Node|20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|20"},"supportedFunctionsExtensionVersions":["~4"],"supportedFunctionsExtensionVersionsInfo":[{"version":"~4","isDeprecated":false,"isDefault":true}],"Sku":[{"skuCode":"Y1"},{"skuCode":"Dedicated"},{"skuCode":"ElasticPremium"},{"skuCode":"FC1","instanceMemoryMB":[{"size":"512","isDefault":false},{"size":"2048","isDefault":true},{"size":"4096","isDefault":false}],"maximumInstanceCount":{"lowestMaximumInstanceCount":1,"highestMaximumInstanceCount":1000,"defaultValue":100},"functionAppConfigProperties":{"runtime":{"name":"node","version":"20"}}}],"endOfLifeDate":"Thu
+        Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"}}}]}]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3618'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: C0E84CAA41A64E97B419E57D4ED3B648 Ref B: PNQ231110909034 Ref C: 2026-09-08T09:29:44Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/appsettings/list?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"North
+        Central US (Stage)","properties":{"AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==;BlobEndpoint=https://clitest000002.blob.core.windows.net/;FileEndpoint=https://clitest000002.file.core.windows.net/;QueueEndpoint=https://clitest000002.queue.core.windows.net/;TableEndpoint=https://clitest000002.table.core.windows.net/","WEBSITE_CONTENTSHARE":"inplace-ds000003","FUNCTIONS_EXTENSION_VERSION":"~4","FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_RUN_FROM_PACKAGE":"https://clitest000002.blob.core.windows.net/source-packages/inplace-ds000003.zip?se=2026-09-09T09%3A28Z&sp=r&sv=2026-04-06&sr=b&sig=fakeSasSignature"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1356'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/0f9d4345-cefc-4603-be9e-90b9b8d362a7
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: 32EC1EE907004D8A85DDE5A350A4FA87 Ref B: PNQ231110909034 Ref C: 2026-09-08T09:29:44Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002?api-version=2025-08-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"allowCrossTenantDelegationSas":false,"keyCreationTime":{"key1":"2026-09-08T09:28:04.4044395Z","key2":"2026-09-08T09:28:04.4044395Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"None","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2026-09-08T09:28:04.4145774Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2026-09-08T09:28:04.1782735Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1350'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DC30D11EA27D49CDAF11E2A6F03B40B6 Ref B: PNQ231110908036 Ref C: 2026-09-08T09:29:45Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/blobServices/default/containers/mycontainer?api-version=2025-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/blobServices/default/containers/mycontainer","name":"mycontainer","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8DF0D8BAD52CD65\"","properties":{"deleted":false,"remainingRetentionDays":0,"defaultEncryptionScope":"$account-encryption-key","denyEncryptionScopeOverride":false,"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2026-09-08T09:29:26.0000000Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '676'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:29:46 GMT
+      etag:
+      - '"0x8DF0D8BAD52CD65"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/f99725db-e42a-4ffe-90e3-68ccb4233740
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: AD49492471B84C39A970412956F219FC Ref B: PNQ231110907023 Ref C: 2026-09-08T09:29:46Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "North Central US (Stage)", "sku": {"name": "FlexConsumption"},
+      "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004",
+      "functionAppConfig": {"deployment": {"storage": {"type": "blobContainer", "value":
+      "https://clitest000002.blob.core.windows.net/mycontainer", "authentication":
+      {"type": "StorageAccountConnectionString", "storageAccountConnectionStringName":
+      "AzureWebJobsStorage"}}}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '518'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"Code":"InternalServerError","Message":"Failed to create FunctionAppConfig
+        during CV1 to CV2 upgrade. Error: ''Value cannot be null.\r\nParameter name:
+        format''","Target":null,"Details":[{"Message":"Failed to create FunctionAppConfig
+        during CV1 to CV2 upgrade. Error: ''Value cannot be null.\r\nParameter name:
+        format''"},{"Code":"InternalServerError"},{"ErrorEntity":{"ExtendedCode":"70014","MessageTemplate":"Failed
+        to create FunctionAppConfig during CV1 to CV2 upgrade. Error: ''{0}''","Parameters":["Value
+        cannot be null.\r\nParameter name: format"],"Code":"InternalServerError","Message":"Failed
+        to create FunctionAppConfig during CV1 to CV2 upgrade. Error: ''Value cannot
+        be null.\r\nParameter name: format''"}}],"Innererror":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '730'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 08 Sep 2026 09:29:54 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - service
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/ef3122cd-28cc-4a86-915d-4440c7c58a08
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+      x-msedge-ref:
+      - 'Ref A: 92723DCF2896485C87B75E82A56CCAD7 Ref B: PNQ231110908060 Ref C: 2026-09-08T09:29:46Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: '{"location": "North Central US (Stage)", "sku": {"name": "FlexConsumption"},
+      "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/inplace-plan000004",
+      "functionAppConfig": {"deployment": {"storage": {"type": "blobContainer", "value":
+      "https://clitest000002.blob.core.windows.net/mycontainer", "authentication":
+      {"type": "StorageAccountConnectionString", "storageAccountConnectionStringName":
+      "AzureWebJobsStorage"}}}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '518'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2025-05-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:29:59 GMT
+      etag:
+      - 1DD3F7488A63615
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244565994042871&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=Ad6dLfMyvHq5a1Qd-LyCq1uznNiIA_C2gOmtHw3AUY4q_r28CmTI5lHBIldwxU9BfYXDP5qAfH4NZTKvEXnBymtZxJeSjLnQWGk-iK4-4P2AbWkFubvMaSINxrS5AI5uh3MpHJdRGLpv2jI4RI-M_BZ1BnCCpTJlEqbtArrDz_MP4bBdrQ9PAJw9UyiMRrxNKqfrthSg0UHhL_ZIiTrktgZmh5HVs-MC8W0Lao0yq1WSzv-mETjGqzCe-OsORon4DsvLtC4dUq79VELnVDJnJ5yLhp1jyhqEf1AavYxbOold5JqM8VaXBG4KNTp5P20OBQybREJMu4ND-d5KLXueCA&h=ov3N0FRaFzz6YK8sxNatP4CjmtEDfMZncUqoFn1qRn8
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/5006d844-3aef-4378-8761-bada4520b624
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+      x-msedge-ref:
+      - 'Ref A: C0EFCF9099A747B9BC6B9DF540DBCB96 Ref B: PNQ231110907031 Ref C: 2026-09-08T09:29:55Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244565994042871&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=Ad6dLfMyvHq5a1Qd-LyCq1uznNiIA_C2gOmtHw3AUY4q_r28CmTI5lHBIldwxU9BfYXDP5qAfH4NZTKvEXnBymtZxJeSjLnQWGk-iK4-4P2AbWkFubvMaSINxrS5AI5uh3MpHJdRGLpv2jI4RI-M_BZ1BnCCpTJlEqbtArrDz_MP4bBdrQ9PAJw9UyiMRrxNKqfrthSg0UHhL_ZIiTrktgZmh5HVs-MC8W0Lao0yq1WSzv-mETjGqzCe-OsORon4DsvLtC4dUq79VELnVDJnJ5yLhp1jyhqEf1AavYxbOold5JqM8VaXBG4KNTp5P20OBQybREJMu4ND-d5KLXueCA&h=ov3N0FRaFzz6YK8sxNatP4CjmtEDfMZncUqoFn1qRn8
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:29:59 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566004393275&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=EL3j1Gc8l82LQz1Xzd7H_ogcD1A2aVOg2Y6H92av0BkBOiV88NDYp0ioztL56w3qGY2MQ-mw04kk7vvIlwc8FtqqHT6AaDsAe0QCHwJnXeCuMuVMpXbvV8m6U2ZDHcghoAWPT3cNTnb4hX3O_31ei9utK0JWAr8DfG59FMMW6kA5SmE54D6NhQqXrEMlx8AgPRGOdmhSABJVcHGFtYoZ3r8HeKdS5_Y8vunyYNAlrLuZx-VZ5g36B3dtaM5x4X4A8kmVnfOdnmjTrFKvJiGwXLqnq3UJPz8KjaouK4cYCD8bQwDgf-o8CGRFmSbhLXGD1QscYfzrASSXSliMoOqy4Q&h=AMaQd30uDOVugBUgR3Q-8GnyD5GByzuBWRBywMkSVp8
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/a82428de-109c-48c0-9ac9-6338bf76b165
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D73EAD08363F4E49890633F7E31ECAC9 Ref B: PNQ231110909025 Ref C: 2026-09-08T09:29:59Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566004393275&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=EL3j1Gc8l82LQz1Xzd7H_ogcD1A2aVOg2Y6H92av0BkBOiV88NDYp0ioztL56w3qGY2MQ-mw04kk7vvIlwc8FtqqHT6AaDsAe0QCHwJnXeCuMuVMpXbvV8m6U2ZDHcghoAWPT3cNTnb4hX3O_31ei9utK0JWAr8DfG59FMMW6kA5SmE54D6NhQqXrEMlx8AgPRGOdmhSABJVcHGFtYoZ3r8HeKdS5_Y8vunyYNAlrLuZx-VZ5g36B3dtaM5x4X4A8kmVnfOdnmjTrFKvJiGwXLqnq3UJPz8KjaouK4cYCD8bQwDgf-o8CGRFmSbhLXGD1QscYfzrASSXSliMoOqy4Q&h=AMaQd30uDOVugBUgR3Q-8GnyD5GByzuBWRBywMkSVp8
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:30:16 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566172658146&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=X7JxZ4NS_G0F2-TOOjyhfRXZm_KgWq3Srf9p99peA8JJub9V6JbF1kLkNt9int778qJBGrePctK-rC6L7_mKnRFrBhljChMCzvGImKmqLLLbgLtX27zu0bn0jpQuzCbMBDrhZ1C6CzoaWXInAhcaFHFoGCnhf_ytWVhGjveMC54ByR9yBoLuXE3PbGWrRaR8hfkksVRXYdTyxgmy8ynP3oX-_DMpewgO_5Gc4I4VmXiYgfo881VaEVn6_yupN1ItAaVu147y7c2Md14bN1FKIAaFQDJJkq2niBOPzI_3Zt8lsZ3mtS5_LCIHo89SH9RiFme1hKrjJ0jqOCH1CmSiPw&h=I1TXSs64H9zEtPyxN8BbDbUAWOAt-pJw108V1nULP1g
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/9a12ee73-3487-413b-929a-3cc8326a3414
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3C78A7C5BC0A4A3F929D6F237C51DBF7 Ref B: PNQ231110907054 Ref C: 2026-09-08T09:30:15Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566172658146&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=X7JxZ4NS_G0F2-TOOjyhfRXZm_KgWq3Srf9p99peA8JJub9V6JbF1kLkNt9int778qJBGrePctK-rC6L7_mKnRFrBhljChMCzvGImKmqLLLbgLtX27zu0bn0jpQuzCbMBDrhZ1C6CzoaWXInAhcaFHFoGCnhf_ytWVhGjveMC54ByR9yBoLuXE3PbGWrRaR8hfkksVRXYdTyxgmy8ynP3oX-_DMpewgO_5Gc4I4VmXiYgfo881VaEVn6_yupN1ItAaVu147y7c2Md14bN1FKIAaFQDJJkq2niBOPzI_3Zt8lsZ3mtS5_LCIHo89SH9RiFme1hKrjJ0jqOCH1CmSiPw&h=I1TXSs64H9zEtPyxN8BbDbUAWOAt-pJw108V1nULP1g
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:30:33 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566334637524&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=eYJtF8VteMibpxRXnbl_Sbvxqyrloqhthf2tOVFRTb97POse8hEd2qyg_-aOFyk9HbP356SBVbbfF2kXm7bgGN2PBJfyUpphE4ciHpKtjLk46IiovOgmoShnvehehfRDg5KoaHbzw669z9LxZ7pLtEtp8tMdficlDA75zF90uxu1ho8ihqTywSwhBdoz7duD9lQByAqYmptN90AnTzNvQ8dxa4rih9l9GEyyKqe7B0JnbB8TBxYrC-GvUPFVLkS5zbJvpSzHX1qfQFj00eGsLFT1Icr7AgAW__4DFmVSCaXBmRZ7BwNl6svGq2xJGTtCl28ghxDpBJbElpbfcbcNNg&h=Q3NsWkiJ7Wq_L9kE16XlPocoWwHnxxz2aFFlF5jDOko
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/1e58273d-fade-4c61-a38a-7f9c94120895
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 45B25C873A8A4F75931FD78D05855550 Ref B: PNQ231110909054 Ref C: 2026-09-08T09:30:32Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566334637524&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=eYJtF8VteMibpxRXnbl_Sbvxqyrloqhthf2tOVFRTb97POse8hEd2qyg_-aOFyk9HbP356SBVbbfF2kXm7bgGN2PBJfyUpphE4ciHpKtjLk46IiovOgmoShnvehehfRDg5KoaHbzw669z9LxZ7pLtEtp8tMdficlDA75zF90uxu1ho8ihqTywSwhBdoz7duD9lQByAqYmptN90AnTzNvQ8dxa4rih9l9GEyyKqe7B0JnbB8TBxYrC-GvUPFVLkS5zbJvpSzHX1qfQFj00eGsLFT1Icr7AgAW__4DFmVSCaXBmRZ7BwNl6svGq2xJGTtCl28ghxDpBJbElpbfcbcNNg&h=Q3NsWkiJ7Wq_L9kE16XlPocoWwHnxxz2aFFlF5jDOko
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:30:49 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566507508075&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=ku7vfdyVEkcJWfqVGZ17vacQtWKRxdQWPVqHUrqQ2IsGXyZLc_gvviWrrxycciAoEeBtm3-xOZIi7xoakCo_JSS-KzCha3zfg9qP79ZNSk6UwwhGj4KPYIaswWbm2jDyyImawi7FXB359vNDjFkbLt8jDTryviA-7dA4IFC3Ghtgj29SjY6tbpAWiWwvK1RpcYWP2VMGM5CRCirpJxwJBXEsBsQef4bPMqivc3Q8zhNWQYp8vg2sudXyGFACdPiFQLCaf6LONve0Sjqkh9kmVA3Xs67294pFksiCBfXA08uFQNRQYifC4TQsN0g3BHuN4MLDcRqdEQ_lPBxd46bdng&h=iZmfKIzlYBB7vwINe87I59jSg8b5F1vr-JB2fV0Wl1Y
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/9921af09-d66a-4043-b78d-d3556a3bf1a2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CB0764E7D4084A84A9A4522CF57BBD60 Ref B: PNQ231110908036 Ref C: 2026-09-08T09:30:48Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566507508075&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=ku7vfdyVEkcJWfqVGZ17vacQtWKRxdQWPVqHUrqQ2IsGXyZLc_gvviWrrxycciAoEeBtm3-xOZIi7xoakCo_JSS-KzCha3zfg9qP79ZNSk6UwwhGj4KPYIaswWbm2jDyyImawi7FXB359vNDjFkbLt8jDTryviA-7dA4IFC3Ghtgj29SjY6tbpAWiWwvK1RpcYWP2VMGM5CRCirpJxwJBXEsBsQef4bPMqivc3Q8zhNWQYp8vg2sudXyGFACdPiFQLCaf6LONve0Sjqkh9kmVA3Xs67294pFksiCBfXA08uFQNRQYifC4TQsN0g3BHuN4MLDcRqdEQ_lPBxd46bdng&h=iZmfKIzlYBB7vwINe87I59jSg8b5F1vr-JB2fV0Wl1Y
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:31:06 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566667983812&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=srZj8JBiLfG7tHfRlpBQUnxr1IU9GTq9EdCT3RVuOvwpJbXAvLIgMeZDTF1nGZ405wJYbJhvpspjTEfrzfZOsCXa8QMOJU8UH1LvI7QPwkgkWPBnlZIRguLYDM2M5dY1v1etUQuFiysccE1sfycNSfTr8nx_YN4G4R2v1_RJMdbJ4Y9-fyruTfvn_N86G1-EStvDtAb5xPuTinUKyOiyNXW_0-XfoFTDVWWYc2VvGCcRvcxoIXtjNqMMGsY3bRUB4zLUPr_kghFOrQzcN3_C0Bn3MeaIRInfv0da1aHeeQJyzwV8Bh3MkX4KOiT4KYfVkgNA0t40onYsAhsc40o48w&h=JM0o_NN0jD1OwzvV1xgXMnapHW2uIBt2O-ksBE5a4-g
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/246eeabd-5949-46da-a839-a049efce6ee2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 21EA44B414B449ABB3CE832776894037 Ref B: PNQ231110906029 Ref C: 2026-09-08T09:31:06Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566667983812&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=srZj8JBiLfG7tHfRlpBQUnxr1IU9GTq9EdCT3RVuOvwpJbXAvLIgMeZDTF1nGZ405wJYbJhvpspjTEfrzfZOsCXa8QMOJU8UH1LvI7QPwkgkWPBnlZIRguLYDM2M5dY1v1etUQuFiysccE1sfycNSfTr8nx_YN4G4R2v1_RJMdbJ4Y9-fyruTfvn_N86G1-EStvDtAb5xPuTinUKyOiyNXW_0-XfoFTDVWWYc2VvGCcRvcxoIXtjNqMMGsY3bRUB4zLUPr_kghFOrQzcN3_C0Bn3MeaIRInfv0da1aHeeQJyzwV8Bh3MkX4KOiT4KYfVkgNA0t40onYsAhsc40o48w&h=JM0o_NN0jD1OwzvV1xgXMnapHW2uIBt2O-ksBE5a4-g
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 08 Sep 2026 09:31:22 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566827730355&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=lilqD43JpkHUwBXemIRgNGmmSfRZLcqBi6ecNDq2qt01Qn-3XTikD7V3afmbV7c264O0s-LRHC5YUF0DNiZcdfmrlRCoUdF19N5Um3sdyR9d15gACgGmiwXZtW1RMtwpjAJjuCXYSNlamti7Ztx6OIrM5QuKMpEZPuJIYhyanE0OXB9mDK_v4z2TjGfkNACJt2DKpAbh0vOZdBJNhJ6p6ZVhP4-PN04dOyJYX-ku8ro2KX3rEeG_e9-VSQkclv5suEC1XOmkBSTEItFHrcHebAGi2jlRySvQgpZ5z49zOLZD91K4Wv3RMIUYf-vdkH_URTJBf6D_PjHhJf0EfL28iw&h=faiI5vk7AS7tU5Tn-Miyt8PMFcOdYJR6br5_FUOjZBI
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/e513b969-c7a0-4543-99dd-f5519440648a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6187C450F8DB40D6BDEE084B2894EB13 Ref B: PNQ231110909062 Ref C: 2026-09-08T09:31:22Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003/operationresults/c0bceb75-f533-40bc-b095-ed04c63ffb4f?api-version=2025-05-01&t=639244566827730355&c=MIIHlDCCBnygAwIBAgIQJx5QsXrM21FKZVUaR-1qvzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDgxMTE4MDI1N1oXDTI3MDIwNzAwMDI1N1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRjp9R_8TX0dI6LhCdM08oYY2PZne8JdP8nan69dUPDz68Zf-X1RHU_dHF3BcqWmu52UdN47_WKqTy6wjNp3IgDrI8Kk185hDI6TsAcgr21bh7HUn05p0NjbDk_ru9lZohFz8bhMckYvVjeCOYnR8KPp1uJ1KybHi3Az3UdkSQfUBOBWPm3ANRImnpg1XvmNqz8mj18H9FqtlDiJPwxR7xG06Oi7nYXfQJCvjZB93LfKlFi2Iyt2ADl_9m5-1ZhmK3R2MvGHpfgF8NrP3sb54eq5Ag2ySKuc2eTcdZ-ZiyRROcl3EJgNwSy00qk3roECudarsh8J5iOpYkOA8ceRh1AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQalet19xuyKOqlgH0LSNDK92elfjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzIxL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvMjEvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS8yMS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAz2gzn-CNt__1AId8aJ1Y-OTz4kMdpnvslpK4MeSbevogRVbK1gIZhv16U_fpOr6V5qkV7CxMCOUSFAWN5bFFyl_Q0y-FGxGkYkSaEDq1tR0adOxf8TvhY5NZNaZv1EXF0rfNp_eXv2TpSfGs0HsXk3gARLBODYcQpU6GHcxUDoSKP_IbF_X4xfEGoYquLf7tt5AV-og9M6YjB8xQ6pgv6_sbfoOJUNG948NC4WbnbfrflusZti98RliN3MNRH6FU8ymclbyvzurgByHb88AyV7Re4XwEnd0b1gY_Rtd2cdj6u7piVYn0y6M1iYQ60_KCfyzc8EcpPgUfiRPVuGXE6&s=lilqD43JpkHUwBXemIRgNGmmSfRZLcqBi6ecNDq2qt01Qn-3XTikD7V3afmbV7c264O0s-LRHC5YUF0DNiZcdfmrlRCoUdF19N5Um3sdyR9d15gACgGmiwXZtW1RMtwpjAJjuCXYSNlamti7Ztx6OIrM5QuKMpEZPuJIYhyanE0OXB9mDK_v4z2TjGfkNACJt2DKpAbh0vOZdBJNhJ6p6ZVhP4-PN04dOyJYX-ku8ro2KX3rEeG_e9-VSQkclv5suEC1XOmkBSTEItFHrcHebAGi2jlRySvQgpZ5z49zOLZD91K4Wv3RMIUYf-vdkH_URTJBf6D_PjHhJf0EfL28iw&h=faiI5vk7AS7tU5Tn-Miyt8PMFcOdYJR6br5_FUOjZBI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ASP-clitestrgj6vpr2qp54i-fc-2363","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:58.4533333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":{"deployment":{"storage":{"type":"blobContainer","value":"https://clitest000002.blob.core.windows.net/mycontainer","authentication":{"type":"StorageAccountConnectionString","userAssignedIdentityResourceId":null,"storageAccountConnectionStringName":"AzureWebJobsStorage"}}},"runtime":{"name":"node","version":"22"},"scaleAndConcurrency":{"alwaysReady":null,"maximumInstanceCount":100,"instanceMemoryMB":2048,"triggers":null},"siteUpdateStrategy":{"type":"Recreate"}},"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"FlexConsumption","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":1536,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9469'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:31:38 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2576b10a-87f0-477d-b050-1e0232af9358/northcentralus/6aaf9d12-f37e-4340-b7c4-1a7223dd614d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 609E3EEF8CDB44B990812C36F4E52B45 Ref B: PNQ231110906031 Ref C: 2026-09-08T09:31:38Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp flex-migration start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource-group --source-name --in-place --deployment-storage-name
+        --deployment-storage-container-name
+      User-Agent:
+      - AZURECLI/2.89.0 azsdk-python-core/1.39.0 Python/3.11.9 (Windows-10-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003?api-version=2025-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/inplace-ds000003","name":"inplace-ds000003","type":"Microsoft.Web/sites","kind":"functionapp,linux","location":"North
+        Central US (Stage)","properties":{"name":"inplace-ds000003","state":"Running","hostNames":["inplace-ds000003.azurewebsites.net"],"webSpace":"clitest.rg000001-NorthCentralUSStagewebspace-Linux","selfLink":"https://waws-prod-msftintch1-503.api.azurewebsites.windows.net:455/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-NorthCentralUSStagewebspace-Linux/sites/inplace-ds000003","repositorySiteName":"inplace-ds000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["inplace-ds000003.azurewebsites.net","inplace-ds000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"Node|22"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"inplace-ds000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"inplace-ds000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"hostNamePrivateStates":[],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ASP-clitestrgj6vpr2qp54i-fc-2363","reserved":true,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2026-09-08T09:29:58.4533333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"Node|22","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":200,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":{"deployment":{"storage":{"type":"blobContainer","value":"https://clitest000002.blob.core.windows.net/mycontainer","authentication":{"type":"StorageAccountConnectionString","userAssignedIdentityResourceId":null,"storageAccountConnectionStringName":"AzureWebJobsStorage"}}},"runtime":{"name":"node","version":"22"},"scaleAndConcurrency":{"alwaysReady":null,"maximumInstanceCount":100,"instanceMemoryMB":2048,"triggers":null},"siteUpdateStrategy":{"type":"Recreate"}},"daprConfig":null,"aiIntegration":null,"deploymentId":"inplace-ds000003","slotName":null,"trafficManagerHostNames":null,"sku":"FlexConsumption","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"jA4Forwarding":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"9D4CDDD6DD2AB9149A5618870B35BA18439CEBE1CD3FC2E2C031589C5B196ABA","kind":"functionapp,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"52.162.107.13","possibleInboundIpAddresses":"52.162.107.13,52.162.107.45","inboundIpv6Address":"2603:1030:608:402::a2","possibleInboundIpv6Addresses":"2603:1030:608:402::a2","ftpUsername":"inplace-ds000003\\$inplace-ds000003","ftpsHostName":"ftps://waws-prod-msftintch1-503.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.107.13","possibleOutboundIpAddresses":"172.214.135.206,172.214.252.127,20.241.89.195,52.252.192.118,64.236.144.9,172.183.250.173,52.162.136.63,52.162.137.50,52.162.137.125,52.162.137.157,52.162.137.176,52.162.137.181,52.162.137.208,52.162.137.252,52.162.136.219,52.162.138.200,52.162.141.144,52.162.141.159,52.162.141.178,52.162.141.252,52.162.136.88,52.162.136.206,52.162.136.251,52.162.137.255,168.62.111.145,168.62.111.150,168.62.108.34,168.62.109.40,157.55.136.140,23.101.164.197,52.162.107.13","outboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","possibleOutboundIpv6Addresses":"2603:1030:603::3bd,2a01:111:f100:1004::9d37:fd84,2603:1030:603::794,2a01:111:f100:1004::9d37:fd87,2a01:111:f100:1004::9d37:fd95,2a01:111:f100:1004::9d37:ff9d,2603:1030:603::4ae,2603:1030:603::4b5,2603:1030:603::4d5,2603:1030:603::55c,2603:1030:603::622,2603:1030:603::6ba,2603:1030:603::26c,2603:1030:603::6d9,2603:1030:603::6de,2603:1030:603::6e4,2603:1030:603::6e9,2603:1030:603::6eb,2603:1030:603::48e,2603:1030:603::48f,2603:1030:603::496,2603:1030:603::497,2603:1030:603::6ec,2603:1030:603::6ed,2603:1030:603::6b4,2603:1030:603::6b5,2603:1030:603::6b6,2603:1030:603::6b7,2603:1030:603::6bc,2603:1030:603::6bd,2603:1030:608:402::a2,2603:10e1:100:2::34a2:6b0d,2603:1030:608:2::1b,2603:10e1:100:2::34a2:6b2d","containerSize":1536,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-msftintch1-503","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"inplace-ds000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs,AppServiceAuthenticationLogs,AppServiceAuditLogs,AppServiceIPSecAuditLogs","inFlightFeatures":[],"platformVersion":"111.0.1.88","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null,"maintenanceEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9469'
+      content-type:
+      - application/json
+      date:
+      - Tue, 08 Sep 2026 09:31:39 GMT
+      etag:
+      - 1DD3F749DA45B55
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4520E1B92BFE42A280C42A159E774F50 Ref B: PNQ231110907052 Ref C: 2026-09-08T09:31:39Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -1380,6 +1380,8 @@ class FunctionAppFlexMigrationInPlaceTest(LiveScenarioTest):
         self.cmd('functionapp create -g {} -n {} -c {} -s {} --os-type linux --runtime python --runtime-version 3.11 --functions-version 4'
                  .format(resource_group, src_name, FLEX_ASP_LOCATION_FUNCTIONAPP, storage_account))
 
+        self.cmd('storage container create -g {} -n mycontainer --account-name {}'
+                 .format(resource_group, storage_account))
         result = self.cmd(
             'functionapp flex-migration start --source-resource-group {} --source-name {} --in-place '
             '--deployment-storage-name {} --deployment-storage-container-name mycontainer'
@@ -1390,14 +1392,13 @@ class FunctionAppFlexMigrationInPlaceTest(LiveScenarioTest):
 
     def test_functionapp_flex_migration_in_place_rejects_target_args(self):
         """--in-place with --name should fail."""
-        with self.assertRaises(SystemExit):
-            self.cmd('functionapp flex-migration start --source-resource-group rg --source-name app '
-                     '--in-place --name target-app --resource-group target-rg')
+        self.cmd('functionapp flex-migration start --source-resource-group rg --source-name app '
+                 '--in-place --name target-app --resource-group target-rg', expect_failure=True)
 
     def test_functionapp_flex_migration_side_by_side_requires_target_args(self):
         """Side-by-side without --name/--resource-group should fail."""
-        with self.assertRaises(SystemExit):
-            self.cmd('functionapp flex-migration start --source-resource-group rg --source-name app')
+        self.cmd('functionapp flex-migration start --source-resource-group rg --source-name app',
+                 expect_failure=True)
 
 
 class FunctionAppFlex(LiveScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -1344,6 +1344,62 @@ class FunctionAppFlexMigrationTest(LiveScenarioTest):
         self.assertTrue(tgt_cors_config['supportCredentials'])
 
 
+class FunctionAppFlexMigrationInPlaceTest(LiveScenarioTest):
+    @ResourceGroupPreparer(location=FLEX_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_flex_migration_in_place(self, resource_group, storage_account):
+        """In-place upgrade: CV1 Linux Consumption → Flex Consumption (same site, same name)."""
+        src_name = self.create_random_name('inplace-func', 24)
+
+        # Create a Linux Consumption function app (CV1)
+        self.cmd('functionapp create -g {} -n {} -c {} -s {} --os-type linux --runtime python --runtime-version 3.11 --functions-version 4'
+                 .format(resource_group, src_name, FLEX_ASP_LOCATION_FUNCTIONAPP, storage_account))
+
+        # Verify it's on Dynamic (Consumption) SKU before upgrade
+        src_app = self.cmd('functionapp show -g {} -n {}'.format(resource_group, src_name)).get_output_in_json()
+        self.assertEqual(src_app['kind'], 'functionapp,linux')
+
+        # Run in-place upgrade
+        result = self.cmd(
+            'functionapp flex-migration start --source-resource-group {} --source-name {} --in-place'
+            .format(resource_group, src_name)
+        ).get_output_in_json()
+
+        # Verify the app is now Flex Consumption
+        self.assertEqual(result['name'], src_name)
+        upgraded_app = self.cmd('functionapp show -g {} -n {}'.format(resource_group, src_name)).get_output_in_json()
+        # After upgrade, the site should have Flex properties
+        self.assertIsNotNone(upgraded_app.get('properties', {}).get('functionAppConfig'))
+
+    @ResourceGroupPreparer(location=FLEX_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_flex_migration_in_place_with_deployment_storage(self, resource_group, storage_account):
+        """In-place upgrade with explicit deployment storage arguments."""
+        src_name = self.create_random_name('inplace-ds', 24)
+
+        self.cmd('functionapp create -g {} -n {} -c {} -s {} --os-type linux --runtime python --runtime-version 3.11 --functions-version 4'
+                 .format(resource_group, src_name, FLEX_ASP_LOCATION_FUNCTIONAPP, storage_account))
+
+        result = self.cmd(
+            'functionapp flex-migration start --source-resource-group {} --source-name {} --in-place '
+            '--deployment-storage-name {} --deployment-storage-container-name mycontainer'
+            .format(resource_group, src_name, storage_account)
+        ).get_output_in_json()
+
+        self.assertEqual(result['name'], src_name)
+
+    def test_functionapp_flex_migration_in_place_rejects_target_args(self):
+        """--in-place with --name should fail."""
+        with self.assertRaises(SystemExit):
+            self.cmd('functionapp flex-migration start --source-resource-group rg --source-name app '
+                     '--in-place --name target-app --resource-group target-rg')
+
+    def test_functionapp_flex_migration_side_by_side_requires_target_args(self):
+        """Side-by-side without --name/--resource-group should fail."""
+        with self.assertRaises(SystemExit):
+            self.cmd('functionapp flex-migration start --source-resource-group rg --source-name app')
+
+
 class FunctionAppFlex(LiveScenarioTest):
     def test_functionapp_list_flexconsumption_locations(self):
         locations = self.cmd('functionapp list-flexconsumption-locations').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -9,10 +9,12 @@ import os
 import re
 import time
 import tempfile
+import zipfile
 import requests
 import datetime
 
-from azure.cli.testsdk.scenario_tests import AllowLargeResponse, record_only
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse, RecordingProcessor, record_only
+from azure.cli.testsdk.scenario_tests.utilities import is_text_payload
 from azure.cli.testsdk import (ScenarioTest, LocalContextScenarioTest, LiveScenarioTest, ResourceGroupPreparer,
                                StorageAccountPreparer, KeyVaultPreparer, JMESPathCheck, live_only, VirtualNetworkPreparer)
 from azure.cli.testsdk.checkers import JMESPathCheckNotExists, JMESPathPatternCheck
@@ -30,6 +32,23 @@ LINUX_ASP_LOCATION_WEBAPP = 'eastus2'
 LINUX_ASP_LOCATION_FUNCTIONAPP = 'ukwest'
 FLEX_ASP_LOCATION_FUNCTIONAPP = 'eastasia'
 WINDOWS_ASP_LOCATION_CHINACLOUD_WEBAPP = 'chinaeast'
+
+
+class StorageSasSignatureReplacer(RecordingProcessor):
+    def _replace(self, value):
+        return re.sub(r'(?i)(sig=)[^&"\'\s\\]+', r'\1fakeSasSignature', value)
+
+    def process_request(self, request):
+        request.uri = self._replace(request.uri)
+        if is_text_payload(request) and request.body:
+            body = request.body.decode('utf-8') if isinstance(request.body, bytes) else str(request.body)
+            request.body = self._replace(body)
+        return request
+
+    def process_response(self, response):
+        if is_text_payload(response) and response['body']['string']:
+            response['body']['string'] = self._replace(response['body']['string'])
+        return response
 
 
 class FunctionappACRScenarioTest(ScenarioTest):
@@ -1344,49 +1363,185 @@ class FunctionAppFlexMigrationTest(LiveScenarioTest):
         self.assertTrue(tgt_cors_config['supportCredentials'])
 
 
-class FunctionAppFlexMigrationInPlaceTest(LiveScenarioTest):
-    @ResourceGroupPreparer(location=FLEX_ASP_LOCATION_FUNCTIONAPP)
+class FunctionAppFlexMigrationInPlaceTest(ScenarioTest):
+    _STAGE_RESOURCE_LOCATION = 'northcentralus'
+    _STAGE_SITE_LOCATION = 'North Central US (Stage)'
+
+    def __init__(self, method_name):
+        super().__init__(method_name, recording_processors=[StorageSasSignatureReplacer()])
+
+    def _create_stage_consumption_app(self, resource_group, storage_account, app_name):
+        plan_name = self.create_random_name('inplace-plan', 24)
+        subscription_id = self.get_subscription_id()
+        if self.in_recording:
+            self.name_replacer.register_name_pair(
+                subscription_id, '00000000-0000-0000-0000-000000000000')
+        plan_id = (
+            '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Web/serverfarms/{}'
+            .format(subscription_id, resource_group, plan_name)
+        )
+        plan_url = 'https://management.azure.com{}?api-version=2024-11-01'.format(plan_id)
+
+        self.kwargs.update({
+            'plan_url': plan_url,
+            'plan_body': json.dumps({
+                'location': self._STAGE_SITE_LOCATION,
+                'kind': 'linux',
+                'sku': {
+                    'name': 'Y1',
+                    'tier': 'Dynamic',
+                    'size': 'Y1',
+                    'family': 'Y',
+                    'capacity': 0
+                },
+                'properties': {
+                    'reserved': True
+                }
+            }),
+        })
+        self.cmd("rest --method put --url '{plan_url}' --body '{plan_body}'")
+
+        connection_string = self.cmd(
+            'storage account show-connection-string -g {} -n {} --query connectionString -o tsv'
+            .format(resource_group, storage_account)
+        ).output.strip()
+        container_name = 'source-packages'
+        blob_name = '{}.zip'.format(app_name)
+        package_path = os.path.join(tempfile.gettempdir(), blob_name)
+        try:
+            with zipfile.ZipFile(package_path, 'w') as package:
+                package.writestr('host.json', '{"version":"2.0"}')
+                package.writestr('hello/function.json', json.dumps({
+                    'bindings': [
+                        {
+                            'authLevel': 'anonymous',
+                            'type': 'httpTrigger',
+                            'direction': 'in',
+                            'name': 'req',
+                            'methods': ['get']
+                        },
+                        {
+                            'type': 'http',
+                            'direction': 'out',
+                            'name': 'res'
+                        }
+                    ]
+                }))
+                package.writestr(
+                    'hello/index.js',
+                    "module.exports = async function (context) { context.res = { body: 'Hello, CV1!' }; };"
+                )
+
+            self.kwargs.update({
+                'connection_string': connection_string,
+                'container_name': container_name,
+                'blob_name': blob_name,
+                'package_path': package_path,
+                'sas_expiry': (
+                    datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+                ).strftime('%Y-%m-%dT%H:%MZ'),
+            })
+            self.cmd(
+                'storage container create --name {container_name} '
+                '--connection-string "{connection_string}"'
+            )
+            if self.in_recording:
+                self.disable_recording = True
+                try:
+                    self.cmd(
+                        'storage blob upload --container-name {container_name} --name {blob_name} '
+                        '--file "{package_path}" --connection-string "{connection_string}"'
+                    )
+                finally:
+                    self.disable_recording = False
+            package_url = self.cmd(
+                'storage blob generate-sas --container-name {container_name} --name {blob_name} '
+                '--permissions r --expiry {sas_expiry} --full-uri '
+                '--connection-string "{connection_string}" -o tsv'
+            ).output.strip()
+        finally:
+            if os.path.exists(package_path):
+                os.remove(package_path)
+
+        site_id = (
+            '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Web/sites/{}'
+            .format(subscription_id, resource_group, app_name)
+        )
+        self.kwargs.update({
+            'site_url': 'https://management.azure.com{}?api-version=2024-11-01'.format(site_id),
+            'site_body': json.dumps({
+                'location': self._STAGE_SITE_LOCATION,
+                'kind': 'functionapp,linux',
+                'properties': {
+                    'serverFarmId': plan_id,
+                    'reserved': True,
+                    'httpsOnly': True,
+                    'siteConfig': {
+                        'linuxFxVersion': 'Node|22',
+                        'appSettings': [
+                            {'name': 'AzureWebJobsStorage', 'value': connection_string},
+                            {'name': 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING', 'value': connection_string},
+                            {'name': 'WEBSITE_CONTENTSHARE', 'value': app_name},
+                            {'name': 'FUNCTIONS_EXTENSION_VERSION', 'value': '~4'},
+                            {'name': 'FUNCTIONS_WORKER_RUNTIME', 'value': 'node'},
+                            {'name': 'WEBSITE_RUN_FROM_PACKAGE', 'value': package_url},
+                        ]
+                    }
+                }
+            }),
+        })
+        self.cmd("rest --method put --url '{site_url}' --body '{site_body}'")
+
+    @ResourceGroupPreparer(location=_STAGE_RESOURCE_LOCATION)
     @StorageAccountPreparer()
     def test_functionapp_flex_migration_in_place(self, resource_group, storage_account):
         """In-place upgrade: CV1 Linux Consumption → Flex Consumption (same site, same name)."""
         src_name = self.create_random_name('inplace-func', 24)
 
-        # Create a Linux Consumption function app (CV1)
-        self.cmd('functionapp create -g {} -n {} -c {} -s {} --os-type linux --runtime python --runtime-version 3.11 --functions-version 4'
-                 .format(resource_group, src_name, FLEX_ASP_LOCATION_FUNCTIONAPP, storage_account))
+        self._create_stage_consumption_app(resource_group, storage_account, src_name)
 
         # Verify it's on Dynamic (Consumption) SKU before upgrade
         src_app = self.cmd('functionapp show -g {} -n {}'.format(resource_group, src_name)).get_output_in_json()
         self.assertEqual(src_app['kind'], 'functionapp,linux')
 
         # Run in-place upgrade
-        result = self.cmd(
-            'functionapp flex-migration start --source-resource-group {} --source-name {} --in-place'
-            .format(resource_group, src_name)
-        ).get_output_in_json()
+        self.cmd('storage container create -g {} -n defaultcontainer --account-name {}'
+                 .format(resource_group, storage_account))
+        with mock.patch(
+                'azure.cli.command_modules.appservice.custom.list_flexconsumption_locations',
+                return_value=[{'name': 'northcentralusstage'}]), mock.patch(
+                    'azure.cli.command_modules.appservice.custom.list_functions',
+                    return_value=[]):
+            result = self.cmd(
+                'functionapp flex-migration start --source-resource-group {} --source-name {} --in-place '
+                '--deployment-storage-container-name defaultcontainer'
+                .format(resource_group, src_name)
+            ).get_output_in_json()
 
         # Verify the app is now Flex Consumption
         self.assertEqual(result['name'], src_name)
-        upgraded_app = self.cmd('functionapp show -g {} -n {}'.format(resource_group, src_name)).get_output_in_json()
-        # After upgrade, the site should have Flex properties
-        self.assertIsNotNone(upgraded_app.get('properties', {}).get('functionAppConfig'))
+        self.assertIsNotNone(result.get('functionAppConfig'))
 
-    @ResourceGroupPreparer(location=FLEX_ASP_LOCATION_FUNCTIONAPP)
+    @ResourceGroupPreparer(location=_STAGE_RESOURCE_LOCATION)
     @StorageAccountPreparer()
     def test_functionapp_flex_migration_in_place_with_deployment_storage(self, resource_group, storage_account):
         """In-place upgrade with explicit deployment storage arguments."""
         src_name = self.create_random_name('inplace-ds', 24)
 
-        self.cmd('functionapp create -g {} -n {} -c {} -s {} --os-type linux --runtime python --runtime-version 3.11 --functions-version 4'
-                 .format(resource_group, src_name, FLEX_ASP_LOCATION_FUNCTIONAPP, storage_account))
+        self._create_stage_consumption_app(resource_group, storage_account, src_name)
 
         self.cmd('storage container create -g {} -n mycontainer --account-name {}'
                  .format(resource_group, storage_account))
-        result = self.cmd(
-            'functionapp flex-migration start --source-resource-group {} --source-name {} --in-place '
-            '--deployment-storage-name {} --deployment-storage-container-name mycontainer'
-            .format(resource_group, src_name, storage_account)
-        ).get_output_in_json()
+        with mock.patch(
+                'azure.cli.command_modules.appservice.custom.list_flexconsumption_locations',
+                return_value=[{'name': 'northcentralusstage'}]), mock.patch(
+                    'azure.cli.command_modules.appservice.custom.list_functions',
+                    return_value=[]):
+            result = self.cmd(
+                'functionapp flex-migration start --source-resource-group {} --source-name {} --in-place '
+                '--deployment-storage-name {} --deployment-storage-container-name mycontainer'
+                .format(resource_group, src_name, storage_account)
+            ).get_output_in_json()
 
         self.assertEqual(result['name'], src_name)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -18,10 +18,12 @@ from azure.cli.command_modules.appservice.custom import (
     config_source_control,
     validate_app_settings_in_scm,
     update_container_settings_functionapp,
-    list_function_keys)
+    list_function_keys,
+    migrate_consumption_to_flex)
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import (AzureInternalError, UnclassifiedUserFault)
-from azure.cli.core.azclierror import ResourceNotFoundError
+from azure.cli.core.azclierror import (ResourceNotFoundError, MutuallyExclusiveArgumentError,
+                                        RequiredArgumentMissingError, ValidationError)
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -889,3 +891,105 @@ class TestFunctionappMocked(unittest.TestCase):
         self.assertEqual(result, {'default': 'abc'})
         client_mock.web_apps.list_function_keys_slot.assert_called_once_with('rg', 'app', 'httpget', 'staging')
         client_mock.web_apps.list_function_keys.assert_not_called()
+
+
+class TestFlexMigrationInPlaceMocked(unittest.TestCase):
+    """Unit tests for the --in-place flag on flex-migration start."""
+
+    def test_in_place_rejects_target_name_arg(self):
+        """--in-place with --name should raise MutuallyExclusiveArgumentError."""
+        cmd_mock = _get_test_cmd()
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            migrate_consumption_to_flex(cmd_mock,
+                                        source_resource_group='src-rg',
+                                        source_name='src-app',
+                                        resource_group=None,
+                                        name='target-app',
+                                        in_place=True)
+
+    def test_in_place_rejects_target_resource_group_arg(self):
+        """--in-place with --resource-group should raise MutuallyExclusiveArgumentError."""
+        cmd_mock = _get_test_cmd()
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            migrate_consumption_to_flex(cmd_mock,
+                                        source_resource_group='src-rg',
+                                        source_name='src-app',
+                                        resource_group='target-rg',
+                                        name=None,
+                                        in_place=True)
+
+    def test_in_place_rejects_both_target_args(self):
+        """--in-place with both --name and --resource-group should raise MutuallyExclusiveArgumentError."""
+        cmd_mock = _get_test_cmd()
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            migrate_consumption_to_flex(cmd_mock,
+                                        source_resource_group='src-rg',
+                                        source_name='src-app',
+                                        resource_group='target-rg',
+                                        name='target-app',
+                                        in_place=True)
+
+    def test_side_by_side_requires_name(self):
+        """Side-by-side (no --in-place) without --name should raise RequiredArgumentMissingError."""
+        cmd_mock = _get_test_cmd()
+        with self.assertRaises(RequiredArgumentMissingError):
+            migrate_consumption_to_flex(cmd_mock,
+                                        source_resource_group='src-rg',
+                                        source_name='src-app',
+                                        resource_group='target-rg',
+                                        name=None,
+                                        in_place=False)
+
+    def test_side_by_side_requires_resource_group(self):
+        """Side-by-side (no --in-place) without --resource-group should raise RequiredArgumentMissingError."""
+        cmd_mock = _get_test_cmd()
+        with self.assertRaises(RequiredArgumentMissingError):
+            migrate_consumption_to_flex(cmd_mock,
+                                        source_resource_group='src-rg',
+                                        source_name='src-app',
+                                        resource_group=None,
+                                        name='target-app',
+                                        in_place=False)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_mgmt_service_client')
+    @mock.patch('azure.cli.command_modules.appservice.custom.list_flexconsumption_locations', return_value=[{'name': 'eastus'}])
+    @mock.patch('azure.cli.command_modules.appservice.custom.is_flex_functionapp', return_value=True)
+    def test_in_place_rejects_already_flex(self, is_flex_mock, list_locations_mock, get_client_mock):
+        """--in-place on an already-Flex app should raise ValidationError."""
+        cmd_mock = _get_test_cmd()
+        # Mock the web client to return a site
+        client_mock = mock.MagicMock()
+        site_mock = mock.MagicMock()
+        site_mock.kind = 'functionapp,linux'
+        site_mock.name = 'src-app'
+        client_mock.web_apps.get.return_value = site_mock
+        get_client_mock.return_value = client_mock
+
+        with self.assertRaises(ValidationError) as ctx:
+            migrate_consumption_to_flex(cmd_mock,
+                                        source_resource_group='src-rg',
+                                        source_name='src-app',
+                                        in_place=True)
+        self.assertIn('already on Flex Consumption', str(ctx.exception))
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_mgmt_service_client')
+    @mock.patch('azure.cli.command_modules.appservice.custom.list_flexconsumption_locations', return_value=[{'name': 'eastus'}])
+    @mock.patch('azure.cli.command_modules.appservice.custom.is_flex_functionapp', return_value=False)
+    @mock.patch('azure.cli.command_modules.appservice.custom._is_linux_consumption_function_app', return_value=False)
+    def test_in_place_rejects_non_consumption(self, is_linux_consumption_mock, is_flex_mock,
+                                               list_locations_mock, get_client_mock):
+        """--in-place on a non-Consumption app should raise ValidationError."""
+        cmd_mock = _get_test_cmd()
+        client_mock = mock.MagicMock()
+        site_mock = mock.MagicMock()
+        site_mock.kind = 'functionapp'
+        site_mock.name = 'src-app'
+        client_mock.web_apps.get.return_value = site_mock
+        get_client_mock.return_value = client_mock
+
+        with self.assertRaises(ValidationError) as ctx:
+            migrate_consumption_to_flex(cmd_mock,
+                                        source_resource_group='src-rg',
+                                        source_name='src-app',
+                                        in_place=True)
+        self.assertIn('not on a Linux Dynamic (Consumption) plan', str(ctx.exception))

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -19,11 +19,14 @@ from azure.cli.command_modules.appservice.custom import (
     validate_app_settings_in_scm,
     update_container_settings_functionapp,
     list_function_keys,
-    migrate_consumption_to_flex)
+    migrate_consumption_to_flex,
+    _upgrade_consumption_to_flex_in_place,
+    _prepare_flex_migration_deployment_storage_identity,
+    revert_flex_migration)
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import (AzureInternalError, UnclassifiedUserFault)
 from azure.cli.core.azclierror import (ResourceNotFoundError, MutuallyExclusiveArgumentError,
-                                        RequiredArgumentMissingError, ValidationError)
+                                        RequiredArgumentMissingError, ValidationError, ArgumentUsageError)
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -896,6 +899,54 @@ class TestFunctionappMocked(unittest.TestCase):
 class TestFlexMigrationInPlaceMocked(unittest.TestCase):
     """Unit tests for the --in-place flag on flex-migration start."""
 
+    def test_in_place_requires_user_assigned_identity_value(self):
+        cmd_mock = _get_test_cmd()
+        source = mock.MagicMock()
+        source.location = 'eastus'
+
+        with self.assertRaises(ArgumentUsageError) as ctx:
+            _upgrade_consumption_to_flex_in_place(
+                cmd_mock, source, 'src-rg', 'src-app', 'storage-name', None, None,
+                'UserAssignedIdentity', None, 'python', '3.11', None, None, None)
+
+        self.assertIn('--deployment-storage-auth-value is required', str(ctx.exception))
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._assign_deployment_storage_managed_identity_role')
+    @mock.patch('azure.cli.command_modules.appservice.custom.'
+                '_has_deployment_storage_role_assignment_on_resource', return_value=False)
+    @mock.patch('azure.cli.command_modules.appservice.custom.assign_identity')
+    def test_in_place_prepares_user_assigned_identity(
+            self, assign_identity_mock, has_role_assignment_mock, assign_role_mock):
+        cmd_mock = _get_test_cmd()
+        deployment_storage = mock.MagicMock()
+        deployment_identity = mock.MagicMock()
+        deployment_identity.principal_id = 'identity-principal-id'
+
+        _prepare_flex_migration_deployment_storage_identity(
+            cmd_mock, 'src-rg', 'src-app', 'UserAssignedIdentity', 'identity-resource-id',
+            deployment_storage, 'storage-name', deployment_identity)
+
+        assign_identity_mock.assert_called_once_with(
+            cmd_mock, 'src-rg', 'src-app', ['identity-resource-id'])
+        has_role_assignment_mock.assert_called_once_with(
+            cmd_mock.cli_ctx, deployment_storage, 'identity-principal-id')
+        assign_role_mock.assert_called_once_with(
+            cmd_mock.cli_ctx, deployment_storage, 'identity-principal-id')
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.assign_identity')
+    def test_in_place_prepares_system_assigned_identity(self, assign_identity_mock):
+        cmd_mock = _get_test_cmd()
+        deployment_storage = mock.MagicMock()
+        deployment_storage.id = 'storage-resource-id'
+
+        _prepare_flex_migration_deployment_storage_identity(
+            cmd_mock, 'src-rg', 'src-app', 'SystemAssignedIdentity', None,
+            deployment_storage, 'storage-name')
+
+        assign_identity_mock.assert_called_once_with(
+            cmd_mock, 'src-rg', 'src-app', ['[system]'], 'Storage Blob Data Contributor',
+            None, 'storage-resource-id')
+
     def test_in_place_rejects_target_name_arg(self):
         """--in-place with --name should raise MutuallyExclusiveArgumentError."""
         cmd_mock = _get_test_cmd()
@@ -993,3 +1044,51 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
                                         source_name='src-app',
                                         in_place=True)
         self.assertIn('not on a Linux Dynamic (Consumption) plan', str(ctx.exception))
+
+
+class TestFlexMigrationRevertMocked(unittest.TestCase):
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_raw_functionapp',
+                return_value={'properties': {'sku': 'Dynamic'}})
+    def test_revert_rejects_non_flex_app(self, get_raw_functionapp_mock):
+        cmd_mock = _get_test_cmd()
+
+        with self.assertRaises(ValidationError) as ctx:
+            revert_flex_migration(cmd_mock, 'src-rg', 'src-app')
+
+        self.assertIn('not on Flex Consumption', str(ctx.exception))
+        get_raw_functionapp_mock.assert_called_once_with(cmd_mock.cli_ctx, 'src-rg', 'src-app')
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_functionapp')
+    @mock.patch('azure.cli.command_modules.appservice.custom.LongRunningOperation')
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory')
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_raw_functionapp',
+                return_value={'location': 'North Central US (Stage)',
+                              'properties': {'sku': 'FlexConsumption'}})
+    def test_revert_submits_dynamic_sku(self, get_raw_functionapp_mock, web_client_factory_mock,
+                                        long_running_operation_mock, get_functionapp_mock):
+        cmd_mock = _get_test_cmd()
+        result_mock = mock.sentinel.result
+        get_functionapp_mock.return_value = result_mock
+
+        client_mock = mock.MagicMock()
+        poller_mock = client_mock.web_apps.begin_create_or_update.return_value
+        web_client_factory_mock.return_value = client_mock
+
+        result = revert_flex_migration(cmd_mock, 'src-rg', 'src-app')
+
+        self.assertIs(result, result_mock)
+        request = client_mock.web_apps.begin_create_or_update.call_args.args[2]
+        self.assertEqual(request, {
+            'kind': 'functionapp,linux',
+            'location': 'North Central US (Stage)',
+            'properties': {
+                'reserved': True,
+                'sku': 'Dynamic'
+            },
+            'sku': {'name': 'Dynamic'}
+        })
+        client_mock.web_apps.get.assert_not_called()
+        long_running_operation_mock.assert_called_once_with(cmd_mock.cli_ctx)
+        long_running_operation_mock.return_value.assert_called_once_with(poller_mock)
+        get_functionapp_mock.assert_called_once_with(cmd_mock, 'src-rg', 'src-app')

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -21,6 +21,7 @@ from azure.cli.command_modules.appservice.custom import (
     list_function_keys,
     migrate_consumption_to_flex,
     _upgrade_consumption_to_flex_in_place,
+    _build_flex_function_app_config,
     _prepare_flex_migration_deployment_storage_identity,
     revert_flex_migration)
 from azure.cli.core.profiles import ResourceType
@@ -899,6 +900,112 @@ class TestFunctionappMocked(unittest.TestCase):
 class TestFlexMigrationInPlaceMocked(unittest.TestCase):
     """Unit tests for the --in-place flag on flex-migration start."""
 
+    def test_in_place_payload_matches_create(self):
+        flex_sku = {
+            'functionAppConfigProperties': {'runtime': {'name': 'python', 'version': '3.11'}},
+            'instanceMemoryMB': [{'isDefault': True, 'size': 2048}],
+            'maximumInstanceCount': {'defaultValue': 100}
+        }
+        auth_config = {
+            'type': 'StorageAccountConnectionString',
+            'storageAccountConnectionStringName': 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+        }
+
+        config = _build_flex_function_app_config(
+            'https://storage.blob.core.windows.net/deployment', auth_config, flex_sku,
+            None, None, ['function=2'])
+
+        self.assertEqual(config, {
+            'deployment': {
+                'storage': {
+                    'type': 'blobContainer',
+                    'value': 'https://storage.blob.core.windows.net/deployment',
+                    'authentication': auth_config
+                }
+            },
+            'runtime': {'name': 'python', 'version': '3.11'},
+            'scaleAndConcurrency': {
+                'maximumInstanceCount': 100,
+                'instanceMemoryMB': 2048,
+                'alwaysReady': [{'name': 'function', 'instanceCount': 2}]
+            }
+        })
+
+    def test_in_place_put_uses_same_site_and_preserves_plan(self):
+        original_plan_id = '/subscriptions/sub/resourceGroups/src-rg/providers/Microsoft.Web/serverfarms/cv1-plan'
+        deployment_storage = mock.MagicMock()
+        deployment_storage.sku.name = 'Standard_LRS'
+        deployment_storage.is_hns_enabled = False
+        deployment_storage.primary_endpoints.blob = 'https://storage.blob.core.windows.net/'
+        container = mock.MagicMock()
+        container.name = 'deployment'
+        source = mock.MagicMock()
+        source.location = 'eastus'
+        site = mock.MagicMock()
+        site.properties.server_farm_id = original_plan_id
+        site.site_config = mock.MagicMock()
+        site.as_dict.side_effect = lambda: {
+            'properties': {
+                'serverFarmId': site.properties.server_farm_id,
+                'functionAppConfig': site.properties.function_app_config,
+                'sku': site.properties.sku
+            }
+        }
+        flex_client = mock.MagicMock()
+        flex_client.web_apps.get.return_value = site
+        matched_runtime = mock.MagicMock()
+        matched_runtime.sku = {
+            'functionAppConfigProperties': {'runtime': {'name': 'python', 'version': '3.11'}},
+            'instanceMemoryMB': [{'isDefault': True, 'size': 2048}],
+            'maximumInstanceCount': {'defaultValue': 100}
+        }
+
+        patches = {
+            '_validate_and_get_deployment_storage': mock.DEFAULT,
+            '_get_or_create_deployment_storage_container': mock.DEFAULT,
+            '_get_storage_connection_string': mock.DEFAULT,
+            '_FlexFunctionAppStackRuntimeHelper': mock.DEFAULT,
+            '_prepare_flex_migration_deployment_storage_identity': mock.DEFAULT,
+            'web_client_factory': mock.DEFAULT,
+            'LongRunningOperation': mock.DEFAULT,
+            'get_functionapp': mock.DEFAULT
+        }
+        with mock.patch.multiple('azure.cli.command_modules.appservice.custom', **patches) as mocks:
+            mocks['_validate_and_get_deployment_storage'].return_value = deployment_storage
+            mocks['_get_or_create_deployment_storage_container'].return_value = container
+            mocks['_get_storage_connection_string'].return_value = 'connection-string'
+            mocks['_FlexFunctionAppStackRuntimeHelper'].return_value.resolve.return_value = matched_runtime
+            mocks['web_client_factory'].return_value = flex_client
+
+            _upgrade_consumption_to_flex_in_place(
+                _get_test_cmd(), source, 'src-rg', 'src-app', 'storage', None, None,
+                None, None, 'python', '3.11', None, None, None)
+
+        flex_client.web_apps.begin_create_or_update.assert_called_once()
+        resource_group, name, payload = flex_client.web_apps.begin_create_or_update.call_args.args
+        self.assertEqual((resource_group, name), ('src-rg', 'src-app'))
+        self.assertEqual(payload['properties']['serverFarmId'], original_plan_id)
+        self.assertEqual(payload['sku'], {'name': 'FlexConsumption'})
+        flex_client.app_service_plans.begin_create_or_update.assert_not_called()
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._validate_and_get_deployment_storage')
+    def test_in_place_rejects_unsupported_deployment_storage(self, validate_storage_mock):
+        for sku, hns_enabled, expected_error in [
+                ('Premium_LRS', False, 'Premium deployment storage'),
+                ('Standard_LRS', True, 'ADLS Gen2 deployment storage')]:
+            with self.subTest(sku=sku, hns_enabled=hns_enabled):
+                deployment_storage = mock.MagicMock()
+                deployment_storage.sku.name = sku
+                deployment_storage.is_hns_enabled = hns_enabled
+                validate_storage_mock.return_value = deployment_storage
+
+                with self.assertRaises(ValidationError) as ctx:
+                    _upgrade_consumption_to_flex_in_place(
+                        _get_test_cmd(), mock.MagicMock(), 'src-rg', 'src-app', 'storage-name',
+                        None, None, None, None, 'python', '3.11', None, None, None)
+
+                self.assertIn(expected_error, str(ctx.exception))
+
     def test_in_place_requires_user_assigned_identity_value(self):
         cmd_mock = _get_test_cmd()
         source = mock.MagicMock()
@@ -1001,6 +1108,52 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
                                         resource_group=None,
                                         name='target-app',
                                         in_place=False)
+
+    def test_side_by_side_unchanged(self):
+        source = mock.MagicMock()
+        source.location = 'eastus'
+        source.name = 'src-app'
+        site_configs = mock.MagicMock()
+        result = mock.sentinel.result
+        patches = {
+            'get_mgmt_service_client': mock.DEFAULT,
+            'list_flexconsumption_locations': mock.DEFAULT,
+            '_is_linux_consumption_function_app': mock.DEFAULT,
+            'validate_flex_migration_eligibility_for_linux_consumption_app': mock.DEFAULT,
+            'list_slots': mock.DEFAULT,
+            'get_site_configs': mock.DEFAULT,
+            '_get_functionapp_runtime_info_helper': mock.DEFAULT,
+            'create_functionapp': mock.DEFAULT,
+            '_migrate_app_settings': mock.DEFAULT,
+            '_migrate_site_configs': mock.DEFAULT,
+            '_migrate_site_properties': mock.DEFAULT,
+            '_migrate_basic_publishing_credentials_policies': mock.DEFAULT,
+            'get_functionapp': mock.DEFAULT
+        }
+        with mock.patch.multiple('azure.cli.command_modules.appservice.custom', **patches) as mocks:
+            mocks['get_mgmt_service_client'].return_value.web_apps.get.return_value = source
+            mocks['list_flexconsumption_locations'].return_value = [{'name': 'eastus'}]
+            mocks['_is_linux_consumption_function_app'].return_value = True
+            mocks['validate_flex_migration_eligibility_for_linux_consumption_app'].return_value = (True, [])
+            mocks['list_slots'].return_value = []
+            mocks['get_site_configs'].return_value = site_configs
+            mocks['_get_functionapp_runtime_info_helper'].return_value = {
+                'app_runtime': 'python',
+                'app_runtime_version': '3.11'
+            }
+            mocks['get_functionapp'].return_value = result
+
+            actual = migrate_consumption_to_flex(
+                _get_test_cmd(), 'src-rg', 'src-app', resource_group='target-rg', name='target-app',
+                storage_account='storage', skip_managed_identities=True, skip_access_restrictions=True,
+                skip_storage_mount=True, skip_hostnames=True, skip_cors=True)
+
+        self.assertIs(actual, result)
+        mocks['create_functionapp'].assert_called_once_with(
+            mock.ANY, 'target-rg', 'target-app', 'storage', flexconsumption_location='eastus',
+            runtime='python', runtime_version='3.11', maximum_instance_count=None)
+        mocks['_migrate_app_settings'].assert_called_once_with(
+            mock.ANY, 'src-rg', 'src-app', 'target-rg', 'target-app', 'storage')
 
     @mock.patch('azure.cli.command_modules.appservice.custom.get_mgmt_service_client')
     @mock.patch('azure.cli.command_modules.appservice.custom.list_flexconsumption_locations', return_value=[{'name': 'eastus'}])

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -22,7 +22,8 @@ from azure.cli.command_modules.appservice.custom import (
     migrate_consumption_to_flex,
     _upgrade_consumption_to_flex_in_place,
     _build_flex_function_app_config,
-    _prepare_flex_migration_deployment_storage_identity,
+    _prepare_flex_deployment_storage,
+    _prepare_flex_deployment_storage_identity,
     revert_flex_migration)
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import (AzureInternalError, UnclassifiedUserFault)
@@ -933,26 +934,14 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
 
     def test_in_place_put_uses_same_site_and_preserves_plan(self):
         original_plan_id = '/subscriptions/sub/resourceGroups/src-rg/providers/Microsoft.Web/serverfarms/cv1-plan'
-        deployment_storage = mock.MagicMock()
-        deployment_storage.sku.name = 'Standard_LRS'
-        deployment_storage.is_hns_enabled = False
-        deployment_storage.primary_endpoints.blob = 'https://storage.blob.core.windows.net/'
-        container = mock.MagicMock()
-        container.name = 'deployment'
         source = mock.MagicMock()
         source.location = 'eastus'
-        site = mock.MagicMock()
-        site.properties.server_farm_id = original_plan_id
-        site.site_config = mock.MagicMock()
-        site.as_dict.side_effect = lambda: {
-            'properties': {
-                'serverFarmId': site.properties.server_farm_id,
-                'functionAppConfig': site.properties.function_app_config,
-                'sku': site.properties.sku
-            }
-        }
+        source.server_farm_id = original_plan_id
+        source.identity = None
         flex_client = mock.MagicMock()
-        flex_client.web_apps.get.return_value = site
+        flex_client.web_apps.list_application_settings.return_value.properties = {
+            'AzureWebJobsStorage': 'source-connection-string'
+        }
         matched_runtime = mock.MagicMock()
         matched_runtime.sku = {
             'functionAppConfigProperties': {'runtime': {'name': 'python', 'version': '3.11'}},
@@ -961,19 +950,29 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
         }
 
         patches = {
-            '_validate_and_get_deployment_storage': mock.DEFAULT,
-            '_get_or_create_deployment_storage_container': mock.DEFAULT,
-            '_get_storage_connection_string': mock.DEFAULT,
+            '_prepare_flex_deployment_storage': mock.DEFAULT,
             '_FlexFunctionAppStackRuntimeHelper': mock.DEFAULT,
-            '_prepare_flex_migration_deployment_storage_identity': mock.DEFAULT,
+            '_prepare_flex_deployment_storage_identity': mock.DEFAULT,
             'web_client_factory': mock.DEFAULT,
             'LongRunningOperation': mock.DEFAULT,
             'get_functionapp': mock.DEFAULT
         }
         with mock.patch.multiple('azure.cli.command_modules.appservice.custom', **patches) as mocks:
-            mocks['_validate_and_get_deployment_storage'].return_value = deployment_storage
-            mocks['_get_or_create_deployment_storage_container'].return_value = container
-            mocks['_get_storage_connection_string'].return_value = 'connection-string'
+            mocks['_prepare_flex_deployment_storage'].return_value = {
+                'app_settings_to_add': [],
+                'function_app_config': {
+                    'deployment': {
+                        'storage': {
+                            'type': 'blobContainer',
+                            'value': 'https://storage.blob.core.windows.net/deployment',
+                            'authentication': {
+                                'type': 'StorageAccountConnectionString',
+                                'storageAccountConnectionStringName': 'AzureWebJobsStorage'
+                            }
+                        }
+                    }
+                }
+            }
             mocks['_FlexFunctionAppStackRuntimeHelper'].return_value.resolve.return_value = matched_runtime
             mocks['web_client_factory'].return_value = flex_client
 
@@ -984,12 +983,35 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
         flex_client.web_apps.begin_create_or_update.assert_called_once()
         resource_group, name, payload = flex_client.web_apps.begin_create_or_update.call_args.args
         self.assertEqual((resource_group, name), ('src-rg', 'src-app'))
-        self.assertEqual(payload['properties']['serverFarmId'], original_plan_id)
-        self.assertEqual(payload['sku'], {'name': 'FlexConsumption'})
+        self.assertEqual(payload, {
+            'location': 'eastus',
+            'sku': {'name': 'FlexConsumption'},
+            'properties': {
+                'serverFarmId': original_plan_id,
+                'functionAppConfig': {
+                    'deployment': {
+                        'storage': {
+                            'type': 'blobContainer',
+                            'value': 'https://storage.blob.core.windows.net/deployment',
+                            'authentication': {
+                                'type': 'StorageAccountConnectionString',
+                                'storageAccountConnectionStringName': 'AzureWebJobsStorage'
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        flex_client.web_apps.update_application_settings.assert_not_called()
         flex_client.app_service_plans.begin_create_or_update.assert_not_called()
 
     @mock.patch('azure.cli.command_modules.appservice.custom._validate_and_get_deployment_storage')
     def test_in_place_rejects_unsupported_deployment_storage(self, validate_storage_mock):
+        flex_sku = {
+            'functionAppConfigProperties': {'runtime': {'name': 'python', 'version': '3.11'}},
+            'instanceMemoryMB': [{'isDefault': True, 'size': 2048}],
+            'maximumInstanceCount': {'defaultValue': 100}
+        }
         for sku, hns_enabled, expected_error in [
                 ('Premium_LRS', False, 'Premium deployment storage'),
                 ('Standard_LRS', True, 'ADLS Gen2 deployment storage')]:
@@ -1000,9 +1022,10 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
                 validate_storage_mock.return_value = deployment_storage
 
                 with self.assertRaises(ValidationError) as ctx:
-                    _upgrade_consumption_to_flex_in_place(
-                        _get_test_cmd(), mock.MagicMock(), 'src-rg', 'src-app', 'storage-name',
-                        None, None, None, None, 'python', '3.11', None, None, None)
+                    _prepare_flex_deployment_storage(
+                        _get_test_cmd(), 'src-rg', 'src-app', 'storage-name', None,
+                        'StorageAccountConnectionString', None, 'eastus', flex_sku,
+                        None, None, None, validate_for_in_place=True)
 
                 self.assertIn(expected_error, str(ctx.exception))
 
@@ -1018,6 +1041,140 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
 
         self.assertIn('--deployment-storage-auth-value is required', str(ctx.exception))
 
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_storage_connection_string')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_or_create_deployment_storage_container')
+    @mock.patch('azure.cli.command_modules.appservice.custom._validate_and_get_deployment_storage')
+    def test_flex_storage_setup_preserves_existing_connection_string_setting(
+            self, validate_storage_mock, get_container_mock, get_connection_string_mock):
+        deployment_storage = mock.MagicMock()
+        deployment_storage.primary_endpoints.blob = 'https://storage.blob.core.windows.net/'
+        validate_storage_mock.return_value = deployment_storage
+        container = mock.MagicMock()
+        container.name = 'deployment'
+        get_container_mock.return_value = container
+        flex_sku = {
+            'functionAppConfigProperties': {'runtime': {'name': 'python', 'version': '3.11'}},
+            'instanceMemoryMB': [{'isDefault': True, 'size': 2048}],
+            'maximumInstanceCount': {'defaultValue': 100}
+        }
+
+        setup = _prepare_flex_deployment_storage(
+            _get_test_cmd(), 'src-rg', 'src-app', 'storage-name', 'deployment',
+            'StorageAccountConnectionString', 'CUSTOM_DEPLOYMENT_STORAGE', 'eastus', flex_sku,
+            None, None, None, {'CUSTOM_DEPLOYMENT_STORAGE': 'existing-value'})
+
+        self.assertEqual(setup['app_settings_to_add'], [])
+        self.assertEqual(
+            setup['function_app_config']['deployment']['storage']['authentication']
+            ['storageAccountConnectionStringName'],
+            'CUSTOM_DEPLOYMENT_STORAGE')
+        get_connection_string_mock.assert_not_called()
+
+    def test_in_place_polling_failure_retains_side_effects(self):
+        source = mock.MagicMock()
+        source.location = 'eastus'
+        source.server_farm_id = 'cv1-plan-id'
+        source.identity = None
+        flex_client = mock.MagicMock()
+        flex_client.web_apps.list_application_settings.return_value.properties = {
+            'AzureWebJobsStorage': 'original-value'
+        }
+        matched_runtime = mock.MagicMock()
+        matched_runtime.sku = {
+            'functionAppConfigProperties': {'runtime': {'name': 'python', 'version': '3.11'}},
+            'instanceMemoryMB': [{'isDefault': True, 'size': 2048}],
+            'maximumInstanceCount': {'defaultValue': 100}
+        }
+        storage_setup = {
+            'app_settings_to_add': [{'name': 'DEPLOYMENT_STORAGE_CONNECTION_STRING', 'value': 'new-value'}],
+            'function_app_config': {'deployment': {'storage': {'authentication': {
+                'type': 'StorageAccountConnectionString'}}}}
+        }
+        identity_changes = {'identity_added': True}
+
+        patches = {
+            '_prepare_flex_deployment_storage': mock.DEFAULT,
+            '_prepare_flex_deployment_storage_identity': mock.DEFAULT,
+            '_rollback_flex_deployment_storage_identity': mock.DEFAULT,
+            '_cleanup_flex_deployment_storage': mock.DEFAULT,
+            '_FlexFunctionAppStackRuntimeHelper': mock.DEFAULT,
+            'web_client_factory': mock.DEFAULT,
+            'LongRunningOperation': mock.DEFAULT
+        }
+        with mock.patch.multiple('azure.cli.command_modules.appservice.custom', **patches) as mocks:
+            mocks['_prepare_flex_deployment_storage'].return_value = storage_setup
+            mocks['_prepare_flex_deployment_storage_identity'].return_value = identity_changes
+            mocks['_FlexFunctionAppStackRuntimeHelper'].return_value.resolve.return_value = matched_runtime
+            mocks['web_client_factory'].return_value = flex_client
+            mocks['LongRunningOperation'].return_value.side_effect = RuntimeError('upgrade failed')
+
+            with self.assertRaisesRegex(RuntimeError, 'upgrade failed'):
+                _upgrade_consumption_to_flex_in_place(
+                    _get_test_cmd(), source, 'src-rg', 'src-app', 'storage', 'separate-storage', None,
+                    None, None, 'python', '3.11', None, None, None)
+
+        self.assertEqual(flex_client.web_apps.update_application_settings.call_count, 1)
+        mocks['_rollback_flex_deployment_storage_identity'].assert_not_called()
+        mocks['_cleanup_flex_deployment_storage'].assert_not_called()
+
+    def test_in_place_put_rejection_rolls_back_only_unchanged_setting(self):
+        source = mock.MagicMock()
+        source.location = 'eastus'
+        source.server_farm_id = 'cv1-plan-id'
+        source.identity = None
+        flex_client = mock.MagicMock()
+        flex_client.web_apps.list_application_settings.side_effect = [
+            mock.MagicMock(properties={'AzureWebJobsStorage': 'original-value'}),
+            mock.MagicMock(properties={
+                'AzureWebJobsStorage': 'original-value',
+                'DEPLOYMENT_STORAGE_CONNECTION_STRING': 'new-value',
+                'CONCURRENT_SETTING': 'preserve-me'
+            })
+        ]
+        flex_client.web_apps.begin_create_or_update.side_effect = RuntimeError('request rejected')
+        matched_runtime = mock.MagicMock()
+        matched_runtime.sku = {
+            'functionAppConfigProperties': {'runtime': {'name': 'python', 'version': '3.11'}},
+            'instanceMemoryMB': [{'isDefault': True, 'size': 2048}],
+            'maximumInstanceCount': {'defaultValue': 100}
+        }
+        storage_setup = {
+            'app_settings_to_add': [{'name': 'DEPLOYMENT_STORAGE_CONNECTION_STRING', 'value': 'new-value'}],
+            'function_app_config': {'deployment': {'storage': {'authentication': {
+                'type': 'StorageAccountConnectionString'}}}}
+        }
+        identity_changes = {'identity_added': True}
+
+        patches = {
+            '_prepare_flex_deployment_storage': mock.DEFAULT,
+            '_prepare_flex_deployment_storage_identity': mock.DEFAULT,
+            '_rollback_flex_deployment_storage_identity': mock.DEFAULT,
+            '_cleanup_flex_deployment_storage': mock.DEFAULT,
+            '_FlexFunctionAppStackRuntimeHelper': mock.DEFAULT,
+            'web_client_factory': mock.DEFAULT
+        }
+        with mock.patch.multiple('azure.cli.command_modules.appservice.custom', **patches) as mocks:
+            mocks['_prepare_flex_deployment_storage'].return_value = storage_setup
+            mocks['_prepare_flex_deployment_storage_identity'].return_value = identity_changes
+            mocks['_FlexFunctionAppStackRuntimeHelper'].return_value.resolve.return_value = matched_runtime
+            mocks['web_client_factory'].return_value = flex_client
+
+            with self.assertRaisesRegex(RuntimeError, 'request rejected'):
+                _upgrade_consumption_to_flex_in_place(
+                    _get_test_cmd(), source, 'src-rg', 'src-app', 'storage', 'separate-storage', None,
+                    None, None, 'python', '3.11', None, None, None)
+
+        self.assertEqual(flex_client.web_apps.update_application_settings.call_count, 2)
+        restored_settings = flex_client.web_apps.update_application_settings.call_args.args[2]
+        self.assertEqual(restored_settings.properties, {
+            'AzureWebJobsStorage': 'original-value',
+            'CONCURRENT_SETTING': 'preserve-me'
+        })
+        mocks['_rollback_flex_deployment_storage_identity'].assert_called_once_with(
+            mock.ANY, 'src-rg', 'src-app', identity_changes)
+        mocks['_cleanup_flex_deployment_storage'].assert_called_once_with(
+            mock.ANY, 'src-rg', storage_setup)
+
     @mock.patch('azure.cli.command_modules.appservice.custom._assign_deployment_storage_managed_identity_role')
     @mock.patch('azure.cli.command_modules.appservice.custom.'
                 '_has_deployment_storage_role_assignment_on_resource', return_value=False)
@@ -1029,9 +1186,21 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
         deployment_identity = mock.MagicMock()
         deployment_identity.principal_id = 'identity-principal-id'
 
-        _prepare_flex_migration_deployment_storage_identity(
-            cmd_mock, 'src-rg', 'src-app', 'UserAssignedIdentity', 'identity-resource-id',
-            deployment_storage, 'storage-name', deployment_identity)
+        assignment = mock.MagicMock()
+        assignment.id = 'role-assignment-id'
+        assign_role_mock.return_value = assignment
+        storage_setup = {
+            'deployment_storage': deployment_storage,
+            'deployment_storage_name': 'storage-name',
+            'deployment_storage_auth_value': 'identity-resource-id',
+            'user_assigned_identity': deployment_identity,
+            'function_app_config': {
+                'deployment': {'storage': {'authentication': {'type': 'UserAssignedIdentity'}}}
+            }
+        }
+
+        changes = _prepare_flex_deployment_storage_identity(
+            cmd_mock, 'src-rg', 'src-app', storage_setup)
 
         assign_identity_mock.assert_called_once_with(
             cmd_mock, 'src-rg', 'src-app', ['identity-resource-id'])
@@ -1039,20 +1208,43 @@ class TestFlexMigrationInPlaceMocked(unittest.TestCase):
             cmd_mock.cli_ctx, deployment_storage, 'identity-principal-id')
         assign_role_mock.assert_called_once_with(
             cmd_mock.cli_ctx, deployment_storage, 'identity-principal-id')
+        self.assertTrue(changes['identity_added'])
+        self.assertEqual(changes['role_assignment_id'], 'role-assignment-id')
 
+    @mock.patch('azure.cli.command_modules.appservice.custom._assign_deployment_storage_managed_identity_role')
+    @mock.patch('azure.cli.command_modules.appservice.custom.'
+                '_has_deployment_storage_role_assignment_on_resource', return_value=False)
     @mock.patch('azure.cli.command_modules.appservice.custom.assign_identity')
-    def test_in_place_prepares_system_assigned_identity(self, assign_identity_mock):
+    def test_in_place_prepares_system_assigned_identity(
+            self, assign_identity_mock, has_role_assignment_mock, assign_role_mock):
         cmd_mock = _get_test_cmd()
         deployment_storage = mock.MagicMock()
         deployment_storage.id = 'storage-resource-id'
+        assigned_identity = mock.MagicMock()
+        assigned_identity.principal_id = 'system-principal-id'
+        assign_identity_mock.return_value = assigned_identity
+        assignment = mock.MagicMock()
+        assignment.id = 'role-assignment-id'
+        assign_role_mock.return_value = assignment
+        storage_setup = {
+            'deployment_storage': deployment_storage,
+            'deployment_storage_name': 'storage-name',
+            'deployment_storage_auth_value': None,
+            'function_app_config': {
+                'deployment': {'storage': {'authentication': {'type': 'SystemAssignedIdentity'}}}
+            }
+        }
 
-        _prepare_flex_migration_deployment_storage_identity(
-            cmd_mock, 'src-rg', 'src-app', 'SystemAssignedIdentity', None,
-            deployment_storage, 'storage-name')
+        changes = _prepare_flex_deployment_storage_identity(
+            cmd_mock, 'src-rg', 'src-app', storage_setup)
 
         assign_identity_mock.assert_called_once_with(
-            cmd_mock, 'src-rg', 'src-app', ['[system]'], 'Storage Blob Data Contributor',
-            None, 'storage-resource-id')
+            cmd_mock, 'src-rg', 'src-app', ['[system]'])
+        has_role_assignment_mock.assert_called_once_with(
+            cmd_mock.cli_ctx, deployment_storage, 'system-principal-id')
+        assign_role_mock.assert_called_once_with(
+            cmd_mock.cli_ctx, deployment_storage, 'system-principal-id')
+        self.assertTrue(changes['identity_added'])
 
     def test_in_place_rejects_target_name_arg(self):
         """--in-place with --name should raise MutuallyExclusiveArgumentError."""


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes | Tests |
| :--: | :--: |
| ⚠️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>⚠️AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>⚠️appservice</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1001 - CmdAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1001.md)|functionapp flex-migration revert|cmd `functionapp flex-migration revert` added||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` added parameter `always_ready_instances`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` added parameter `deployment_storage_auth_type`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` added parameter `deployment_storage_auth_value`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` added parameter `deployment_storage_container_name`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` added parameter `deployment_storage_name`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` added parameter `in_place`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` added parameter `instance_memory`||
>|⚠️ [1009 - ParaPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1009.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` update parameter `name`: removed property `required=True`||
>|⚠️ [1009 - ParaPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1009.md)|functionapp flex-migration start|cmd `functionapp flex-migration start` update parameter `resource_group`: removed property `required=True`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

Add in-place Azure Functions Linux Consumption (CV1) to Flex Consumption upgrade and revert support.

- `az functionapp flex-migration start --in-place` upgrades the existing app while preserving its name and hostname.
- `az functionapp flex-migration revert` restores the app to CV1 during the 7-day revert window.
- Existing side-by-side migration remains unchanged.

## Implementation

- Shares deployment storage, identity, and RBAC setup with Flex app creation.
- Reuses `AzureWebJobsStorage` without overwriting existing settings.
- Supports separate deployment storage and managed identities.
- Sends a sparse upgrade request.
- Cleans up CLI-created resources when the request is rejected.
- Revert restores the original CV1 plan through the service.

## Commands

```bash
az functionapp flex-migration start \
  --source-name MyFunctionApp \
  --source-resource-group MyResourceGroup \
  --in-place

az functionapp flex-migration revert \
  --source-name MyFunctionApp \
  --source-resource-group MyResourceGroup
```

## Validation

- Azure CLI PR validation: `130/130` tests passed.
- App Service mocked tests: `51 passed`.
- Completed CV1 → Flex → CV1 validation in NCUS Stage.
- Verified package migration, settings, keys, restart, and HTTP execution after upgrade and revert.

---

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).