### PR TITLE
{Compute} Fix #33556: az vm boot-diagnostics get-boot-log: Fix TypeError with azure-mgmt-storage 25.0.0

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -204,7 +204,7 @@ def _get_disk_lun_by_aaz(data_disks):
 def _get_private_config(cli_ctx, resource_group_name, storage_account):
     storage_mgmt_client = _get_storage_management_client(cli_ctx)
     # pylint: disable=no-member
-    keys = storage_mgmt_client.storage_accounts.list_keys(resource_group_name, storage_account).keys
+    keys = storage_mgmt_client.storage_accounts.list_keys(resource_group_name, storage_account).keys_property
 
     private_config = {
         'storageAccountName': storage_account,
@@ -2300,7 +2300,7 @@ def get_boot_log(cmd, resource_group_name, vm_name):
     # Get account key
     keys = storage_mgmt_client.storage_accounts.list_keys(rg, storage_account.name)
 
-    blob_client = BlobClient.from_blob_url(blob_url=blob_uri, credential=keys.keys[0].value)
+    blob_client = BlobClient.from_blob_url(blob_url=blob_uri, credential=keys.keys_property[0].value)
 
     # our streamwriter not seekable, so no parallel.
     downloader = blob_client.download_blob(max_concurrency=1)

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -195,6 +195,48 @@ class TestVMBootLog(unittest.TestCase):
         except ErrorToExitCommandEarly:
             get_sdk_mock.assert_called_with(cli_ctx_mock, ResourceType.DATA_STORAGE_BLOB, '_blob_client#BlobClient')
 
+    @mock.patch('azure.cli.command_modules.vm.custom.BootLogStreamWriter', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom._get_storage_management_client', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_instance_view', autospec=True)
+    @mock.patch('azure.cli.core.profiles.get_sdk', autospec=True)
+    def test_vm_boot_log_uses_keys_property(self, get_sdk_mock, get_instance_view_mock,
+                                            get_storage_client_mock, stream_writer_mock):
+        # azure-mgmt-storage>=25.0.0 renamed the account keys list from `keys` to
+        # `keys_property` (`.keys` now resolves to `MutableMapping.keys`).
+        blob_url = 'https://mystorage.blob.core.windows.net/bootdiagnostics/vm1.serialconsole.log'
+        get_instance_view_mock.return_value = {
+            'instanceView': {
+                'bootDiagnostics': {'serialConsoleLogBlobUri': blob_url}
+            }
+        }
+
+        storage_account = mock.MagicMock()
+        storage_account.primary_endpoints.blob = 'https://mystorage.blob.core.windows.net/'
+        storage_account.id = '/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/mystorage'
+        storage_account.name = 'mystorage'
+
+        storage_key = mock.MagicMock()
+        storage_key.value = 'the-account-key'
+        list_keys_result = mock.MagicMock(spec=['keys_property'])
+        list_keys_result.keys_property = [storage_key]
+
+        storage_client_mock = get_storage_client_mock.return_value
+        storage_client_mock.storage_accounts.list.return_value = [storage_account]
+        storage_client_mock.storage_accounts.list_keys.return_value = list_keys_result
+
+        blob_client_mock = mock.MagicMock()
+        blob_client_class_mock = mock.MagicMock()
+        blob_client_class_mock.from_blob_url.return_value = blob_client_mock
+        get_sdk_mock.return_value = blob_client_class_mock
+
+        cmd_mock = mock.MagicMock()
+        get_boot_log(cmd_mock, 'rg1', 'vm1')
+
+        blob_client_class_mock.from_blob_url.assert_called_once_with(
+            blob_url=blob_url, credential='the-account-key')
+        blob_client_mock.download_blob.assert_called_once_with(max_concurrency=1)
+        blob_client_mock.download_blob.return_value.readinto.assert_called_once()
+
 
 class FakedVM:  # pylint: disable=too-few-public-methods
     def __init__(self, nics=None, disks=None, os_disk=None):


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
`az vm boot-diagnostics get-boot-log`

**Description**
Fixes #33556. `StorageAccountListKeysResult` in `azure-mgmt-storage` 25.0.0 now inherits from `MutableMapping`, so `.keys` resolves to the built-in `dict.keys` method instead of the renamed `keys_property` list. This crashed `get_boot_log` with `TypeError: 'method' object is not subscriptable` when a VM uses a custom (non-managed) storage account for boot diagnostics. Also fixes the same pattern in the unused `_get_private_config` helper.

Related to #33727, which addresses the same root cause but additionally adds a `keys_property`/`keys` fallback for older `azure-mgmt-storage` versions and touches `batchai/custom.py`. Since this repo pins `azure-mgmt-storage==25.0.0` exactly (see `src/azure-cli/setup.py`), that fallback isn't functionally required here, so this PR keeps the fix minimal and scoped to the actual regression.

**Testing Guide**
```
# Unit test (no live resources needed)
python -m pytest src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py -k BootLog -v

# Live smoke-test (VM must use a custom storage account for boot diagnostics)
az vm boot-diagnostics get-boot-log --resource-group <rg> --name <vm-name>
```

**History Notes**
[Compute] `az vm boot-diagnostics get-boot-log`: Fix `TypeError: 'method' object is not subscriptable` when VM uses a custom storage account for boot diagnostics (regression with azure-mgmt-storage 25.0.0)

---

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
