### PR TITLE
{Util} `az rest`: Correct indefinite article in AAD Graph help example

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/util/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/util/_help.py
@@ -26,7 +26,7 @@ examples:
 - name: Get Audit log through Microsoft Graph
   text: >
       az rest --method get --url https://graph.microsoft.com/beta/auditLogs/directoryAudits
-- name: Update a Azure Active Directory Graph User's display name
+- name: Update an Azure Active Directory Graph User's display name
   text: |
       (Bash or CMD)
       az rest --method patch --url "https://graph.microsoft.com/v1.0/users/johndoe@azuresdkteam.onmicrosoft.com" --body "{\\"displayName\\": \\"johndoe2\\"}"


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary
Fixes #27937

Updates the `az rest` help example name from `a Azure Active Directory` to `an Azure Active Directory`.

## Test plan
* [ ] Confirm `az rest -h` shows the corrected example name
* [ ] Confirm no other help text changed