### PR TITLE
[Compute] `az sig image-version create`: Normalize storage type case in target region validation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -2366,7 +2366,7 @@ def process_gallery_image_version_namespace(cmd, namespace):
                 try:
                     replica_count = int(parts[1])   # raises ValueError if this is not a replica count, try other order.
                     storage_account_type = parts[2]
-                    if storage_account_type not in storage_account_types_list:
+                    if storage_account_type.lower() not in storage_account_types_list:
                         raise ArgumentUsageError(
                             "usage error: {} is an invalid target region argument. "
                             "The third part is not a valid storage account type. "
@@ -2499,7 +2499,7 @@ def process_gallery_image_version_namespace(cmd, namespace):
                 try:
                     replica_count = int(parts[2])  # raises ValueError if this is not a replica count, try other order.
                     storage_account_type = parts[3]
-                    if storage_account_type not in storage_account_types_list:
+                    if storage_account_type.lower() not in storage_account_types_list:
                         raise ArgumentUsageError(
                             "usage error: {} is an invalid target edge zone argument. "
                             "The forth part is not a valid storage account type. "

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -2502,7 +2502,7 @@ def process_gallery_image_version_namespace(cmd, namespace):
                     if storage_account_type.lower() not in storage_account_types_list:
                         raise ArgumentUsageError(
                             "usage error: {} is an invalid target edge zone argument. "
-                            "The forth part is not a valid storage account type. "
+                            "The fourth part is not a valid storage account type. "
                             "Storage account types must be one of {}.".format(t, storage_account_types_str))
                 except ValueError:
                     raise ArgumentUsageError(

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -595,6 +595,25 @@ class TestActions(unittest.TestCase):
         self.assertEqual(target_regions_objs[1]["name"], "westus2")
         self.assertEqual(target_regions_objs[1]["storage_account_type"], "Premium_LRS")
 
+        # four-part region=edgeZone=replica=storage_type must accept mixed-case storage types
+        np.target_regions = None
+        np.target_edge_zones = [
+            "westus=microsoftlosangeles1=1=Standard_LRS",
+            "eastus=microsoftlosangeles1=2=Premium_LRS",
+        ]
+        process_gallery_image_version_namespace(cmd, np)
+        target_edge_zone_objs = np.target_edge_zones
+        self.assertEqual(target_edge_zone_objs[0]["name"], "westus")
+        self.assertEqual(target_edge_zone_objs[0]["extended_location"]["name"], "microsoftlosangeles1")
+        self.assertEqual(target_edge_zone_objs[0]["extended_location_replica_count"], 1)
+        self.assertEqual(target_edge_zone_objs[0]["storage_account_type"], "Standard_LRS")
+        self.assertEqual(target_edge_zone_objs[1]["name"], "eastus")
+        self.assertEqual(target_edge_zone_objs[1]["extended_location_replica_count"], 2)
+        self.assertEqual(target_edge_zone_objs[1]["storage_account_type"], "Premium_LRS")
+
+        # restore target_regions for the remaining invalid-input cases
+        np.target_edge_zones = None
+
         # handle invalid storage account / replica count
         with self.assertRaises(CLIError):
             target_regions_list = ["westus=f"]

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -583,6 +583,18 @@ class TestActions(unittest.TestCase):
         self.assertEqual(target_regions_objs[3]["regional_replica_count"], 2)
         self.assertEqual(target_regions_objs[3]["storage_account_type"], "standard_lrs")
 
+        # three-part region=replica=storage_type must accept mixed-case storage types
+        # the same way the two-part region=storage_type form does
+        target_regions_list = ["southeastasia=1=Standard_LRS", "westus2=Premium_LRS"]
+        np.target_regions = target_regions_list
+        process_gallery_image_version_namespace(cmd, np)
+        target_regions_objs = np.target_regions
+        self.assertEqual(target_regions_objs[0]["name"], "southeastasia")
+        self.assertEqual(target_regions_objs[0]["regional_replica_count"], 1)
+        self.assertEqual(target_regions_objs[0]["storage_account_type"], "Standard_LRS")
+        self.assertEqual(target_regions_objs[1]["name"], "westus2")
+        self.assertEqual(target_regions_objs[1]["storage_account_type"], "Premium_LRS")
+
         # handle invalid storage account / replica count
         with self.assertRaises(CLIError):
             target_regions_list = ["westus=f"]


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

`az sig image-version create --target-regions` validated storage account types case-insensitively for the two-part form (`region=Standard_LRS`) but case-sensitively for the three-part form (`region=1=Standard_LRS`).

This compares with `.lower()` in the three-part path, matching the two-part path, and applies the same fix to the four-part `--target-edge-zones` validator. A unit test covers mixed-case three-part and two-part values.

Fixes #33880

## Test plan

1. `python -m unittest azure.cli.command_modules.vm.tests.latest.test_vm_actions.TestVMImage.test_process_gallery_image_version_namespace` (or the local test module equivalent)
2. Confirm `southeastasia=1=Standard_LRS` no longer fails local validation