### PR TITLE
[App Config] Sanitize resource group name in data-plane test recordings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py
@@ -6,9 +6,9 @@
 import json
 import os
 
+from azure.cli.testsdk import ResourceGroupPreparer
 from azure.cli.testsdk.scenario_tests import RecordingProcessor
 from azure.cli.testsdk.scenario_tests.utilities import is_json_payload
-from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.core.util import shell_safe_json_parse
 
 def create_config_store(test, kwargs, disable_local_auth=False):
@@ -30,21 +30,23 @@ def get_resource_name_prefix(prefix):
     return prefix if resource_prefix is None else resource_prefix + prefix
 
 # Value the reused live test resource group (AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME) is rewritten to
-# in recordings by ResourceGroupNameReplacer, and returned by get_test_resource_group() during
-# playback so requests match the sanitized cassettes. Matches the default ResourceGroupPreparer() moniker.
+# in recordings by ResourceGroupNameReplacer. Matches the default ResourceGroupPreparer() moniker.
 SANITIZED_TEST_RESOURCE_GROUP = "clitest.rg000001"
 
-def get_test_resource_group():
-    resource_group = os.environ.get("AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME")
-    if resource_group:
-        return resource_group
-    # The stub only exists inside sanitized recordings; a live run needs a real group where the
-    # recording principal holds "App Configuration Data Owner".
-    if os.environ.get("AZURE_TEST_RUN_LIVE"):
-        raise CliTestError(
-            "Set AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a resource group where you hold "
-            "'App Configuration Data Owner' to record App Configuration data-plane tests.")
-    return SANITIZED_TEST_RESOURCE_GROUP
+
+class AppConfigResourceGroupPreparer(ResourceGroupPreparer):
+    """ ResourceGroupPreparer that keeps moniker numbering aligned when reusing a dev resource group.
+
+    In dev-setting mode the base preparer returns early without calling live_only_execute, so it never
+    advances test_resources_count during recording the way it does in playback. That would desync
+    create_random_name numbering (e.g. store000001 vs store000002) between recording and playback, so
+    touch the moniker here to consume the same counter slot in both modes.
+    """
+
+    def create_resource(self, name, **kwargs):
+        if self.dev_setting_name:
+            _ = self.moniker
+        return super().create_resource(name, **kwargs)
 
 
 def _case_insensitive_query_matcher(r1, r2):
@@ -101,8 +103,8 @@ class ResourceGroupNameReplacer(RecordingProcessor):
     """ Scrub the reused live test resource group name from recordings.
 
     Data-plane tests reuse a pre-provisioned resource group (AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME)
-    that holds a standing "App Configuration Data Owner" role. That name is never registered with the
-    base name-replacer, so rewrite it to the value get_test_resource_group() returns during playback.
+    that holds a standing "App Configuration Data Owner" role. ResourceGroupPreparer does not sanitize
+    a dev-setting resource group, so rewrite it to the moniker ResourceGroupPreparer uses in playback.
     """
 
     def __init__(self):

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/_test_utils.py
@@ -8,6 +8,7 @@ import os
 
 from azure.cli.testsdk.scenario_tests import RecordingProcessor
 from azure.cli.testsdk.scenario_tests.utilities import is_json_payload
+from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.core.util import shell_safe_json_parse
 
 def create_config_store(test, kwargs, disable_local_auth=False):
@@ -28,12 +29,22 @@ def get_resource_name_prefix(prefix):
     resource_prefix = _get_local_test_resource_prefix()
     return prefix if resource_prefix is None else resource_prefix + prefix
 
+# Value the reused live test resource group (AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME) is rewritten to
+# in recordings by ResourceGroupNameReplacer, and returned by get_test_resource_group() during
+# playback so requests match the sanitized cassettes. Matches the default ResourceGroupPreparer() moniker.
+SANITIZED_TEST_RESOURCE_GROUP = "clitest.rg000001"
+
 def get_test_resource_group():
-    # Data-plane tests use Microsoft Entra ID (--auth-mode login) against a store whose local auth
-    # is disabled. The recording principal must already hold "App Configuration Data Owner" at a
-    # scope covering the store, so tests target a fixed resource group with that standing role
-    # instead of an ephemeral @ResourceGroupPreparer group. Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    return os.environ.get("AZURE_CLI_APPCONFIG_TEST_RG", "mametcal-python")
+    resource_group = os.environ.get("AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME")
+    if resource_group:
+        return resource_group
+    # The stub only exists inside sanitized recordings; a live run needs a real group where the
+    # recording principal holds "App Configuration Data Owner".
+    if os.environ.get("AZURE_TEST_RUN_LIVE"):
+        raise CliTestError(
+            "Set AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a resource group where you hold "
+            "'App Configuration Data Owner' to record App Configuration data-plane tests.")
+    return SANITIZED_TEST_RESOURCE_GROUP
 
 
 def _case_insensitive_query_matcher(r1, r2):
@@ -86,9 +97,43 @@ class OperationLocationSanitizer(RecordingProcessor):
         return response
 
 
+class ResourceGroupNameReplacer(RecordingProcessor):
+    """ Scrub the reused live test resource group name from recordings.
+
+    Data-plane tests reuse a pre-provisioned resource group (AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME)
+    that holds a standing "App Configuration Data Owner" role. That name is never registered with the
+    base name-replacer, so rewrite it to the value get_test_resource_group() returns during playback.
+    """
+
+    def __init__(self):
+        self._real_rg = os.environ.get("AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME")
+
+    def _scrub(self, value):
+        if self._real_rg and value:
+            return value.replace(self._real_rg, SANITIZED_TEST_RESOURCE_GROUP)
+        return value
+
+    def process_request(self, request):
+        request.uri = self._scrub(request.uri)
+        if isinstance(request.body, bytes):
+            try:
+                request.body = self._scrub(request.body.decode('utf-8')).encode('utf-8')
+            except UnicodeDecodeError:
+                pass
+        elif request.body:
+            request.body = self._scrub(request.body)
+        return request
+
+    def process_response(self, response):
+        if response.get('body', {}).get('string'):
+            response['body']['string'] = self._scrub(response['body']['string'])
+        return response
+
+
 def register_appconfig_recording_processors(test):
     """ Register App Configuration-specific recording processors on the test. """
     test.recording_processors.append(OperationLocationSanitizer(test.name_replacer))
+    test.recording_processors.append(ResourceGroupNameReplacer())
 
 class CredentialResponseSanitizer(RecordingProcessor):
     def process_response(self, response):

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_appconfig_to_appconfig_import_export.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_appconfig_to_appconfig_import_export.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
         "name": "source000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:58:09+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:58:09+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001",
+        "User", "lastModifiedAt": "2026-07-15T17:58:09+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
         "name": "source000001", "tags": {}}'
     headers:
       cache-control:
@@ -351,7 +351,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -360,7 +360,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
         "name": "destination000002", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -618,7 +618,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -631,7 +631,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:58:46+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:58:46+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
+        "User", "lastModifiedAt": "2026-07-15T17:58:46+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
         "name": "destination000002", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_appconfig_to_appconfig_import_export.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_appconfig_to_appconfig_import_export.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
-        "name": "source000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002",
+        "name": "source000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.ZhckdA_vLeiQGuEcvedp6FlTffDBCZOjBK_Y6Xa_WI4?api-version=2025-08-01-preview&t=639197350894010544&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=jYEm0A1proMec3T-RdmpYTBzRUcRqtMR1UqBwA00i9Fzxi9mkAQ3AhRZ7lOjlhf1-IcBygKf0AbY18TphGkpV7793lUKf7IR9oCu7_t_m5DEDOwSCBNVsL0y6wkdKwvzlaAxcVgRnkReLLZn5LHI87QinK3XkITI2UTNM4nYWwxMXu6woTOzhzyQOk1r-N0yYTD2Msi_rZDHxNg9VWBSTxSk0ACSDH4zQzulaajC7_6YUiPuhhcx2V1TJBIH6fjarMEDygw3rKQ9P0q5ydFj-l4htArM5CDKCga9GL78LT_ILR6-dgmUmg4hEL-jjHEGWaulEwEC11YFWd9c5NhsDA&h=90cG0e2WwzCxWnjmKAZYLm5LYpg5YgVkIo8ljoaCxiw
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:58:09+00:00", "endpoint": "https://source000001.azconfig.io",
+        "2026-07-15T17:58:09+00:00", "endpoint": "https://source000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:58:09+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:58:09+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
-        "name": "source000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:58:09+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002",
+        "name": "source000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -351,7 +351,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -360,8 +360,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
-        "name": "destination000002", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003",
+        "name": "destination000003", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.vzlzv8ifr3nZ3AH-t4AEipfSVfreMgSw07NkuGzSaGw?api-version=2025-08-01-preview&t=639197351271203645&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=GnlHVhqS07Tc2_1lMtYOP7A31riF38gWPHjIEL3npZcWpRsWIabCBB7GV28k-DWfx8KvzRZkYz9IjqLKq8GvMOtWnmQUJZfDdkHgaAtBG5ZeMm6XUaAxYFDHiqL3qWzpR_SG9i43Kw5CqR1jOMEJC8ey0XwOHWLSfJ0sx0pcAu-RMKCWWtZBiD08sQX6S4nmUD95pWr76fhvZqHSEErPPekpGVSq2TBPg62vnCZDT76-3abm54BfxgYaLIMgk2ICX9lZOcIhuEuVq8Vtu2Jo7sx5JSqE77sYMARy__zfJbvsDUHgaiYhUoiBndHEOK26uXA98C0KZq1jGiYBjIBv6w&h=_3DSeWnXPC1NiWrdlP3Buv942p2WOgKzDehNSIEW5Bc
@@ -618,12 +618,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:58:46+00:00", "endpoint": "https://destination000002.azconfig.io",
+        "2026-07-15T17:58:46+00:00", "endpoint": "https://destination000003.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -631,8 +631,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:58:46+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:58:46+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
-        "name": "destination000002", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:58:46+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003",
+        "name": "destination000003", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -674,7 +674,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
+    uri: https://source000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
   response:
     body:
       string: ''
@@ -717,7 +717,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
+    uri: https://source000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"EMd_98ajNDRDOcPG1qxI-6nH03A-3lIvW8SawUU8yaA","key":"Color","label":"v1","content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:25+00:00"}'
@@ -758,7 +758,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
+    uri: https://source000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
   response:
     body:
       string: ''
@@ -801,7 +801,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
+    uri: https://source000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"k5BTS_C9ihpOXZ5igXmz9wegerXKEQ5Ck03vQ9HQO1g","key":"Color","label":"v2","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:26+00:00"}'
@@ -842,7 +842,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: ''
@@ -888,7 +888,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -931,7 +931,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: ''
@@ -977,7 +977,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"BkIZFwYOd6kRDYWJ7xnPQemKsHqMJmcKady2FARikdE","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1020,7 +1020,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
   response:
     body:
       string: '{"etag":"L-oNVk_mxRlAPTOzMYMqfw2x_F8jLiSruqufZeMZNKo","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1065,7 +1065,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"WfYC9VaxlL6e2-oGNwT2GcjGat19SneiBH7YFtNm-u4","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1108,7 +1108,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=DestLabel
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1149,7 +1149,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DestLabel
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1195,7 +1195,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"zrVkj-c_d72sz8icqV1oyjbtdfIPx7Ry9h17zvZCoy8","key":"Color","label":"DestLabel","content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:35+00:00"}'
@@ -1243,7 +1243,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"2ytK2cbiOxlobipsp0ibh_zDlDX5ZbPaR4HB5jwZQ_Y","key":"Color","label":"DestLabel","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:35+00:00"}'
@@ -1293,7 +1293,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"qhEt3zQ3IaeY_HDz6bv6fBynoD_uvbcpwqDZS_hYGTE","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1345,7 +1345,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"zXSy_Vnl5OPkWxCGmaWijykI4k3CxG4fdu-nO-2MLMA","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1397,7 +1397,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"V8GZQ0suiCAF0EfG3LjONHTBp_LkpQEG-r14tUmAKlI","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1449,7 +1449,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"gQ6p7XsOfBnyubOa1L63_PdmGYef6aqGvFWt4Q8Z-rc","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1492,7 +1492,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"57nLICQ7zge30I-he3EgNESe4X-u2k3SBrTxPkQLtKA","items":[{"etag":"gQ6p7XsOfBnyubOa1L63_PdmGYef6aqGvFWt4Q8Z-rc","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1539,7 +1539,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"gQ6p7XsOfBnyubOa1L63_PdmGYef6aqGvFWt4Q8Z-rc","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1588,7 +1588,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"2ytK2cbiOxlobipsp0ibh_zDlDX5ZbPaR4HB5jwZQ_Y","key":"Color","label":"DestLabel","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:35+00:00"}'
@@ -1629,7 +1629,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
   response:
     body:
       string: '{"etag":"L-oNVk_mxRlAPTOzMYMqfw2x_F8jLiSruqufZeMZNKo","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1674,7 +1674,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"WfYC9VaxlL6e2-oGNwT2GcjGat19SneiBH7YFtNm-u4","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1717,7 +1717,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1758,7 +1758,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1804,7 +1804,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_ERHdsk9nSE4CE4j36RnbahZLVdjDkcQp6yrqYIU2LE","key":"Color","label":null,"content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:45+00:00"}'
@@ -1852,7 +1852,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Ylggi7-JJAYIufFRhtMOf_a5fnSA5wknEX1eFUcI2Tw","key":"Color","label":null,"content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:46+00:00"}'
@@ -1902,7 +1902,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"8cXu1vVHC02poklBvlMRNszm9q6K1pOfQn9ieDtQJ7E","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1954,7 +1954,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"MD7NJiqgJCWQadbSXGIiw0vj3nxGAzm2hd_HecTS_xE","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2006,7 +2006,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"ria_Cu6gTZ4_3XEPhZrJfTPiOeBxa1PciM9zbnDPVVA","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2058,7 +2058,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"bwoF8TIdft4qziGcDZeU4SpTesFBWGkWYn8m-UNBJvo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2101,7 +2101,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"rP5W73u__M76MbuLtraQWJNqe0MUyfMhz-W81RLTw0g","items":[{"etag":"bwoF8TIdft4qziGcDZeU4SpTesFBWGkWYn8m-UNBJvo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2148,7 +2148,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"bwoF8TIdft4qziGcDZeU4SpTesFBWGkWYn8m-UNBJvo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2197,7 +2197,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Ylggi7-JJAYIufFRhtMOf_a5fnSA5wknEX1eFUcI2Tw","key":"Color","label":null,"content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:46+00:00"}'
@@ -2238,7 +2238,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
   response:
     body:
       string: '{"etag":"L-oNVk_mxRlAPTOzMYMqfw2x_F8jLiSruqufZeMZNKo","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2283,7 +2283,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"WfYC9VaxlL6e2-oGNwT2GcjGat19SneiBH7YFtNm-u4","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2326,7 +2326,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2367,7 +2367,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2413,7 +2413,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"gR_8bNvHTfqI4p5tCtZg4A2m_TSSRiLDfp6Tme5Okss","key":"Color","label":"v1","content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:56+00:00"}'
@@ -2461,7 +2461,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"GD0CUvf1rmqkRHrekMwT7xGEWN7q0EV9ZEPKIZk5xlY","key":"Color","label":"v2","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:57+00:00"}'
@@ -2511,7 +2511,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"Xppl-6EL8czae8hRxaZC4jcR274n6uIHj-l3KeK3KVQ","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2563,7 +2563,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"uOIH2LltDRZYTUyOifdOReFkaWVpkiFWLY4xoxG8uL4","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2615,7 +2615,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"OG0T9-OP00hihVY5E-HrjSIyccsDg1GsPIzVj008398","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2667,7 +2667,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"iqHa3I4kjnt5Fzc-DurKw9RaXsBIQ9LCgjYp7TiPhes","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2710,7 +2710,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"g8i8y3asbABwFyM4FffKZLBmeWAljLF-1AfQSnxijAM","items":[{"etag":"OG0T9-OP00hihVY5E-HrjSIyccsDg1GsPIzVj008398","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2759,7 +2759,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"OG0T9-OP00hihVY5E-HrjSIyccsDg1GsPIzVj008398","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2808,7 +2808,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"iqHa3I4kjnt5Fzc-DurKw9RaXsBIQ9LCgjYp7TiPhes","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2857,7 +2857,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"gR_8bNvHTfqI4p5tCtZg4A2m_TSSRiLDfp6Tme5Okss","key":"Color","label":"v1","content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:56+00:00"}'
@@ -2904,7 +2904,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"GD0CUvf1rmqkRHrekMwT7xGEWN7q0EV9ZEPKIZk5xlY","key":"Color","label":"v2","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:59:57+00:00"}'
@@ -2945,7 +2945,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
   response:
     body:
       string: '{"etag":"L-oNVk_mxRlAPTOzMYMqfw2x_F8jLiSruqufZeMZNKo","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2988,7 +2988,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"WfYC9VaxlL6e2-oGNwT2GcjGat19SneiBH7YFtNm-u4","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3031,7 +3031,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=DestLabel
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3070,7 +3070,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DestLabel
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3116,7 +3116,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"7iiUeF_fRzWaIAT_cUHPQNG2WEE1g4lpzRG0DGpLJs0","key":"Color","label":"DestLabel","content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:10+00:00"}'
@@ -3164,7 +3164,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"_yqtadyaMHVUxpNdgsm419fVzSey8p7KMT5ESB_jPiw","key":"Color","label":"DestLabel","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:10+00:00"}'
@@ -3214,7 +3214,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"LkE1DTqB1cOySSjby_zwkgdzucS5MOTJGJP6FCOxW38","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3266,7 +3266,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"qElmBIRJm73WHO3FdFfqBMoMMgTqaT_0-PTqcellZkc","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3309,7 +3309,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"VucyVWXBWHGvrqHcUWVhqSvuwdWwiMhdQfWoIxSlWPs","items":[{"etag":"qElmBIRJm73WHO3FdFfqBMoMMgTqaT_0-PTqcellZkc","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3356,7 +3356,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"qElmBIRJm73WHO3FdFfqBMoMMgTqaT_0-PTqcellZkc","key":".appconfig.featureflag/Beta","label":"DestLabel","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3405,7 +3405,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=DestLabel
   response:
     body:
       string: '{"etag":"_yqtadyaMHVUxpNdgsm419fVzSey8p7KMT5ESB_jPiw","key":"Color","label":"DestLabel","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:10+00:00"}'
@@ -3446,7 +3446,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
   response:
     body:
       string: '{"etag":"L-oNVk_mxRlAPTOzMYMqfw2x_F8jLiSruqufZeMZNKo","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3489,7 +3489,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"WfYC9VaxlL6e2-oGNwT2GcjGat19SneiBH7YFtNm-u4","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3532,7 +3532,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3571,7 +3571,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3617,7 +3617,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"o7pn-cpPAKtbBFVfpHct8VzaYXOffLr46IIbN0Kp41g","key":"Color","label":null,"content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:19+00:00"}'
@@ -3665,7 +3665,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"BSF1PBr8_x0I0v80SJ5k39Cfv4kqlW2OuBmiYNGZHlk","key":"Color","label":null,"content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:20+00:00"}'
@@ -3715,7 +3715,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"qZxI1ToimzldCDluQm5i-78vF8SlpeCXqaySHQbBaB4","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3767,7 +3767,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"gWfsnQ8kLgK6eoqYFpGXhqY9xm-TSLrZv6-su0m-iXM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3810,7 +3810,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"aGksUvc4mULdAiUSXwYOszMSALLNtqLoPA1h_5DM7Gc","items":[{"etag":"gWfsnQ8kLgK6eoqYFpGXhqY9xm-TSLrZv6-su0m-iXM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3857,7 +3857,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"gWfsnQ8kLgK6eoqYFpGXhqY9xm-TSLrZv6-su0m-iXM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3906,7 +3906,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"BSF1PBr8_x0I0v80SJ5k39Cfv4kqlW2OuBmiYNGZHlk","key":"Color","label":null,"content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:20+00:00"}'
@@ -3947,7 +3947,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%2A
   response:
     body:
       string: '{"etag":"L-oNVk_mxRlAPTOzMYMqfw2x_F8jLiSruqufZeMZNKo","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3990,7 +3990,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"WfYC9VaxlL6e2-oGNwT2GcjGat19SneiBH7YFtNm-u4","items":[{"etag":"yR9Gu2WaJLklcqFZ8h2_joIoYXu3s28RY_SfuQGnaa8","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4033,7 +4033,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4072,7 +4072,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4118,7 +4118,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"nPpkG35yORPHb22eezOqN1M5b6YsaootgToCbii-Z1s","key":"Color","label":"v1","content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:30+00:00"}'
@@ -4166,7 +4166,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"KWzU7MA0WxSpBpS22bggvOPQ64ym2-HUqaq8Ih76Q10","key":"Color","label":"v2","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:31+00:00"}'
@@ -4216,7 +4216,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"rUMs0RSOzjY9rW6AV9qYFp8axlKNWgSt_pe352CDmio","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4268,7 +4268,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"vcO20a8WXyUp7d9ZjJ0Yppj9t90CazBF1VISiGOy0GM","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4311,7 +4311,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"pN1k4vJ_beeNITT1rjkfpcHS3pkWrga5_KH35HorF9E","items":[{"etag":"rUMs0RSOzjY9rW6AV9qYFp8axlKNWgSt_pe352CDmio","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4360,7 +4360,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"rUMs0RSOzjY9rW6AV9qYFp8axlKNWgSt_pe352CDmio","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4409,7 +4409,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"vcO20a8WXyUp7d9ZjJ0Yppj9t90CazBF1VISiGOy0GM","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4458,7 +4458,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"nPpkG35yORPHb22eezOqN1M5b6YsaootgToCbii-Z1s","key":"Color","label":"v1","content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:30+00:00"}'
@@ -4505,7 +4505,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
+    uri: https://destination000003.azconfig.io/kv/Color?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"KWzU7MA0WxSpBpS22bggvOPQ64ym2-HUqaq8Ih76Q10","key":"Color","label":"v2","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:31+00:00"}'
@@ -4546,7 +4546,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/TagTestKey?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -4590,7 +4590,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/TagTestKey?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"yLnxqtyI_J7kGtE3HjUejgO0LV2s4Z8NuH2j90NufqE","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag1":"value1","tag2":"value2"},"locked":false,"last_modified":"2026-07-15T18:00:38+00:00"}'
@@ -4631,7 +4631,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/TagTestKey?api-version=2023-11-01&label=LabelWithoutTags
+    uri: https://source000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01&label=LabelWithoutTags
   response:
     body:
       string: ''
@@ -4675,7 +4675,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/TagTestKey?api-version=2023-11-01&label=LabelWithoutTags
+    uri: https://source000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01&label=LabelWithoutTags
   response:
     body:
       string: '{"etag":"_zLwqJ7vniBFV9-FCxSqWRNt9V4Ax-JY2YOf14JIe_Y","key":"TagTestKey","label":"LabelWithoutTags","content_type":"","value":"Blue","tags":{},"locked":false,"last_modified":"2026-07-15T18:00:39+00:00"}'
@@ -4716,7 +4716,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
   response:
     body:
       string: '{"etag":"aRjbSDmIHotw6L0L8mnFqyrgrwg1KYkf7KkUyaB12yk","items":[{"etag":"yLnxqtyI_J7kGtE3HjUejgO0LV2s4Z8NuH2j90NufqE","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag1":"value1","tag2":"value2"},"locked":false,"last_modified":"2026-07-15T18:00:38+00:00"}]}'
@@ -4755,7 +4755,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4794,7 +4794,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4833,7 +4833,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4879,7 +4879,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/TagTestKey?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HI7crc3h70I6Lb6zFeVZWOpUGoyMcB05hgJSbflVXxw","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag3":"value3"},"locked":false,"last_modified":"2026-07-15T18:00:43+00:00"}'
@@ -4920,7 +4920,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag3%3Dvalue3
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag3%3Dvalue3
   response:
     body:
       string: '{"etag":"yQs6ANId4oMkgCFs9IhhklZzLQjmIRzuIvq73Tpg5gg","items":[{"etag":"HI7crc3h70I6Lb6zFeVZWOpUGoyMcB05hgJSbflVXxw","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag3":"value3"},"locked":false,"last_modified":"2026-07-15T18:00:43+00:00"}]}'
@@ -4965,7 +4965,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/TagTestKey?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HI7crc3h70I6Lb6zFeVZWOpUGoyMcB05hgJSbflVXxw","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag3":"value3"},"locked":false,"last_modified":"2026-07-15T18:00:43+00:00"}'
@@ -5006,7 +5006,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
   response:
     body:
       string: '{"etag":"aRjbSDmIHotw6L0L8mnFqyrgrwg1KYkf7KkUyaB12yk","items":[{"etag":"yLnxqtyI_J7kGtE3HjUejgO0LV2s4Z8NuH2j90NufqE","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag1":"value1","tag2":"value2"},"locked":false,"last_modified":"2026-07-15T18:00:38+00:00"}]}'
@@ -5047,7 +5047,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -5086,7 +5086,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -5132,7 +5132,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/TagTestKey?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"VWImE-x1TfhIMzEvTibL04NtMLg5e2Px7sP-a_rTtsk","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag3":"value3"},"locked":false,"last_modified":"2026-07-15T18:00:48+00:00"}'
@@ -5173,7 +5173,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag3%3Dvalue3
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=TagTestKey&label=%00&tags=tag3%3Dvalue3
   response:
     body:
       string: '{"etag":"PkzxCrZkhRtLrGS5kb7ks8fozYW8wNbDkQ9Uys4ohf4","items":[{"etag":"VWImE-x1TfhIMzEvTibL04NtMLg5e2Px7sP-a_rTtsk","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag3":"value3"},"locked":false,"last_modified":"2026-07-15T18:00:48+00:00"}]}'
@@ -5218,7 +5218,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/TagTestKey?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/TagTestKey?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"VWImE-x1TfhIMzEvTibL04NtMLg5e2Px7sP-a_rTtsk","key":"TagTestKey","label":null,"content_type":"","value":"Blue","tags":{"tag3":"value3"},"locked":false,"last_modified":"2026-07-15T18:00:48+00:00"}'

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001",
-        "name": "featuretest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000002",
+        "name": "featuretest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.bBu-ILxA3m3R7CKLsm2mAmLyg3uAkVdDUEvDd5bYY30?api-version=2025-08-01-preview&t=639197346167728344&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=am6P6DPvK7cncpo1r91jRykBtjuje0j9tiXc6TOE0xmd-Xn0fyItvlu-RvVmXWnGQCc0zMNnRwQD9SU9eO0txPKLf2i8F7vAcc0LtqR1KMLCrAOEngCI4b24wRqb89gBIAru6vVMC19gVruRb67-EMdT7dyfYkuf7NxzabrCmMvgtkZwKPAMi-zFN4wHa46EQFTFh2Gwlh2QcGkQfycLEzxMOhiZDfTKG8RVyRAKuJ3PpEh52bVBkf1kvjbWHX177i0Yh7Heg4BZd1XH9zun6HCZu9VT2Ejz2XcYfpm61C6DiJr68N4MpPLaI62Br_TFBp2cSpe1RVPc9bMKL64N2g&h=aL-Ijv6apP01yNPff1eu5grcQKyL5sqyNv3JS9Ue1Kk
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest000001.azconfig.io",
+        "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:50:16+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001",
-        "name": "featuretest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000002",
+        "name": "featuretest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: ''
@@ -390,7 +390,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"zezVAuAJj0ob_-F2SHvpbwYlLNwKPTfQf3slmNJAn84","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -433,7 +433,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"zezVAuAJj0ob_-F2SHvpbwYlLNwKPTfQf3slmNJAn84","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -488,7 +488,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"lN66Q106R4DTcGqFFa1NuqAn4WciuNB6rvsekzYz5J4","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -531,7 +531,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"lN66Q106R4DTcGqFFa1NuqAn4WciuNB6rvsekzYz5J4","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -586,7 +586,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"PrPgqiP4fgPsJrwXF_3F8dQE-o8XSungmlCVVAU6AiY","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -629,7 +629,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: ''
@@ -675,7 +675,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"SJEwQBhc4bglcGYQtou6LExVdVmtDkfs77U7E_q2iW8","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -718,7 +718,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"SJEwQBhc4bglcGYQtou6LExVdVmtDkfs77U7E_q2iW8","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -772,7 +772,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"_tKtqOFUBEabd7PF4KZKVxRx_emMxJbrZ4YkdrjpgLI","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -815,7 +815,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"_tKtqOFUBEabd7PF4KZKVxRx_emMxJbrZ4YkdrjpgLI","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -858,7 +858,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"_tKtqOFUBEabd7PF4KZKVxRx_emMxJbrZ4YkdrjpgLI","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -901,7 +901,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -940,7 +940,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"dtKjKHQpSEGGYf71pZDZd0DPptZbdZJYxVZ197zifc4","items":[{"etag":"PrPgqiP4fgPsJrwXF_3F8dQE-o8XSungmlCVVAU6AiY","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -983,7 +983,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"dtKjKHQpSEGGYf71pZDZd0DPptZbdZJYxVZ197zifc4","items":[{"etag":"PrPgqiP4fgPsJrwXF_3F8dQE-o8XSungmlCVVAU6AiY","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1026,7 +1026,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBetaPrefix?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBetaPrefix?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1072,7 +1072,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBetaPrefix?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBetaPrefix?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"0GUJc7pcfqqAgerV4chLv_y0vjJMcr48TkcQ7BL13AY","key":".appconfig.featureflag/BetaPrefix","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1115,7 +1115,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FSuffixBeta?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FSuffixBeta?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1161,7 +1161,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FSuffixBeta?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FSuffixBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dkjVfz2z6TWSwWTsWJPfgEGhNo1n5BHyh__Pcxd6ZJM","key":".appconfig.featureflag/SuffixBeta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1204,7 +1204,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1250,7 +1250,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"rM0Y6Mnia263OV44lhgPqR-Kg4YULyvzLx969WsEaDE","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1293,7 +1293,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"jA6oWUtxXH3c68roaLC8aeKAFC6T_kK1DqsLSQ8RfPw","items":[{"etag":"PrPgqiP4fgPsJrwXF_3F8dQE-o8XSungmlCVVAU6AiY","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1342,7 +1342,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2A&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2A&label=%2A
   response:
     body:
       string: '{"etag":"_SJXq2HJv563yVe24ud1SPWEv0uc2orJL2tChqFOLZs","items":[{"etag":"PrPgqiP4fgPsJrwXF_3F8dQE-o8XSungmlCVVAU6AiY","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1387,7 +1387,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2A&label=%00
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2A&label=%00
   response:
     body:
       string: '{"etag":"6jA0y_TVJhwdL9Ee5clYH6qr9RQL6wHTazTJ509jq00","items":[{"etag":"0GUJc7pcfqqAgerV4chLv_y0vjJMcr48TkcQ7BL13AY","key":".appconfig.featureflag/BetaPrefix","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1428,7 +1428,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2Aion&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2Aion&label=%2A
   response:
     body:
       string: '{"type":"https://azconfig.io/errors/invalid-argument","title":"Invalid
@@ -1464,7 +1464,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2ABeta&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2ABeta&label=%2A
   response:
     body:
       string: '{"type":"https://azconfig.io/errors/invalid-argument","title":"Invalid
@@ -1500,7 +1500,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2A%2A&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta%2A%2A&label=%2A
   response:
     body:
       string: '{"type":"https://azconfig.io/errors/invalid-argument","title":"Invalid
@@ -1536,7 +1536,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: ''
@@ -1583,7 +1583,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"DqATUxSrunzudQZeHZJvLQODI8mHs4WoDCS0LLt3S5w","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithTags","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1626,7 +1626,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2&tags=tag3%3Dvalue3&tags=tag4%3Dvalue4&tags=tag5%3Dvalue5
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2&tags=tag3%3Dvalue3&tags=tag4%3Dvalue4&tags=tag5%3Dvalue5
   response:
     body:
       string: '{"etag":"oZXu0g-7iIo-X2LjdfZ4x1fuHPuAZQXTXOzeufn2rKY","items":[{"etag":"DqATUxSrunzudQZeHZJvLQODI8mHs4WoDCS0LLt3S5w","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithTags","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1667,7 +1667,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: ''
@@ -1713,7 +1713,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: '{"etag":"3eDpO37j_DszrrnDoHCPTz7rloE0a7MQ9BdzUHxeZ0M","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithTag1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1756,7 +1756,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3Dvalue1
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3Dvalue1
   response:
     body:
       string: '{"etag":"0onGwcjazmj-MeIQbXpYAeDXvJ0cR_QMKdL1QnQQRlY","items":[{"etag":"3eDpO37j_DszrrnDoHCPTz7rloE0a7MQ9BdzUHxeZ0M","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithTag1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1799,7 +1799,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
   response:
     body:
       string: ''
@@ -1845,7 +1845,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
   response:
     body:
       string: '{"etag":"TtoV-VefclrqC4_fSbbmmfJOoce31IO7jyrbo4Mh9m4","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithEmptyTagValue","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1888,7 +1888,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3D
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3D
   response:
     body:
       string: '{"etag":"wmnVk6wWsZGR-e59DU-tz8sv7eICRjHOPeOXwqVfZpc","items":[{"etag":"TtoV-VefclrqC4_fSbbmmfJOoce31IO7jyrbo4Mh9m4","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithEmptyTagValue","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1929,7 +1929,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A
   response:
     body:
       string: '{"etag":"k_YIVVwCz44Y-wKfdFe6mRAhCWj6Q8Zc6bBsaq804pE","items":[{"etag":"TtoV-VefclrqC4_fSbbmmfJOoce31IO7jyrbo4Mh9m4","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithEmptyTagValue","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1974,7 +1974,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3Dvalue1
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=%2A&tags=tag1%3Dvalue1
   response:
     body:
       string: '{"etag":"0onGwcjazmj-MeIQbXpYAeDXvJ0cR_QMKdL1QnQQRlY","items":[{"etag":"3eDpO37j_DszrrnDoHCPTz7rloE0a7MQ9BdzUHxeZ0M","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithTag1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2023,7 +2023,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: '{"etag":"3eDpO37j_DszrrnDoHCPTz7rloE0a7MQ9BdzUHxeZ0M","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithTag1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2072,7 +2072,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"DqATUxSrunzudQZeHZJvLQODI8mHs4WoDCS0LLt3S5w","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithTags","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2115,7 +2115,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=labelWithEmptyTagValue&tags=tag1%3D
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FFeatureWithTags&label=labelWithEmptyTagValue&tags=tag1%3D
   response:
     body:
       string: '{"etag":"wmnVk6wWsZGR-e59DU-tz8sv7eICRjHOPeOXwqVfZpc","items":[{"etag":"TtoV-VefclrqC4_fSbbmmfJOoce31IO7jyrbo4Mh9m4","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithEmptyTagValue","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2162,7 +2162,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
   response:
     body:
       string: '{"etag":"TtoV-VefclrqC4_fSbbmmfJOoce31IO7jyrbo4Mh9m4","key":".appconfig.featureflag/FeatureWithTags","label":"labelWithEmptyTagValue","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2205,7 +2205,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta&label=v2
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FBeta&label=v2
   response:
     body:
       string: '{"etag":"feDfWEr120oci6QIaTE7RILdugQ1T2QGp-JjID1BxCs","items":[{"etag":"_tKtqOFUBEabd7PF4KZKVxRx_emMxJbrZ4YkdrjpgLI","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2252,7 +2252,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=v2
   response:
     body:
       string: '{"etag":"_tKtqOFUBEabd7PF4KZKVxRx_emMxJbrZ4YkdrjpgLI","key":".appconfig.featureflag/Beta","label":"v2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2295,7 +2295,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"rM0Y6Mnia263OV44lhgPqR-Kg4YULyvzLx969WsEaDE","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2344,7 +2344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/locks/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/locks/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"YT-Wh6TdGEv3GqQHjdQIxHrU0DflNMVUvAGz1pHPvsQ","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2387,7 +2387,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"YT-Wh6TdGEv3GqQHjdQIxHrU0DflNMVUvAGz1pHPvsQ","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2436,7 +2436,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://featuretest000001.azconfig.io/locks/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/locks/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"0c_UuTSolWKTS7fJkpiC4t3ewnLHu4ug599UlAOzqs0","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2479,7 +2479,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"0c_UuTSolWKTS7fJkpiC4t3ewnLHu4ug599UlAOzqs0","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2534,7 +2534,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"MAYrCZPeKJfynXuCLlnagMcnDWhNTcKHvHjeKTVFgvU","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2577,7 +2577,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"MAYrCZPeKJfynXuCLlnagMcnDWhNTcKHvHjeKTVFgvU","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2632,7 +2632,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretest000001.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
+    uri: https://featuretest000002.azconfig.io/kv/.appconfig.featureflag%2FThisBetaVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"8TMm9DGWR_2vTfhkJ50r-mVm8ISI_HnFNP8xnLxWIyA","key":".appconfig.featureflag/ThisBetaVersion","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2675,7 +2675,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://featuretest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"2tbQkfNdD1KU-EgzUIfsBqjCXLw1RHdvv1b2O_ZlfS8","items":[{"etag":"PrPgqiP4fgPsJrwXF_3F8dQE-o8XSungmlCVVAU6AiY","key":".appconfig.featureflag/Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001",
         "name": "featuretest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:50:16+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest000001",
         "name": "featuretest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_filter.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_filter.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001",
         "name": "featurefiltertest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001",
         "name": "featurefiltertest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_filter.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_filter.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001",
-        "name": "featurefiltertest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000002",
+        "name": "featurefiltertest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw._FhA49jDGMqEGE1L3DDk04-N6LszfeuO6KRh2fKopBo?api-version=2025-08-01-preview&t=639186261999667197&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=ZbR6QTTgzGkpDRswNicKMGD1_ysUvsCndYqwa3mC5nMevq54Y9QzowVIuaFX7qcLR7rwF2IUs8JoNq8lVUdcWeMsU3Vhe3GbMlg9LY-PY36T6bkLBPYkNM2OguIKooMq0tSGHsQRdiqGqC4OD8O6q6kk4UQ3JoQAVWJJw3_szORRkEX9gqCFxFShkK0VveUY0liCyG6nxJAWZ8C9J5LyItknhoOD7Z_uKH6CRcudpWph_O5CvvCCqcjgG5tRJyGtBWBUAuWQ9eexQALDRlDQ0koMxhqJimZBRPmq3GgnGGkzMzKwvUOFPnxEkZSTU9cowmX7R7M7Gc6QrT6vNZTrWg&h=N1FOGz3ESqjSvfqCvD89jtNZw6biQkI_gzH4qtVvqKw
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:56:39+00:00", "endpoint": "https://featurefiltertest000001.azconfig.io",
+        "2026-07-02T21:56:39+00:00", "endpoint": "https://featurefiltertest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000001",
-        "name": "featurefiltertest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertest000002",
+        "name": "featurefiltertest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: ''
@@ -389,7 +389,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"Eo_S96LlJuhqMJKKqJUw6HokGSxc3cHHmPAJxYDfGm0","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -432,7 +432,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"Eo_S96LlJuhqMJKKqJUw6HokGSxc3cHHmPAJxYDfGm0","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -489,7 +489,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"0PUCIOat7rcVhs62cxOcybYOKWR8VEbcKcmBtH15rLw","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -533,7 +533,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"0PUCIOat7rcVhs62cxOcybYOKWR8VEbcKcmBtH15rLw","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -593,7 +593,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"hWw0mHIedQT3vyvM09Z_4jKwBk-ttMKFOKbI4LFKfWs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -640,7 +640,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"hWw0mHIedQT3vyvM09Z_4jKwBk-ttMKFOKbI4LFKfWs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -703,7 +703,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"tIw2pVf8VFePJu5pagAfUtXpqZQ9Yt8CfFWg9qXVohs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -750,7 +750,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"tIw2pVf8VFePJu5pagAfUtXpqZQ9Yt8CfFWg9qXVohs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -797,7 +797,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"tIw2pVf8VFePJu5pagAfUtXpqZQ9Yt8CfFWg9qXVohs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -844,7 +844,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"tIw2pVf8VFePJu5pagAfUtXpqZQ9Yt8CfFWg9qXVohs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -891,7 +891,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"tIw2pVf8VFePJu5pagAfUtXpqZQ9Yt8CfFWg9qXVohs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -938,7 +938,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"tIw2pVf8VFePJu5pagAfUtXpqZQ9Yt8CfFWg9qXVohs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1001,7 +1001,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"IgcDiBzP1oJ0797wl7BzPir4FlgNEpFi0JOhZ0rah1I","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1048,7 +1048,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"IgcDiBzP1oJ0797wl7BzPir4FlgNEpFi0JOhZ0rah1I","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1095,7 +1095,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"IgcDiBzP1oJ0797wl7BzPir4FlgNEpFi0JOhZ0rah1I","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1142,7 +1142,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"IgcDiBzP1oJ0797wl7BzPir4FlgNEpFi0JOhZ0rah1I","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1205,7 +1205,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"pyfTs7L2k5k9h2iMDqIHtHRo5fuURMtPhrlipGQdSxs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1251,7 +1251,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"pyfTs7L2k5k9h2iMDqIHtHRo5fuURMtPhrlipGQdSxs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1297,7 +1297,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"pyfTs7L2k5k9h2iMDqIHtHRo5fuURMtPhrlipGQdSxs","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1358,7 +1358,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"qI80sZo7AN3g6rOqwirncsqSa9lLM2uad7AytuDqN6Y","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1404,7 +1404,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"qI80sZo7AN3g6rOqwirncsqSa9lLM2uad7AytuDqN6Y","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1462,7 +1462,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"4NlrZ-y4msaE3M5LFlwW93UEUMt771iDNW2E1m_QhY4","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1505,7 +1505,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"4NlrZ-y4msaE3M5LFlwW93UEUMt771iDNW2E1m_QhY4","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1548,7 +1548,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"4NlrZ-y4msaE3M5LFlwW93UEUMt771iDNW2E1m_QhY4","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1591,7 +1591,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"4NlrZ-y4msaE3M5LFlwW93UEUMt771iDNW2E1m_QhY4","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1647,7 +1647,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"P5DgTIALkwyM-hxlWMYeQUEBDyDBwobtKkwn_n9U_k4","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1691,7 +1691,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"P5DgTIALkwyM-hxlWMYeQUEBDyDBwobtKkwn_n9U_k4","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1750,7 +1750,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurefiltertest000001.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
+    uri: https://featurefiltertest000002.azconfig.io/kv/.appconfig.featureflag%2FColor?api-version=2023-11-01&label=Standard
   response:
     body:
       string: '{"etag":"qc8xRxfCNtCuyL00tk81uaFZK7FhbR7_hArKFNrF_A0","key":".appconfig.featureflag/Color","label":"Standard","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_namespacing.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_namespacing.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001",
-        "name": "featurenamespacetest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000002",
+        "name": "featurenamespacetest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.cJ5BjhSPKSmVDT5-_QMzwrtr7aRT15UwzxrWV83BNyE?api-version=2025-08-01-preview&t=639186261997872239&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=FKoaM662GTabinRh5fUqD0dje2tdAgwApwwEgI1JTCHxL8tgtXXG5mCJMw28jy3ppABvQ4KK6uilJeLIUw1eCmylmhvwXQoyonc5o4EKdvTB6jn9agnzHalgNy8L-htiYIDaSgqjFcR2qSQ3FfdUEUC0K6-E9BW4iWrae0Je8S9UfwUU6GnoIRIZzQPqo8Tjx3ZY_bD5jgTr_Uio4_koydZxehQUVNZkX4rGdwMyDsIi45iBGam8Nm6OpjLXeoQq5pyi2vsg1OvaNg0hbcRZtqoIw__tiaC7dDZyDUkMmGPA9S6f2pvd7UVh67ICpI-pHeGGUHlssiP04JvdIRwGWw&h=0p20phmjahMMOgDHY2kcGdycxtEJPe9gKVocFj7orgs
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:56:39+00:00", "endpoint": "https://featurenamespacetest000001.azconfig.io",
+        "2026-07-02T21:56:39+00:00", "endpoint": "https://featurenamespacetest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001",
-        "name": "featurenamespacetest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000002",
+        "name": "featurenamespacetest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurenamespacetest000001.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
+    uri: https://featurenamespacetest000002.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: ''
@@ -390,7 +390,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurenamespacetest000001.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
+    uri: https://featurenamespacetest000002.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"ND9fxz4tD1dql7R_z9joI_mE60z0GqGZnwL9RSRtFsU","key":".appconfig.featureflag/MyApp:Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -433,7 +433,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurenamespacetest000001.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
+    uri: https://featurenamespacetest000002.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"ND9fxz4tD1dql7R_z9joI_mE60z0GqGZnwL9RSRtFsU","key":".appconfig.featureflag/MyApp:Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -488,7 +488,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurenamespacetest000001.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
+    uri: https://featurenamespacetest000002.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3ABeta?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"ocTV-H7Gvwa8X16FdsKYivH5oxPz4CJntwmM4qE_50M","key":".appconfig.featureflag/MyApp:Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -531,7 +531,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurenamespacetest000001.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3AGlobalFeature?api-version=2023-11-01&label=v1
+    uri: https://featurenamespacetest000002.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3AGlobalFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: ''
@@ -577,7 +577,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featurenamespacetest000001.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3AGlobalFeature?api-version=2023-11-01&label=v1
+    uri: https://featurenamespacetest000002.azconfig.io/kv/.appconfig.featureflag%2FMyApp%3AGlobalFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"t76tJYws7j9Ur6XmJZprJ9QgH4yNJLM2rxIBMeAAReI","key":".appconfig.featureflag/MyApp:GlobalFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -620,7 +620,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featurenamespacetest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FMyApp%3A%2A&label=%2A
+    uri: https://featurenamespacetest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2FMyApp%3A%2A&label=%2A
   response:
     body:
       string: '{"etag":"nQfoiAa6UapCYyfs6W_EIpQpugkuIHktFCW2KMaVLpw","items":[{"etag":"ocTV-H7Gvwa8X16FdsKYivH5oxPz4CJntwmM4qE_50M","key":".appconfig.featureflag/MyApp:Beta","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_namespacing.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_namespacing.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001",
         "name": "featurenamespacetest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetest000001",
         "name": "featurenamespacetest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_telemetry.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_telemetry.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.wj85-GcpGOjcjjA4K2pkLCGZCukp2zwnR77tlD5jnGw?api-version=2025-08-01-preview&t=639197346950713124&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=CrxVOvnJ7A1i-_NaHptgDkrPRthkw_6AByeG4SDm-F00tto4RxIojxUHuuDeQHLRhtpDxMLk5WM577Ju-BfBzPMh0qoXX_YSzKNWjFWeAKe9M7a28RmhqLj8e3ri42YcCwW_rDa90-upEKkOj1n33WIF4VU-he2MQLyQuwpQrKQeSFZ-341FbBrlRU-D_rVPiLOfWCsMERjV20KK9upJ8dLX11DGJTuQ5V8m9cnjtUOpiR701ySKuOIfdml-AhsLNI5Nj9nfv8AJVsiRw1gDoe3Za6Ve9kwVD5RSEEZ0nFz0bQC8ShpX-9Hnp3RpjGX4RUH5rUd9293EsrxIlpNrPQ&h=YzpLPs79OEDobsASvARKI5gCqXxPidQc-2HpOarrwbo
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -4742,7 +4742,7 @@ interactions:
         "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
         "name": "featuretelemetrytesthtmd", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -4750,8 +4750,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest2cqiwuykgtyzw.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
@@ -7822,12 +7822,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -7835,8 +7835,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -7878,7 +7878,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: ''
@@ -7924,7 +7924,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"QdNR4cFM7iFF4uvRm8W_LO3m15pEEAVgrC7gqBguPag","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -7967,7 +7967,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"QdNR4cFM7iFF4uvRm8W_LO3m15pEEAVgrC7gqBguPag","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -8010,7 +8010,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"QdNR4cFM7iFF4uvRm8W_LO3m15pEEAVgrC7gqBguPag","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -8065,7 +8065,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"2PMmQHBJHRryc4eNukiZc4R0Eencg_WaDIAkwhAZTRo","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -8108,7 +8108,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"2PMmQHBJHRryc4eNukiZc4R0Eencg_WaDIAkwhAZTRo","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -12549,7 +12549,7 @@ interactions:
         "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
         "name": "featuretelemetrytesthtmd", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -12557,8 +12557,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest2cqiwuykgtyzw.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
@@ -15629,12 +15629,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -15642,8 +15642,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -15685,7 +15685,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"2PMmQHBJHRryc4eNukiZc4R0Eencg_WaDIAkwhAZTRo","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -15740,7 +15740,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"XHsY3Nu325Fxn1yh6dPv2kbpa0vVKBb5kwgWbk-oJuo","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -15771,7 +15771,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
+    body: '{"properties": {"telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000003"},
       "dataPlaneProxy": {}}}'
     headers:
       Accept:
@@ -15791,22 +15791,22 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000003"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2026-07-15T17:51:34+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2026-07-15T17:52:41.0042962+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}'
+        "2026-07-15T17:52:41.0042962+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -20250,17 +20250,17 @@ interactions:
         "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
         "name": "featuretelemetrytesthtmd", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000003"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2026-07-15T17:51:34+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
+        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest2cqiwuykgtyzw.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
@@ -23331,22 +23331,22 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
+        "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000003"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2026-07-15T17:51:34+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
-        "name": "featuretelemetrytest000001", "tags": {}}'
+        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000002",
+        "name": "featuretelemetrytest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -23388,7 +23388,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"XHsY3Nu325Fxn1yh6dPv2kbpa0vVKBb5kwgWbk-oJuo","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -23443,7 +23443,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://featuretelemetrytest000001.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
+    uri: https://featuretelemetrytest000002.azconfig.io/kv/.appconfig.featureflag%2FTelemetryFeature?api-version=2023-11-01&label=v1
   response:
     body:
       string: '{"etag":"GhDx5nDAG2elkkjgXREYwOwuoQCOjfkTp5mLtjFuXHs","key":".appconfig.featureflag/TelemetryFeature","label":"v1","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_telemetry.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_feature_telemetry.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}'
     headers:
       cache-control:
@@ -2475,7 +2475,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:05+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:05+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destinationm44rd5kb2honm",
+        "User", "lastModifiedAt": "2026-07-02T21:45:05+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destinationm44rd5kb2honm",
         "name": "destinationm44rd5kb2honm", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:33:22+00:00", "endpoint": "https://destinationnqga6gaurejxxtvybkxnccztp.azconfig.io",
@@ -2790,11 +2790,11 @@ interactions:
         null, "publicNetworkAccess": "Enabled", "disableLocalAuth": false, "softDeleteRetentionInDays":
         7, "defaultKeyValueRevisionRetentionPeriodInSeconds": 2592000, "enablePurgeProtection":
         false, "dataPlaneProxy": {"authenticationMode": "Local", "privateLinkDelegation":
-        "Disabled"}, "telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.Insights/components/appinsightswmsp7gt2w2iak"},
+        "Disabled"}, "telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/components/appinsightswmsp7gt2w2iak"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2024-10-23T17:01:30+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-10-23T17:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/appconfigwmsp7gt2w2iak",
+        "2024-10-23T17:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/appconfigwmsp7gt2w2iak",
         "name": "appconfigwmsp7gt2w2iak", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-08-29T08:29:59+00:00", "endpoint": "https://appcs-4mqdznmoaayla.azconfig.io",
@@ -2876,7 +2876,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-05-27T21:15:21+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-05-27T21:15:21+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/azure-sdk-for-python-tests",
+        "User", "lastModifiedAt": "2026-05-27T21:15:21+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/azure-sdk-for-python-tests",
         "name": "azure-sdk-for-python-tests", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T09:10:56+00:00", "endpoint": "https://configmapimporttest2uedl.azconfig.io",
@@ -3131,7 +3131,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-04-29T22:46:13+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-04-29T22:46:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/multi-store-test",
+        "User", "lastModifiedAt": "2026-04-29T22:46:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/multi-store-test",
         "name": "multi-store-test", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T19:11:37+00:00", "endpoint": "https://next-link-test-python.azconfig.io",
@@ -3142,7 +3142,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T19:11:37+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T19:11:37+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/next-link-test-python",
+        "User", "lastModifiedAt": "2025-11-19T19:11:37+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/next-link-test-python",
         "name": "next-link-test-python", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-26T22:52:06+00:00", "endpoint": "https://python-ai-test.azconfig.io",
@@ -3161,11 +3161,11 @@ interactions:
         null, "disableLocalAuth": false, "softDeleteRetentionInDays": 7, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/microsoft.insights/components/appinsightswmsp7gt2w2iak"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsightswmsp7gt2w2iak"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2025-05-22T17:53:31+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2025-07-25T23:18:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-chatapp-example",
+        "2025-07-25T23:18:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-chatapp-example",
         "name": "Python-ChatApp-Example", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T22:41:57+00:00", "endpoint": "https://python-connection-string-test.azconfig.io",
@@ -3176,7 +3176,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T22:41:57+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T22:42:49+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-connection-string-test",
+        "User", "lastModifiedAt": "2025-11-19T22:42:49+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-connection-string-test",
         "name": "python-connection-string-test", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2024-09-13T18:28:47+00:00", "endpoint": "https://python-multi-source-ff.azconfig.io",
@@ -3188,7 +3188,7 @@ interactions:
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2024-09-13T18:28:47+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-09-27T18:33:26+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-multi-source-ff",
+        "2024-09-27T18:33:26+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-multi-source-ff",
         "name": "python-multi-source-ff", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-09-01T16:51:09+00:00", "endpoint": "https://python-provider.azconfig.io",
@@ -3199,7 +3199,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2022-09-01T16:51:09+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-04-25T17:52:29+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider",
+        "User", "lastModifiedAt": "2023-04-25T17:52:29+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider",
         "name": "python-provider", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-03-09T17:53:50+00:00", "endpoint": "https://python-provider-demo.azconfig.io",
@@ -3210,7 +3210,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-03-09T17:53:50+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-03-09T17:53:51+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-demo",
+        "User", "lastModifiedAt": "2023-03-09T17:53:51+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-demo",
         "name": "python-provider-demo", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-05-26T18:00:59+00:00", "endpoint": "https://python-provider-flask-sample.azconfig.io",
@@ -3222,7 +3222,7 @@ interactions:
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2023-05-26T18:00:59+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-07-18T22:38:47+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-flask-sample",
+        "2024-07-18T22:38:47+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-flask-sample",
         "name": "python-provider-flask-sample", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-09-27T19:37:52+00:00", "endpoint": "https://python-provider-tests.azconfig.io",
@@ -3245,7 +3245,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T22:41:07+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-01-12T18:28:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-test-aad",
+        "User", "lastModifiedAt": "2026-01-12T18:28:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-test-aad",
         "name": "python-test-aad", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T20:11:02+00:00", "endpoint": "https://sdk-tests.azconfig.io",
@@ -3256,7 +3256,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T20:11:02+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T20:16:33+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sdk-tests",
+        "User", "lastModifiedAt": "2025-11-19T20:16:33+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sdk-tests",
         "name": "sdk-tests", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-12-07T18:13:20+00:00", "endpoint": "https://spring-demo.azconfig.io",
@@ -4365,7 +4365,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:17+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destinationsfslv2pfcew7u",
+        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destinationsfslv2pfcew7u",
         "name": "destinationsfslv2pfcew7u", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-02-12T08:07:04+00:00", "endpoint": "https://destinationvzuqxfj74tquf.azconfig.io",
@@ -4519,7 +4519,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdfkee5x",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdfkee5x",
         "name": "featurefiltertestdfkee5x", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:44:28+00:00", "endpoint": "https://featurefiltertestdpt3epj.azconfig.io",
@@ -4530,7 +4530,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdpt3epj",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdpt3epj",
         "name": "featurefiltertestdpt3epj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:32:31+00:00", "endpoint": "https://featurefiltertestntvamlv3qsxhrqghqxt.azconfig.io",
@@ -4673,7 +4673,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestpaul",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestpaul",
         "name": "featurenamespacetestpaul", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:36:08+00:00", "endpoint": "https://featurenamespacetestvjoivvcjifknwzao.azconfig.io",
@@ -4717,7 +4717,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestzgxs",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestzgxs",
         "name": "featurenamespacetestzgxs", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:57:25+00:00", "endpoint": "https://featuretelemetrytest6iu3.azconfig.io",
@@ -4728,7 +4728,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest6iu3",
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest6iu3",
         "name": "featuretelemetrytest6iu3", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:45:13+00:00", "endpoint": "https://featuretelemetrytesthtmd.azconfig.io",
@@ -4739,7 +4739,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:13+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
+        "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
         "name": "featuretelemetrytesthtmd", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
@@ -4750,7 +4750,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest2cqiwuykgtyzw.azconfig.io",
@@ -4761,7 +4761,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:50:16+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest2cqiwuykgtyzw",
+        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest2cqiwuykgtyzw",
         "name": "featuretest2cqiwuykgtyzw", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:52:14+00:00", "endpoint": "https://featuretest3fn4mdqdwkvlndvuwfdofk3nr.azconfig.io",
@@ -5235,7 +5235,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:32+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/importtestbxwjabeussp5mj",
+        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtestbxwjabeussp5mj",
         "name": "importtestbxwjabeussp5mj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:51:15+00:00", "endpoint": "https://importtestgiddobrgr672gjpl3hucqravfy.azconfig.io",
@@ -5639,7 +5639,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:36:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:36:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest34ykelbm3r",
+        "User", "lastModifiedAt": "2026-06-30T19:36:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest34ykelbm3r",
         "name": "KVRevisionTest34ykelbm3r", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:51:15+00:00", "endpoint": "https://kvrevisiontest4fqq5hbnxzmfbwe5dby2vr.azconfig.io",
@@ -5683,7 +5683,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestfjufzc3wq3",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestfjufzc3wq3",
         "name": "kvrevisiontestfjufzc3wq3", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T03:43:27+00:00", "endpoint": "https://kvrevisiontestibwkfz57qn.azconfig.io",
@@ -5705,7 +5705,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:46:48+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:46:48+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestihm7xsq45j",
+        "User", "lastModifiedAt": "2026-06-30T19:46:48+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestihm7xsq45j",
         "name": "kvrevisiontestihm7xsq45j", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:34:10+00:00", "endpoint": "https://kvrevisiontestkoz2orto53hamn6kwqjrwi.azconfig.io",
@@ -5727,7 +5727,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:41:06+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:41:06+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestpdvhetf3vj",
+        "User", "lastModifiedAt": "2026-06-30T19:41:06+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestpdvhetf3vj",
         "name": "kvrevisiontestpdvhetf3vj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:56:39+00:00", "endpoint": "https://kvrevisiontestqiwqa4a5co.azconfig.io",
@@ -5738,7 +5738,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestqiwqa4a5co",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestqiwqa4a5co",
         "name": "kvrevisiontestqiwqa4a5co", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:56:57+00:00", "endpoint": "https://kvrevisiontestsnib44xkg5dbxlix2d6pep.azconfig.io",
@@ -5903,7 +5903,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest34ag7twnvlcsojr4ex",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest34ag7twnvlcsojr4ex",
         "name": "kvtest34ag7twnvlcsojr4ex", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:57:25+00:00", "endpoint": "https://kvtest4xfx3rdh5b3amhzdod.azconfig.io",
@@ -5914,7 +5914,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest4xfx3rdh5b3amhzdod",
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest4xfx3rdh5b3amhzdod",
         "name": "kvtest4xfx3rdh5b3amhzdod", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T03:45:02+00:00", "endpoint": "https://kvtest56m7lyhkxttu5o7cy6.azconfig.io",
@@ -5947,7 +5947,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest7wlsqxqbq6zysncyhx",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest7wlsqxqbq6zysncyhx",
         "name": "kvtest7wlsqxqbq6zysncyhx", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-02-11T11:47:50+00:00", "endpoint": "https://kvtesta5gfdkk3ofsqlz3axj.azconfig.io",
@@ -6079,7 +6079,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:12+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:12+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtesthmsyyxx4g5mhqv37j6",
+        "User", "lastModifiedAt": "2026-07-02T21:45:12+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtesthmsyyxx4g5mhqv37j6",
         "name": "kvtesthmsyyxx4g5mhqv37j6", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:55:13+00:00", "endpoint": "https://kvtesthtjrqiylsqskz3c6d5ejdr4mbl6buh.azconfig.io",
@@ -6935,7 +6935,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-02-26T23:28:14+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-02-26T23:28:14+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-test-project",
+        "User", "lastModifiedAt": "2026-02-26T23:28:14+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-test-project",
         "name": "python-provider-test-project", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "identity": {"type": "SystemAssigned", "principalId":
         "493023af-0d46-48de-a070-eef831383228", "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"},
@@ -7061,7 +7061,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:45:10+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreflist7bnuakj5fkmnn",
+        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist7bnuakj5fkmnn",
         "name": "snapreflist7bnuakj5fkmnn", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:46:55+00:00", "endpoint": "https://snapreftestasreriss4i2pe.azconfig.io",
@@ -7072,7 +7072,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:46:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreftestasreriss4i2pe",
+        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftestasreriss4i2pe",
         "name": "snapreftestasreriss4i2pe", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-04-06T23:31:37+00:00", "endpoint": "https://softdelete-demo.azconfig.io",
@@ -7234,7 +7234,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sourcel3lurjj7avmaqrqoaz",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sourcel3lurjj7avmaqrqoaz",
         "name": "sourcel3lurjj7avmaqrqoaz", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-04-30T12:59:28+00:00", "endpoint": "https://sourcemezyxebj53szyzzqn2.azconfig.io",
@@ -7322,7 +7322,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sourcexi7tfbczaztmtqrblp",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sourcexi7tfbczaztmtqrblp",
         "name": "sourcexi7tfbczaztmtqrblp", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:55:04+00:00", "endpoint": "https://sourceykdeluxupgutssmtp4s2ndonnpmrfx.azconfig.io",
@@ -7476,7 +7476,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-07-24T21:01:29+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python",
+        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python",
         "name": "test-azconfig-python", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-07-24T21:01:29+00:00", "endpoint": "https://test-azconfig-python-provider.azconfig.io",
@@ -7487,7 +7487,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-07-24T21:01:29+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python-provider",
+        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python-provider",
         "name": "test-azconfig-python-provider", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-03-18T03:11:21+00:00", "endpoint": "https://test-deletion.azconfig.io",
@@ -7822,7 +7822,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -7835,7 +7835,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}'
     headers:
       cache-control:
@@ -10282,7 +10282,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:05+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:05+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destinationm44rd5kb2honm",
+        "User", "lastModifiedAt": "2026-07-02T21:45:05+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destinationm44rd5kb2honm",
         "name": "destinationm44rd5kb2honm", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:33:22+00:00", "endpoint": "https://destinationnqga6gaurejxxtvybkxnccztp.azconfig.io",
@@ -10597,11 +10597,11 @@ interactions:
         null, "publicNetworkAccess": "Enabled", "disableLocalAuth": false, "softDeleteRetentionInDays":
         7, "defaultKeyValueRevisionRetentionPeriodInSeconds": 2592000, "enablePurgeProtection":
         false, "dataPlaneProxy": {"authenticationMode": "Local", "privateLinkDelegation":
-        "Disabled"}, "telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.Insights/components/appinsightswmsp7gt2w2iak"},
+        "Disabled"}, "telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/components/appinsightswmsp7gt2w2iak"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2024-10-23T17:01:30+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-10-23T17:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/appconfigwmsp7gt2w2iak",
+        "2024-10-23T17:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/appconfigwmsp7gt2w2iak",
         "name": "appconfigwmsp7gt2w2iak", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-08-29T08:29:59+00:00", "endpoint": "https://appcs-4mqdznmoaayla.azconfig.io",
@@ -10683,7 +10683,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-05-27T21:15:21+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-05-27T21:15:21+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/azure-sdk-for-python-tests",
+        "User", "lastModifiedAt": "2026-05-27T21:15:21+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/azure-sdk-for-python-tests",
         "name": "azure-sdk-for-python-tests", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T09:10:56+00:00", "endpoint": "https://configmapimporttest2uedl.azconfig.io",
@@ -10938,7 +10938,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-04-29T22:46:13+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-04-29T22:46:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/multi-store-test",
+        "User", "lastModifiedAt": "2026-04-29T22:46:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/multi-store-test",
         "name": "multi-store-test", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T19:11:37+00:00", "endpoint": "https://next-link-test-python.azconfig.io",
@@ -10949,7 +10949,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T19:11:37+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T19:11:37+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/next-link-test-python",
+        "User", "lastModifiedAt": "2025-11-19T19:11:37+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/next-link-test-python",
         "name": "next-link-test-python", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-26T22:52:06+00:00", "endpoint": "https://python-ai-test.azconfig.io",
@@ -10968,11 +10968,11 @@ interactions:
         null, "disableLocalAuth": false, "softDeleteRetentionInDays": 7, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/microsoft.insights/components/appinsightswmsp7gt2w2iak"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsightswmsp7gt2w2iak"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2025-05-22T17:53:31+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2025-07-25T23:18:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-chatapp-example",
+        "2025-07-25T23:18:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-chatapp-example",
         "name": "Python-ChatApp-Example", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T22:41:57+00:00", "endpoint": "https://python-connection-string-test.azconfig.io",
@@ -10983,7 +10983,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T22:41:57+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T22:42:49+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-connection-string-test",
+        "User", "lastModifiedAt": "2025-11-19T22:42:49+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-connection-string-test",
         "name": "python-connection-string-test", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2024-09-13T18:28:47+00:00", "endpoint": "https://python-multi-source-ff.azconfig.io",
@@ -10995,7 +10995,7 @@ interactions:
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2024-09-13T18:28:47+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-09-27T18:33:26+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-multi-source-ff",
+        "2024-09-27T18:33:26+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-multi-source-ff",
         "name": "python-multi-source-ff", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-09-01T16:51:09+00:00", "endpoint": "https://python-provider.azconfig.io",
@@ -11006,7 +11006,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2022-09-01T16:51:09+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-04-25T17:52:29+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider",
+        "User", "lastModifiedAt": "2023-04-25T17:52:29+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider",
         "name": "python-provider", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-03-09T17:53:50+00:00", "endpoint": "https://python-provider-demo.azconfig.io",
@@ -11017,7 +11017,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-03-09T17:53:50+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-03-09T17:53:51+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-demo",
+        "User", "lastModifiedAt": "2023-03-09T17:53:51+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-demo",
         "name": "python-provider-demo", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-05-26T18:00:59+00:00", "endpoint": "https://python-provider-flask-sample.azconfig.io",
@@ -11029,7 +11029,7 @@ interactions:
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2023-05-26T18:00:59+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-07-18T22:38:47+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-flask-sample",
+        "2024-07-18T22:38:47+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-flask-sample",
         "name": "python-provider-flask-sample", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-09-27T19:37:52+00:00", "endpoint": "https://python-provider-tests.azconfig.io",
@@ -11052,7 +11052,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T22:41:07+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-01-12T18:28:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-test-aad",
+        "User", "lastModifiedAt": "2026-01-12T18:28:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-test-aad",
         "name": "python-test-aad", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T20:11:02+00:00", "endpoint": "https://sdk-tests.azconfig.io",
@@ -11063,7 +11063,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T20:11:02+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T20:16:33+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sdk-tests",
+        "User", "lastModifiedAt": "2025-11-19T20:16:33+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sdk-tests",
         "name": "sdk-tests", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-12-07T18:13:20+00:00", "endpoint": "https://spring-demo.azconfig.io",
@@ -12172,7 +12172,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:17+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destinationsfslv2pfcew7u",
+        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destinationsfslv2pfcew7u",
         "name": "destinationsfslv2pfcew7u", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-02-12T08:07:04+00:00", "endpoint": "https://destinationvzuqxfj74tquf.azconfig.io",
@@ -12326,7 +12326,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdfkee5x",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdfkee5x",
         "name": "featurefiltertestdfkee5x", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:44:28+00:00", "endpoint": "https://featurefiltertestdpt3epj.azconfig.io",
@@ -12337,7 +12337,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdpt3epj",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdpt3epj",
         "name": "featurefiltertestdpt3epj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:32:31+00:00", "endpoint": "https://featurefiltertestntvamlv3qsxhrqghqxt.azconfig.io",
@@ -12480,7 +12480,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestpaul",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestpaul",
         "name": "featurenamespacetestpaul", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:36:08+00:00", "endpoint": "https://featurenamespacetestvjoivvcjifknwzao.azconfig.io",
@@ -12524,7 +12524,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestzgxs",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestzgxs",
         "name": "featurenamespacetestzgxs", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:57:25+00:00", "endpoint": "https://featuretelemetrytest6iu3.azconfig.io",
@@ -12535,7 +12535,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest6iu3",
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest6iu3",
         "name": "featuretelemetrytest6iu3", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:45:13+00:00", "endpoint": "https://featuretelemetrytesthtmd.azconfig.io",
@@ -12546,7 +12546,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:13+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
+        "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
         "name": "featuretelemetrytesthtmd", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
@@ -12557,7 +12557,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest2cqiwuykgtyzw.azconfig.io",
@@ -12568,7 +12568,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:50:16+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest2cqiwuykgtyzw",
+        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest2cqiwuykgtyzw",
         "name": "featuretest2cqiwuykgtyzw", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:52:14+00:00", "endpoint": "https://featuretest3fn4mdqdwkvlndvuwfdofk3nr.azconfig.io",
@@ -13042,7 +13042,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:32+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/importtestbxwjabeussp5mj",
+        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtestbxwjabeussp5mj",
         "name": "importtestbxwjabeussp5mj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:51:15+00:00", "endpoint": "https://importtestgiddobrgr672gjpl3hucqravfy.azconfig.io",
@@ -13446,7 +13446,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:36:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:36:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest34ykelbm3r",
+        "User", "lastModifiedAt": "2026-06-30T19:36:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest34ykelbm3r",
         "name": "KVRevisionTest34ykelbm3r", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:51:15+00:00", "endpoint": "https://kvrevisiontest4fqq5hbnxzmfbwe5dby2vr.azconfig.io",
@@ -13490,7 +13490,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestfjufzc3wq3",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestfjufzc3wq3",
         "name": "kvrevisiontestfjufzc3wq3", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T03:43:27+00:00", "endpoint": "https://kvrevisiontestibwkfz57qn.azconfig.io",
@@ -13512,7 +13512,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:46:48+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:46:48+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestihm7xsq45j",
+        "User", "lastModifiedAt": "2026-06-30T19:46:48+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestihm7xsq45j",
         "name": "kvrevisiontestihm7xsq45j", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:34:10+00:00", "endpoint": "https://kvrevisiontestkoz2orto53hamn6kwqjrwi.azconfig.io",
@@ -13534,7 +13534,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:41:06+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:41:06+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestpdvhetf3vj",
+        "User", "lastModifiedAt": "2026-06-30T19:41:06+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestpdvhetf3vj",
         "name": "kvrevisiontestpdvhetf3vj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:56:39+00:00", "endpoint": "https://kvrevisiontestqiwqa4a5co.azconfig.io",
@@ -13545,7 +13545,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestqiwqa4a5co",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestqiwqa4a5co",
         "name": "kvrevisiontestqiwqa4a5co", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:56:57+00:00", "endpoint": "https://kvrevisiontestsnib44xkg5dbxlix2d6pep.azconfig.io",
@@ -13710,7 +13710,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest34ag7twnvlcsojr4ex",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest34ag7twnvlcsojr4ex",
         "name": "kvtest34ag7twnvlcsojr4ex", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:57:25+00:00", "endpoint": "https://kvtest4xfx3rdh5b3amhzdod.azconfig.io",
@@ -13721,7 +13721,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest4xfx3rdh5b3amhzdod",
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest4xfx3rdh5b3amhzdod",
         "name": "kvtest4xfx3rdh5b3amhzdod", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T03:45:02+00:00", "endpoint": "https://kvtest56m7lyhkxttu5o7cy6.azconfig.io",
@@ -13754,7 +13754,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest7wlsqxqbq6zysncyhx",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest7wlsqxqbq6zysncyhx",
         "name": "kvtest7wlsqxqbq6zysncyhx", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-02-11T11:47:50+00:00", "endpoint": "https://kvtesta5gfdkk3ofsqlz3axj.azconfig.io",
@@ -13886,7 +13886,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:12+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:12+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtesthmsyyxx4g5mhqv37j6",
+        "User", "lastModifiedAt": "2026-07-02T21:45:12+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtesthmsyyxx4g5mhqv37j6",
         "name": "kvtesthmsyyxx4g5mhqv37j6", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:55:13+00:00", "endpoint": "https://kvtesthtjrqiylsqskz3c6d5ejdr4mbl6buh.azconfig.io",
@@ -14742,7 +14742,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-02-26T23:28:14+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-02-26T23:28:14+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-test-project",
+        "User", "lastModifiedAt": "2026-02-26T23:28:14+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-test-project",
         "name": "python-provider-test-project", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "identity": {"type": "SystemAssigned", "principalId":
         "493023af-0d46-48de-a070-eef831383228", "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"},
@@ -14868,7 +14868,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:45:10+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreflist7bnuakj5fkmnn",
+        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist7bnuakj5fkmnn",
         "name": "snapreflist7bnuakj5fkmnn", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:46:55+00:00", "endpoint": "https://snapreftestasreriss4i2pe.azconfig.io",
@@ -14879,7 +14879,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:46:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreftestasreriss4i2pe",
+        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftestasreriss4i2pe",
         "name": "snapreftestasreriss4i2pe", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-04-06T23:31:37+00:00", "endpoint": "https://softdelete-demo.azconfig.io",
@@ -15041,7 +15041,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sourcel3lurjj7avmaqrqoaz",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sourcel3lurjj7avmaqrqoaz",
         "name": "sourcel3lurjj7avmaqrqoaz", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-04-30T12:59:28+00:00", "endpoint": "https://sourcemezyxebj53szyzzqn2.azconfig.io",
@@ -15129,7 +15129,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sourcexi7tfbczaztmtqrblp",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sourcexi7tfbczaztmtqrblp",
         "name": "sourcexi7tfbczaztmtqrblp", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:55:04+00:00", "endpoint": "https://sourceykdeluxupgutssmtp4s2ndonnpmrfx.azconfig.io",
@@ -15283,7 +15283,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-07-24T21:01:29+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python",
+        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python",
         "name": "test-azconfig-python", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-07-24T21:01:29+00:00", "endpoint": "https://test-azconfig-python-provider.azconfig.io",
@@ -15294,7 +15294,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-07-24T21:01:29+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python-provider",
+        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python-provider",
         "name": "test-azconfig-python-provider", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-03-18T03:11:21+00:00", "endpoint": "https://test-deletion.azconfig.io",
@@ -15629,7 +15629,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -15642,7 +15642,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:51:34+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:51:34+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}'
     headers:
       cache-control:
@@ -15771,7 +15771,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/microsoft.insights/components/appinsights000002"},
+    body: '{"properties": {"telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
       "dataPlaneProxy": {}}}'
     headers:
       Accept:
@@ -15791,7 +15791,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -15801,11 +15801,11 @@ interactions:
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/microsoft.insights/components/appinsights000002"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2026-07-15T17:51:34+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2026-07-15T17:52:41.0042962+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "2026-07-15T17:52:41.0042962+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}'
     headers:
       cache-control:
@@ -17983,7 +17983,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:05+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:05+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destinationm44rd5kb2honm",
+        "User", "lastModifiedAt": "2026-07-02T21:45:05+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destinationm44rd5kb2honm",
         "name": "destinationm44rd5kb2honm", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:33:22+00:00", "endpoint": "https://destinationnqga6gaurejxxtvybkxnccztp.azconfig.io",
@@ -18298,11 +18298,11 @@ interactions:
         null, "publicNetworkAccess": "Enabled", "disableLocalAuth": false, "softDeleteRetentionInDays":
         7, "defaultKeyValueRevisionRetentionPeriodInSeconds": 2592000, "enablePurgeProtection":
         false, "dataPlaneProxy": {"authenticationMode": "Local", "privateLinkDelegation":
-        "Disabled"}, "telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.Insights/components/appinsightswmsp7gt2w2iak"},
+        "Disabled"}, "telemetry": {"resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/components/appinsightswmsp7gt2w2iak"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2024-10-23T17:01:30+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-10-23T17:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/appconfigwmsp7gt2w2iak",
+        "2024-10-23T17:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/appconfigwmsp7gt2w2iak",
         "name": "appconfigwmsp7gt2w2iak", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-08-29T08:29:59+00:00", "endpoint": "https://appcs-4mqdznmoaayla.azconfig.io",
@@ -18384,7 +18384,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-05-27T21:15:21+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-05-27T21:15:21+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/azure-sdk-for-python-tests",
+        "User", "lastModifiedAt": "2026-05-27T21:15:21+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/azure-sdk-for-python-tests",
         "name": "azure-sdk-for-python-tests", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T09:10:56+00:00", "endpoint": "https://configmapimporttest2uedl.azconfig.io",
@@ -18639,7 +18639,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-04-29T22:46:13+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-04-29T22:46:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/multi-store-test",
+        "User", "lastModifiedAt": "2026-04-29T22:46:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/multi-store-test",
         "name": "multi-store-test", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T19:11:37+00:00", "endpoint": "https://next-link-test-python.azconfig.io",
@@ -18650,7 +18650,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T19:11:37+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T19:11:37+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/next-link-test-python",
+        "User", "lastModifiedAt": "2025-11-19T19:11:37+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/next-link-test-python",
         "name": "next-link-test-python", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-26T22:52:06+00:00", "endpoint": "https://python-ai-test.azconfig.io",
@@ -18669,11 +18669,11 @@ interactions:
         null, "disableLocalAuth": false, "softDeleteRetentionInDays": 7, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/microsoft.insights/components/appinsightswmsp7gt2w2iak"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsightswmsp7gt2w2iak"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2025-05-22T17:53:31+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2025-07-25T23:18:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-chatapp-example",
+        "2025-07-25T23:18:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-chatapp-example",
         "name": "Python-ChatApp-Example", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T22:41:57+00:00", "endpoint": "https://python-connection-string-test.azconfig.io",
@@ -18684,7 +18684,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T22:41:57+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T22:42:49+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-connection-string-test",
+        "User", "lastModifiedAt": "2025-11-19T22:42:49+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-connection-string-test",
         "name": "python-connection-string-test", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2024-09-13T18:28:47+00:00", "endpoint": "https://python-multi-source-ff.azconfig.io",
@@ -18696,7 +18696,7 @@ interactions:
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2024-09-13T18:28:47+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-09-27T18:33:26+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-multi-source-ff",
+        "2024-09-27T18:33:26+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-multi-source-ff",
         "name": "python-multi-source-ff", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-09-01T16:51:09+00:00", "endpoint": "https://python-provider.azconfig.io",
@@ -18707,7 +18707,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2022-09-01T16:51:09+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-04-25T17:52:29+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider",
+        "User", "lastModifiedAt": "2023-04-25T17:52:29+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider",
         "name": "python-provider", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-03-09T17:53:50+00:00", "endpoint": "https://python-provider-demo.azconfig.io",
@@ -18718,7 +18718,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-03-09T17:53:50+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-03-09T17:53:51+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-demo",
+        "User", "lastModifiedAt": "2023-03-09T17:53:51+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-demo",
         "name": "python-provider-demo", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-05-26T18:00:59+00:00", "endpoint": "https://python-provider-flask-sample.azconfig.io",
@@ -18730,7 +18730,7 @@ interactions:
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2023-05-26T18:00:59+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-07-18T22:38:47+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-flask-sample",
+        "2024-07-18T22:38:47+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-flask-sample",
         "name": "python-provider-flask-sample", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-09-27T19:37:52+00:00", "endpoint": "https://python-provider-tests.azconfig.io",
@@ -18753,7 +18753,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T22:41:07+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-01-12T18:28:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-test-aad",
+        "User", "lastModifiedAt": "2026-01-12T18:28:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-test-aad",
         "name": "python-test-aad", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-11-19T20:11:02+00:00", "endpoint": "https://sdk-tests.azconfig.io",
@@ -18764,7 +18764,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2025-11-19T20:11:02+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2025-11-19T20:16:33+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sdk-tests",
+        "User", "lastModifiedAt": "2025-11-19T20:16:33+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sdk-tests",
         "name": "sdk-tests", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "westus2", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-12-07T18:13:20+00:00", "endpoint": "https://spring-demo.azconfig.io",
@@ -19873,7 +19873,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:17+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destinationsfslv2pfcew7u",
+        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destinationsfslv2pfcew7u",
         "name": "destinationsfslv2pfcew7u", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-02-12T08:07:04+00:00", "endpoint": "https://destinationvzuqxfj74tquf.azconfig.io",
@@ -20027,7 +20027,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdfkee5x",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdfkee5x",
         "name": "featurefiltertestdfkee5x", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:44:28+00:00", "endpoint": "https://featurefiltertestdpt3epj.azconfig.io",
@@ -20038,7 +20038,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdpt3epj",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurefiltertestdpt3epj",
         "name": "featurefiltertestdpt3epj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:32:31+00:00", "endpoint": "https://featurefiltertestntvamlv3qsxhrqghqxt.azconfig.io",
@@ -20181,7 +20181,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestpaul",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestpaul",
         "name": "featurenamespacetestpaul", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:36:08+00:00", "endpoint": "https://featurenamespacetestvjoivvcjifknwzao.azconfig.io",
@@ -20225,7 +20225,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestzgxs",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featurenamespacetestzgxs",
         "name": "featurenamespacetestzgxs", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:57:25+00:00", "endpoint": "https://featuretelemetrytest6iu3.azconfig.io",
@@ -20236,7 +20236,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest6iu3",
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest6iu3",
         "name": "featuretelemetrytest6iu3", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:45:13+00:00", "endpoint": "https://featuretelemetrytesthtmd.azconfig.io",
@@ -20247,7 +20247,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:13+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
+        "User", "lastModifiedAt": "2026-07-02T21:45:13+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytesthtmd",
         "name": "featuretelemetrytesthtmd", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:51:34+00:00", "endpoint": "https://featuretelemetrytest000001.azconfig.io",
@@ -20255,11 +20255,11 @@ interactions:
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/microsoft.insights/components/appinsights000002"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2026-07-15T17:51:34+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:50:16+00:00", "endpoint": "https://featuretest2cqiwuykgtyzw.azconfig.io",
@@ -20270,7 +20270,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:50:16+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretest2cqiwuykgtyzw",
+        "User", "lastModifiedAt": "2026-07-15T17:50:16+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretest2cqiwuykgtyzw",
         "name": "featuretest2cqiwuykgtyzw", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:52:14+00:00", "endpoint": "https://featuretest3fn4mdqdwkvlndvuwfdofk3nr.azconfig.io",
@@ -20744,7 +20744,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:32+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/importtestbxwjabeussp5mj",
+        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtestbxwjabeussp5mj",
         "name": "importtestbxwjabeussp5mj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:51:15+00:00", "endpoint": "https://importtestgiddobrgr672gjpl3hucqravfy.azconfig.io",
@@ -21148,7 +21148,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:36:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:36:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest34ykelbm3r",
+        "User", "lastModifiedAt": "2026-06-30T19:36:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest34ykelbm3r",
         "name": "KVRevisionTest34ykelbm3r", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-19T19:51:15+00:00", "endpoint": "https://kvrevisiontest4fqq5hbnxzmfbwe5dby2vr.azconfig.io",
@@ -21192,7 +21192,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestfjufzc3wq3",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestfjufzc3wq3",
         "name": "kvrevisiontestfjufzc3wq3", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T03:43:27+00:00", "endpoint": "https://kvrevisiontestibwkfz57qn.azconfig.io",
@@ -21214,7 +21214,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:46:48+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:46:48+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestihm7xsq45j",
+        "User", "lastModifiedAt": "2026-06-30T19:46:48+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestihm7xsq45j",
         "name": "kvrevisiontestihm7xsq45j", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:34:10+00:00", "endpoint": "https://kvrevisiontestkoz2orto53hamn6kwqjrwi.azconfig.io",
@@ -21236,7 +21236,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-06-30T19:41:06+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-06-30T19:41:06+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestpdvhetf3vj",
+        "User", "lastModifiedAt": "2026-06-30T19:41:06+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestpdvhetf3vj",
         "name": "kvrevisiontestpdvhetf3vj", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:56:39+00:00", "endpoint": "https://kvrevisiontestqiwqa4a5co.azconfig.io",
@@ -21247,7 +21247,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestqiwqa4a5co",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontestqiwqa4a5co",
         "name": "kvrevisiontestqiwqa4a5co", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:56:57+00:00", "endpoint": "https://kvrevisiontestsnib44xkg5dbxlix2d6pep.azconfig.io",
@@ -21412,7 +21412,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest34ag7twnvlcsojr4ex",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest34ag7twnvlcsojr4ex",
         "name": "kvtest34ag7twnvlcsojr4ex", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-02T21:57:25+00:00", "endpoint": "https://kvtest4xfx3rdh5b3amhzdod.azconfig.io",
@@ -21423,7 +21423,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest4xfx3rdh5b3amhzdod",
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest4xfx3rdh5b3amhzdod",
         "name": "kvtest4xfx3rdh5b3amhzdod", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-07-10T03:45:02+00:00", "endpoint": "https://kvtest56m7lyhkxttu5o7cy6.azconfig.io",
@@ -21456,7 +21456,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest7wlsqxqbq6zysncyhx",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest7wlsqxqbq6zysncyhx",
         "name": "kvtest7wlsqxqbq6zysncyhx", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-02-11T11:47:50+00:00", "endpoint": "https://kvtesta5gfdkk3ofsqlz3axj.azconfig.io",
@@ -21588,7 +21588,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:45:12+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:45:12+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtesthmsyyxx4g5mhqv37j6",
+        "User", "lastModifiedAt": "2026-07-02T21:45:12+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtesthmsyyxx4g5mhqv37j6",
         "name": "kvtesthmsyyxx4g5mhqv37j6", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:55:13+00:00", "endpoint": "https://kvtesthtjrqiylsqskz3c6d5ejdr4mbl6buh.azconfig.io",
@@ -22444,7 +22444,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "premium"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-02-26T23:28:14+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-02-26T23:28:14+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/python-provider-test-project",
+        "User", "lastModifiedAt": "2026-02-26T23:28:14+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/python-provider-test-project",
         "name": "python-provider-test-project", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "identity": {"type": "SystemAssigned", "principalId":
         "493023af-0d46-48de-a070-eef831383228", "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"},
@@ -22570,7 +22570,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:45:10+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreflist7bnuakj5fkmnn",
+        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist7bnuakj5fkmnn",
         "name": "snapreflist7bnuakj5fkmnn", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-07-15T17:46:55+00:00", "endpoint": "https://snapreftestasreriss4i2pe.azconfig.io",
@@ -22581,7 +22581,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:46:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreftestasreriss4i2pe",
+        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftestasreriss4i2pe",
         "name": "snapreftestasreriss4i2pe", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-04-06T23:31:37+00:00", "endpoint": "https://softdelete-demo.azconfig.io",
@@ -22743,7 +22743,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sourcel3lurjj7avmaqrqoaz",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sourcel3lurjj7avmaqrqoaz",
         "name": "sourcel3lurjj7avmaqrqoaz", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2026-04-30T12:59:28+00:00", "endpoint": "https://sourcemezyxebj53szyzzqn2.azconfig.io",
@@ -22831,7 +22831,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:44:28+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/sourcexi7tfbczaztmtqrblp",
+        "User", "lastModifiedAt": "2026-07-02T21:44:28+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/sourcexi7tfbczaztmtqrblp",
         "name": "sourcexi7tfbczaztmtqrblp", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2025-03-18T13:55:04+00:00", "endpoint": "https://sourceykdeluxupgutssmtp4s2ndonnpmrfx.azconfig.io",
@@ -22985,7 +22985,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-07-24T21:01:29+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python",
+        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python",
         "name": "test-azconfig-python", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2023-07-24T21:01:29+00:00", "endpoint": "https://test-azconfig-python-provider.azconfig.io",
@@ -22996,7 +22996,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2023-07-24T21:01:29+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python-provider",
+        "User", "lastModifiedAt": "2023-07-24T21:01:30+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001-provider-test/providers/Microsoft.AppConfiguration/configurationStores/test-azconfig-python-provider",
         "name": "test-azconfig-python-provider", "tags": {}}, {"type": "Microsoft.AppConfiguration/configurationStores",
         "location": "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
         "2022-03-18T03:11:21+00:00", "endpoint": "https://test-deletion.azconfig.io",
@@ -23331,7 +23331,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -23341,11 +23341,11 @@ interactions:
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
         "Local", "privateLinkDelegation": "Disabled"}, "telemetry": {"resourceId":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/microsoft.insights/components/appinsights000002"},
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/appinsights000002"},
         "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"}, "systemData":
         {"createdBy": "test@example.com", "createdByType": "User", "createdAt": "2026-07-15T17:51:34+00:00",
         "lastModifiedBy": "test@example.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
+        "2026-07-15T17:52:41+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/featuretelemetrytest000001",
         "name": "featuretelemetrytest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001",
-        "name": "importtest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000002",
+        "name": "importtest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.C-mvS1Ymeu24tttMDvlNovPXJcY_96H21KBkFFQluTg?api-version=2025-08-01-preview&t=639186262528044589&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=jkdg1MPwKfpHnXbnswD3O5x0ooqSO5Ghm4QSr7Yv-C1Tl8jrqhJxF3w1rPZ9QlWiIZC423Z2JbdBA8oBtyDJWVNkpTnCEXHdOB-9Sx2lvbvEzWYk8HKPmQ9U1PTNAPaGe8JuQltflu1R9CT1_m-_qDhMvW-4YLeV_NcCzaK-rpscFo20u-cxyqHxCeAx5VAUMnAENZLxf9RObH9eGRSaETRn7biCH22UjB64hHdEysHPPpwBopEKLCnoSVRvQrUmTpFJczXa660wKb7yCsH7qFamy-zHwTDQXvgzTgWNtMSk_w7_Q0d1Qa-tPASvYb8JVXUkKPsu36OXNkztfV3Srg&h=0_kZZLMzeZ_F4T7tN5xHBWy5ewMImOhwl5N2k2Bu1m0
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:57:32+00:00", "endpoint": "https://importtest000001.azconfig.io",
+        "2026-07-02T21:57:32+00:00", "endpoint": "https://importtest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:32+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001",
-        "name": "importtest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000002",
+        "name": "importtest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -389,7 +389,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HHQRvL8Qy2LUIGizbSIJ0X8TLt8GlSqGEjtSa-SuwQ4","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:10+00:00"}'
@@ -436,7 +436,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Language?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Language?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"gtdGjXpFZL8MqOJD1A-fIXzraQ7C8xBPlYlgd07iE_4","key":"Language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:11+00:00"}'
@@ -483,7 +483,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Langugage?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Langugage?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"JPQLynEvoDcdGD5PuI6d1wE8n_Quuig5nFhZ9oHbhEE","key":"Langugage","label":null,"content_type":null,"value":"English","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:12+00:00"}'
@@ -531,7 +531,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fcars%2FToyota?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fcars%2FToyota?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"gNrRGQRHdb8YinuYUWKy1qG0k-iX33t8jVBe5QRe89A","key":"Settings:BackgroundColor/cars/Toyota","label":null,"content_type":null,"value":"Acura","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"}'
@@ -579,7 +579,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F0?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F0?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"hIU9alVRgM9oLN_frRN70TxUSIySUTQAz_xVf4mHvhc","key":"Settings:BackgroundColor/ship/0","label":null,"content_type":null,"value":"ship1","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"}'
@@ -627,7 +627,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F1?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_vevWXmTrB-puipmGm9QPnX6bpK2Lkvtxhtc82YOgKk","key":"Settings:BackgroundColor/ship/1","label":null,"content_type":null,"value":"ship2","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:14+00:00"}'
@@ -675,7 +675,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F2?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"jWdE4eVv5z6bUKZiIt4RGMuH_t8QB3xhNRSVDw0OCbQ","key":"Settings:BackgroundColor/ship/2","label":null,"content_type":null,"value":"ship3","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:15+00:00"}'
@@ -722,7 +722,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/abc?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/abc?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"EzTK96i61rE6j5LHz2H7nTuAI9QRu24k6gL_z1uWcKM","key":"abc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"}'
@@ -769,7 +769,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/appabc?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/appabc?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"klWDnHrJKtBOp_GTzDWU_76o7hCX6KyGTWEFuzoEncU","key":"appabc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"}'
@@ -816,7 +816,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/background-color?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/background-color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dXFkSnCFCF9GDuscAy4DbE02Iu18oHHlir1AL1GRcrc","key":"background-color","label":null,"content_type":null,"value":"black","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:17+00:00"}'
@@ -863,7 +863,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/font-size?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/font-size?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dJs31Pqkm4LKFJUUTH8Yhf9Mn7uKmuTnnhCLZtDqGNw","key":"font-size","label":null,"content_type":null,"value":"34","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:18+00:00"}'
@@ -910,7 +910,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/language?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/language?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"vrriWO3geRYggHCzJEa3lmt2R4E57qoW5KjileX3cyY","key":"language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:19+00:00"}'
@@ -951,7 +951,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"ZNCUMRhsG5yXeUlAWhhQF_FWuFjfFQv4RmFQKTEbcY4","items":[{"etag":"HHQRvL8Qy2LUIGizbSIJ0X8TLt8GlSqGEjtSa-SuwQ4","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:10+00:00"},{"etag":"gtdGjXpFZL8MqOJD1A-fIXzraQ7C8xBPlYlgd07iE_4","key":"Language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:11+00:00"},{"etag":"JPQLynEvoDcdGD5PuI6d1wE8n_Quuig5nFhZ9oHbhEE","key":"Langugage","label":null,"content_type":null,"value":"English","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:12+00:00"},{"etag":"gNrRGQRHdb8YinuYUWKy1qG0k-iX33t8jVBe5QRe89A","key":"Settings:BackgroundColor/cars/Toyota","label":null,"content_type":null,"value":"Acura","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"},{"etag":"hIU9alVRgM9oLN_frRN70TxUSIySUTQAz_xVf4mHvhc","key":"Settings:BackgroundColor/ship/0","label":null,"content_type":null,"value":"ship1","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"},{"etag":"_vevWXmTrB-puipmGm9QPnX6bpK2Lkvtxhtc82YOgKk","key":"Settings:BackgroundColor/ship/1","label":null,"content_type":null,"value":"ship2","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:14+00:00"},{"etag":"jWdE4eVv5z6bUKZiIt4RGMuH_t8QB3xhNRSVDw0OCbQ","key":"Settings:BackgroundColor/ship/2","label":null,"content_type":null,"value":"ship3","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:15+00:00"},{"etag":"EzTK96i61rE6j5LHz2H7nTuAI9QRu24k6gL_z1uWcKM","key":"abc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"},{"etag":"klWDnHrJKtBOp_GTzDWU_76o7hCX6KyGTWEFuzoEncU","key":"appabc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"},{"etag":"dXFkSnCFCF9GDuscAy4DbE02Iu18oHHlir1AL1GRcrc","key":"background-color","label":null,"content_type":null,"value":"black","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:17+00:00"},{"etag":"dJs31Pqkm4LKFJUUTH8Yhf9Mn7uKmuTnnhCLZtDqGNw","key":"font-size","label":null,"content_type":null,"value":"34","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:18+00:00"},{"etag":"vrriWO3geRYggHCzJEa3lmt2R4E57qoW5KjileX3cyY","key":"language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:19+00:00"}]}'
@@ -990,7 +990,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1029,7 +1029,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HHQRvL8Qy2LUIGizbSIJ0X8TLt8GlSqGEjtSa-SuwQ4","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:10+00:00"}'
@@ -1070,7 +1070,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"ZNCUMRhsG5yXeUlAWhhQF_FWuFjfFQv4RmFQKTEbcY4","items":[{"etag":"HHQRvL8Qy2LUIGizbSIJ0X8TLt8GlSqGEjtSa-SuwQ4","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:10+00:00"},{"etag":"gtdGjXpFZL8MqOJD1A-fIXzraQ7C8xBPlYlgd07iE_4","key":"Language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:11+00:00"},{"etag":"JPQLynEvoDcdGD5PuI6d1wE8n_Quuig5nFhZ9oHbhEE","key":"Langugage","label":null,"content_type":null,"value":"English","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:12+00:00"},{"etag":"gNrRGQRHdb8YinuYUWKy1qG0k-iX33t8jVBe5QRe89A","key":"Settings:BackgroundColor/cars/Toyota","label":null,"content_type":null,"value":"Acura","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"},{"etag":"hIU9alVRgM9oLN_frRN70TxUSIySUTQAz_xVf4mHvhc","key":"Settings:BackgroundColor/ship/0","label":null,"content_type":null,"value":"ship1","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"},{"etag":"_vevWXmTrB-puipmGm9QPnX6bpK2Lkvtxhtc82YOgKk","key":"Settings:BackgroundColor/ship/1","label":null,"content_type":null,"value":"ship2","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:14+00:00"},{"etag":"jWdE4eVv5z6bUKZiIt4RGMuH_t8QB3xhNRSVDw0OCbQ","key":"Settings:BackgroundColor/ship/2","label":null,"content_type":null,"value":"ship3","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:15+00:00"},{"etag":"EzTK96i61rE6j5LHz2H7nTuAI9QRu24k6gL_z1uWcKM","key":"abc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"},{"etag":"klWDnHrJKtBOp_GTzDWU_76o7hCX6KyGTWEFuzoEncU","key":"appabc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"},{"etag":"dXFkSnCFCF9GDuscAy4DbE02Iu18oHHlir1AL1GRcrc","key":"background-color","label":null,"content_type":null,"value":"black","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:17+00:00"},{"etag":"dJs31Pqkm4LKFJUUTH8Yhf9Mn7uKmuTnnhCLZtDqGNw","key":"font-size","label":null,"content_type":null,"value":"34","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:18+00:00"},{"etag":"vrriWO3geRYggHCzJEa3lmt2R4E57qoW5KjileX3cyY","key":"language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:19+00:00"}]}'
@@ -1115,7 +1115,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Language?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Language?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"xoMgTzf_q8B8APpW8SodeTjNPWsX5ondeGRlfucEzG4","key":"Language","label":null,"content_type":null,"value":"French","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:23+00:00"}'
@@ -1156,7 +1156,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HHQRvL8Qy2LUIGizbSIJ0X8TLt8GlSqGEjtSa-SuwQ4","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:10+00:00"}'
@@ -1201,7 +1201,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"FotRftH-k_S3IVdtOH5Zb2mtesdYGuPrL38tB_omvs8","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:25+00:00"}'
@@ -1248,7 +1248,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Language?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Language?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"8d3eKNU9it6oiZo5QXn3Srpisf2Vl_Fa7D36KRoCqKI","key":"Language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:25+00:00"}'
@@ -1295,7 +1295,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Langugage?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Langugage?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"EOped63ULQtWeWMB5bVfdap5ArBbrIao65b3iIAfvB0","key":"Langugage","label":null,"content_type":null,"value":"English","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"}'
@@ -1343,7 +1343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fcars%2FToyota?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fcars%2FToyota?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"YTekHaZphL6NV6QaEs0utVAakEDVmL7p43hvI5hEgWU","key":"Settings:BackgroundColor/cars/Toyota","label":null,"content_type":null,"value":"Acura","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:27+00:00"}'
@@ -1391,7 +1391,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F0?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F0?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"q9bpmMCPeXuUHy49VeTnRKTnJKu6I1fFW2Q1t0qg9M0","key":"Settings:BackgroundColor/ship/0","label":null,"content_type":null,"value":"ship1","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"}'
@@ -1439,7 +1439,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F1?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Q0bNe4VPoRAVZbjka20-9XXBdWOq7utAJ-NRu9KrcgE","key":"Settings:BackgroundColor/ship/1","label":null,"content_type":null,"value":"ship2","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"}'
@@ -1487,7 +1487,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F2?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%2Fship%2F2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"oShykj1D2lcy4k1JgYuHuikwoYZZp0C_BTqnR70u-kw","key":"Settings:BackgroundColor/ship/2","label":null,"content_type":null,"value":"ship3","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:29+00:00"}'
@@ -1534,7 +1534,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/abc?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/abc?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"4XYA4mczMpOUpUsjyFXyAgVJaUBvPVWmK7jvY6uPfaI","key":"abc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:30+00:00"}'
@@ -1581,7 +1581,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/appabc?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/appabc?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"5QTAfnJGDAwsmuXjZHxbJDMYBfD6RXB2GKYrC2Ackk0","key":"appabc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:30+00:00"}'
@@ -1628,7 +1628,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/background-color?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/background-color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"N9e2jEnN4VYlmOsMHryiMITZOcYo4Spqx2GdVv9s_pI","key":"background-color","label":null,"content_type":null,"value":"black","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:31+00:00"}'
@@ -1675,7 +1675,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/font-size?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/font-size?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"YCfM_x6SnKJgS2i3hJBDKoG_WwotGYsg2lZVykcd2Go","key":"font-size","label":null,"content_type":null,"value":"34","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:32+00:00"}'
@@ -1722,7 +1722,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/language?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/language?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"AsJLBC3ugjCpziE0x2WGWdz11R2nNnm6MToZk15K__c","key":"language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:33+00:00"}'
@@ -1763,7 +1763,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/BackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"FotRftH-k_S3IVdtOH5Zb2mtesdYGuPrL38tB_omvs8","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:25+00:00"}'
@@ -1804,7 +1804,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv/key_vault_reference?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/key_vault_reference?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1848,7 +1848,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/key_vault_reference?api-version=2023-11-01
+    uri: https://importtest000002.azconfig.io/kv/key_vault_reference?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"6LNWVrS6Ln9kGN2VUzbemrmfxrf4VYe7J4EEoN6-ci0","key":"key_vault_reference","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1890,7 +1890,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"_sdKdm6h1WzC1SCbo2IAL3ivzsEhsVM4nZatJ7Lbg4w","items":[{"etag":"FotRftH-k_S3IVdtOH5Zb2mtesdYGuPrL38tB_omvs8","key":"BackgroundColor","label":null,"content_type":null,"value":"red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:25+00:00"},{"etag":"8d3eKNU9it6oiZo5QXn3Srpisf2Vl_Fa7D36KRoCqKI","key":"Language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:25+00:00"},{"etag":"EOped63ULQtWeWMB5bVfdap5ArBbrIao65b3iIAfvB0","key":"Langugage","label":null,"content_type":null,"value":"English","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"},{"etag":"YTekHaZphL6NV6QaEs0utVAakEDVmL7p43hvI5hEgWU","key":"Settings:BackgroundColor/cars/Toyota","label":null,"content_type":null,"value":"Acura","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:27+00:00"},{"etag":"q9bpmMCPeXuUHy49VeTnRKTnJKu6I1fFW2Q1t0qg9M0","key":"Settings:BackgroundColor/ship/0","label":null,"content_type":null,"value":"ship1","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"},{"etag":"Q0bNe4VPoRAVZbjka20-9XXBdWOq7utAJ-NRu9KrcgE","key":"Settings:BackgroundColor/ship/1","label":null,"content_type":null,"value":"ship2","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"},{"etag":"oShykj1D2lcy4k1JgYuHuikwoYZZp0C_BTqnR70u-kw","key":"Settings:BackgroundColor/ship/2","label":null,"content_type":null,"value":"ship3","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:29+00:00"},{"etag":"4XYA4mczMpOUpUsjyFXyAgVJaUBvPVWmK7jvY6uPfaI","key":"abc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:30+00:00"},{"etag":"5QTAfnJGDAwsmuXjZHxbJDMYBfD6RXB2GKYrC2Ackk0","key":"appabc","label":null,"content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:30+00:00"},{"etag":"N9e2jEnN4VYlmOsMHryiMITZOcYo4Spqx2GdVv9s_pI","key":"background-color","label":null,"content_type":null,"value":"black","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:31+00:00"},{"etag":"YCfM_x6SnKJgS2i3hJBDKoG_WwotGYsg2lZVykcd2Go","key":"font-size","label":null,"content_type":null,"value":"34","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:32+00:00"},{"etag":"6LNWVrS6Ln9kGN2VUzbemrmfxrf4VYe7J4EEoN6-ci0","key":"key_vault_reference","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1930,7 +1930,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1969,7 +1969,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=array_test
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=array_test
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2014,7 +2014,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F0?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F0?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"xVDbFr0kxP86MRN2PNMnXemCX6-Uk94swdXifsYEIdU","key":"arr/0","label":"array_test","content_type":null,"value":"test1","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:38+00:00"}'
@@ -2061,7 +2061,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F1?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F1?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"5xZuTyhtHyV-CU5V5Op0PTJrLPxz7l1tCsznz_aiKMc","key":"arr/1","label":"array_test","content_type":null,"value":"test2","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:39+00:00"}'
@@ -2108,7 +2108,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F2?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F2?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"L-MCozD7whPlofiZw8-c8eEw2hHNlf1CtK9ohDwBJCk","key":"arr/2","label":"array_test","content_type":null,"value":"test3","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"}'
@@ -2155,7 +2155,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F3?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F3?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"KKTppQ2UlhExKnA8j-y6EBMU5wd1tsgd6wNVMU69CbA","key":"arr/3","label":"array_test","content_type":null,"value":"test4","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"}'
@@ -2202,7 +2202,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F4?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F4?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"zrFPJdj7aTCiT8besVWpAs6FxdK32iwK-oU01CyuV6E","key":"arr/4","label":"array_test","content_type":null,"value":"test5","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:41+00:00"}'
@@ -2249,7 +2249,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F5?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F5?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"3eSSPT9NxXeUC-duVtpaw4p6HN9uIXOwRkdF-63XXFg","key":"arr/5","label":"array_test","content_type":null,"value":"test6","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:42+00:00"}'
@@ -2296,7 +2296,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F6?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F6?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"0MRoaqMmf_FwV3PprQNNHbJSt9p1haA2eE7lYmtOmeY","key":"arr/6","label":"array_test","content_type":null,"value":"test7","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:43+00:00"}'
@@ -2343,7 +2343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F7?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F7?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"k1cc6uRRdfV7c7tswsySnN9Sb9mjJbISLwWtRYPkCsI","key":"arr/7","label":"array_test","content_type":null,"value":"test8","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:43+00:00"}'
@@ -2390,7 +2390,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F8?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F8?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"e0XSv2jpHLd2YkVleI5VGq5VV2rmpyzKYSdoKtG-3Ko","key":"arr/8","label":"array_test","content_type":null,"value":"test9","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:44+00:00"}'
@@ -2437,7 +2437,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F9?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F9?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"rBefbhIz7ul3C10gqsMZkVSjfXPsuufJ29rQxJp9fVg","key":"arr/9","label":"array_test","content_type":null,"value":"test10","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:45+00:00"}'
@@ -2484,7 +2484,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F10?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F10?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"JyDqWk2a-om76xyUX8VsBvsFqZCyfLH84BQSzNHMNHw","key":"arr/10","label":"array_test","content_type":null,"value":"test11","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:46+00:00"}'
@@ -2531,7 +2531,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2F11?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2F11?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"Gnc0WirArlVmlpw0pVD8ulN8k-JnsC7Dd-R-qNBAF7M","key":"arr/11","label":"array_test","content_type":null,"value":"test12","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:46+00:00"}'
@@ -2572,7 +2572,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv/arr%2Ffoo?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2Ffoo?api-version=2023-11-01&label=array_test
   response:
     body:
       string: ''
@@ -2616,7 +2616,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/arr%2Ffoo?api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv/arr%2Ffoo?api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"NyiWleZjlt6uqb3QzcVOYUBvVh1qilf3tCCrb09EoE0","key":"arr/foo","label":"array_test","content_type":"","value":"bar","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:48+00:00"}'
@@ -2657,7 +2657,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=array_test
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=array_test
   response:
     body:
       string: '{"etag":"U-F2IGV-WzZmZP_FXYjsjCc38SGgNjZXZBO-m1YsUOQ","items":[{"etag":"xVDbFr0kxP86MRN2PNMnXemCX6-Uk94swdXifsYEIdU","key":"arr/0","label":"array_test","content_type":null,"value":"test1","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:38+00:00"},{"etag":"5xZuTyhtHyV-CU5V5Op0PTJrLPxz7l1tCsznz_aiKMc","key":"arr/1","label":"array_test","content_type":null,"value":"test2","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:39+00:00"},{"etag":"JyDqWk2a-om76xyUX8VsBvsFqZCyfLH84BQSzNHMNHw","key":"arr/10","label":"array_test","content_type":null,"value":"test11","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:46+00:00"},{"etag":"Gnc0WirArlVmlpw0pVD8ulN8k-JnsC7Dd-R-qNBAF7M","key":"arr/11","label":"array_test","content_type":null,"value":"test12","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:46+00:00"},{"etag":"L-MCozD7whPlofiZw8-c8eEw2hHNlf1CtK9ohDwBJCk","key":"arr/2","label":"array_test","content_type":null,"value":"test3","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"},{"etag":"KKTppQ2UlhExKnA8j-y6EBMU5wd1tsgd6wNVMU69CbA","key":"arr/3","label":"array_test","content_type":null,"value":"test4","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"},{"etag":"zrFPJdj7aTCiT8besVWpAs6FxdK32iwK-oU01CyuV6E","key":"arr/4","label":"array_test","content_type":null,"value":"test5","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:41+00:00"},{"etag":"3eSSPT9NxXeUC-duVtpaw4p6HN9uIXOwRkdF-63XXFg","key":"arr/5","label":"array_test","content_type":null,"value":"test6","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:42+00:00"},{"etag":"0MRoaqMmf_FwV3PprQNNHbJSt9p1haA2eE7lYmtOmeY","key":"arr/6","label":"array_test","content_type":null,"value":"test7","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:43+00:00"},{"etag":"k1cc6uRRdfV7c7tswsySnN9Sb9mjJbISLwWtRYPkCsI","key":"arr/7","label":"array_test","content_type":null,"value":"test8","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:43+00:00"},{"etag":"e0XSv2jpHLd2YkVleI5VGq5VV2rmpyzKYSdoKtG-3Ko","key":"arr/8","label":"array_test","content_type":null,"value":"test9","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:44+00:00"},{"etag":"rBefbhIz7ul3C10gqsMZkVSjfXPsuufJ29rQxJp9fVg","key":"arr/9","label":"array_test","content_type":null,"value":"test10","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:45+00:00"},{"etag":"NyiWleZjlt6uqb3QzcVOYUBvVh1qilf3tCCrb09EoE0","key":"arr/foo","label":"array_test","content_type":"","value":"bar","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:48+00:00"}]}'
@@ -2696,7 +2696,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=array_test
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=array_test
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2735,7 +2735,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2776,7 +2776,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2822,7 +2822,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"a1pjG1BEtakdWbO2R_ro37y8Ukgub2UMcoNQ5EJkLNU","key":"Color","label":"KeyValuesWithFeatures","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:52+00:00"}'
@@ -2870,7 +2870,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Region?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/Region?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"XSdRRBdAolGVW6oWw4LJjch9JrGGRXfDJA-qTelxbiE","key":"Region","label":"KeyValuesWithFeatures","content_type":null,"value":"West
@@ -2921,7 +2921,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"i-KcmKjem_x25xEOFiFidORqzaGXjMT6nB0sL_DhdXo","key":".appconfig.featureflag/Beta","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2972,7 +2972,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"XRHNkxZYDnZqf7q1soBtiQW_LQIPmIF0WzUrZ66nSuE","key":".appconfig.featureflag/Percentage","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3026,7 +3026,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"NsxKpr9qGi03Mn14QOmjvqXcEDdnUeOWwG9a7Xhrk24","key":".appconfig.featureflag/Timestamp","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3080,7 +3080,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"eJxSDkMqKK_HcfTJaH0PxmrYq86Bj1LUuk0O7Mi0EUQ","key":".appconfig.featureflag/Beta","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3131,7 +3131,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"thugPMJNayxiOB1wboABh6gP3CD1sX74n-NVRLBULCU","key":".appconfig.featureflag/Percentage","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3185,7 +3185,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"058j_RNEdCRHjSJXP78XSaIionND_fBvTDlquTNU7hU","key":".appconfig.featureflag/Timestamp","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3230,7 +3230,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"adWouQswEdwNxGNiZEiv1ar3ORPh4Nay4uB3FxYlGn4","items":[{"etag":"eJxSDkMqKK_HcfTJaH0PxmrYq86Bj1LUuk0O7Mi0EUQ","key":".appconfig.featureflag/Beta","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3276,7 +3276,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"lT1eb40qe_92JvrpyrWFKD0LFtiMXPEI97Loy5Nl32E","items":[{"etag":"eJxSDkMqKK_HcfTJaH0PxmrYq86Bj1LUuk0O7Mi0EUQ","key":".appconfig.featureflag/Beta","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3321,7 +3321,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"adWouQswEdwNxGNiZEiv1ar3ORPh4Nay4uB3FxYlGn4","items":[{"etag":"eJxSDkMqKK_HcfTJaH0PxmrYq86Bj1LUuk0O7Mi0EUQ","key":".appconfig.featureflag/Beta","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3367,7 +3367,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=SkipFeatures
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=SkipFeatures
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3412,7 +3412,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=SkipFeatures
+    uri: https://importtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=SkipFeatures
   response:
     body:
       string: '{"etag":"xwWyfr5avThW31TfMNg8oLpGglKxFtsELTMe8itu9q8","key":"Color","label":"SkipFeatures","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:01+00:00"}'
@@ -3460,7 +3460,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Region?api-version=2023-11-01&label=SkipFeatures
+    uri: https://importtest000002.azconfig.io/kv/Region?api-version=2023-11-01&label=SkipFeatures
   response:
     body:
       string: '{"etag":"aiuVAskTuLQMWtr05E9zKMwx7dSgbDzTutmtDDAXeyU","key":"Region","label":"SkipFeatures","content_type":null,"value":"West
@@ -3502,7 +3502,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=SkipFeatures
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=SkipFeatures
   response:
     body:
       string: '{"etag":"Zx-_dO5RI3TgHQ3JXJum--OhzU60bnjsxZ3CACFteJg","items":[{"etag":"xwWyfr5avThW31TfMNg8oLpGglKxFtsELTMe8itu9q8","key":"Color","label":"SkipFeatures","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:01+00:00"},{"etag":"aiuVAskTuLQMWtr05E9zKMwx7dSgbDzTutmtDDAXeyU","key":"Region","label":"SkipFeatures","content_type":null,"value":"West
@@ -3542,7 +3542,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=SkipFeatures
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=SkipFeatures
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3581,7 +3581,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Test%2A&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Test%2A&label=PrefixTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3622,7 +3622,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=PrefixTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -3667,7 +3667,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/TestColor?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/TestColor?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"RiPz4bH_p6sqUj_5qkmSNd5BPNUH0BJjS99ng5SLGBQ","key":"TestColor","label":"PrefixTest","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:05+00:00"}'
@@ -3715,7 +3715,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/TestRegion?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/TestRegion?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"OFcfyeNHZ8ooClVNAlimtrUbh-gwOTKkoGX3FO6sloQ","key":"TestRegion","label":"PrefixTest","content_type":null,"value":"West
@@ -3766,7 +3766,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"PMJRZoc8PUXs-Pw6mRqCw_nunwUnxZaydq_6uWua2u0","key":".appconfig.featureflag/Beta","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3817,7 +3817,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"lnbb9XTKWw1fcpW5L-MAnxBpQ1nAdbm7Q3F63d0JJnE","key":".appconfig.featureflag/Percentage","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3871,7 +3871,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"xZLtvGNqs8JCbU15dJtfX1cBMk7Jji1lLimMhV-MkOU","key":".appconfig.featureflag/Timestamp","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3925,7 +3925,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"AkiltYNFCP5moSh_bTqkTxkI0IqJd5dt-Jo2vL5AtDk","key":".appconfig.featureflag/Beta","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3976,7 +3976,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"jl73ZjkA0p7j2NQijVORtn9duZGzFpllJdZJrByDZUs","key":".appconfig.featureflag/Percentage","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4030,7 +4030,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"LNY6hNkluAY1G5xCUSeqDGSvhfh1OkTnMU7BAD6WNmg","key":".appconfig.featureflag/Timestamp","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4075,7 +4075,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"Jshb5EB0KN2-_K6qnO_A6FC4w7NMrwGe4iFytIajenE","items":[{"etag":"AkiltYNFCP5moSh_bTqkTxkI0IqJd5dt-Jo2vL5AtDk","key":".appconfig.featureflag/Beta","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4121,7 +4121,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=PrefixTest
   response:
     body:
       string: '{"etag":"h343sp9qmQcepe-YOj4_SEW3Ds67UarNSSuHMy2ceFY","items":[{"etag":"AkiltYNFCP5moSh_bTqkTxkI0IqJd5dt-Jo2vL5AtDk","key":".appconfig.featureflag/Beta","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4166,7 +4166,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=PrefixTest
   response:
     body:
       string: '{"etag":"Jshb5EB0KN2-_K6qnO_A6FC4w7NMrwGe4iFytIajenE","items":[{"etag":"AkiltYNFCP5moSh_bTqkTxkI0IqJd5dt-Jo2vL5AtDk","key":".appconfig.featureflag/Beta","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4212,7 +4212,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=PrefixTest
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=PrefixTest
   response:
     body:
       string: '{"etag":"h343sp9qmQcepe-YOj4_SEW3Ds67UarNSSuHMy2ceFY","items":[{"etag":"AkiltYNFCP5moSh_bTqkTxkI0IqJd5dt-Jo2vL5AtDk","key":".appconfig.featureflag/Beta","label":"PrefixTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4257,7 +4257,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Col%2A&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Col%2A&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"fWhfd_kaNBUxeqD9XwS5GQLcD_1W4RBsXKe8QUQFsJY","items":[{"etag":"a1pjG1BEtakdWbO2R_ro37y8Ukgub2UMcoNQ5EJkLNU","key":"Color","label":"KeyValuesWithFeatures","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:52+00:00"}]}'
@@ -4296,7 +4296,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeatures
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeatures
   response:
     body:
       string: '{"etag":"lT1eb40qe_92JvrpyrWFKD0LFtiMXPEI97Loy5Nl32E","items":[{"etag":"eJxSDkMqKK_HcfTJaH0PxmrYq86Bj1LUuk0O7Mi0EUQ","key":".appconfig.featureflag/Beta","label":"KeyValuesWithFeatures","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4341,7 +4341,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=SeparatorTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4382,7 +4382,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=SeparatorTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4427,7 +4427,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"YI1-ge5Jahkc_Ncxa4WqCcGNHcG6cyvDGpUoKhDZG0A","key":"Color","label":"SeparatorTest","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:17+00:00"}'
@@ -4475,7 +4475,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Region?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/Region?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"jRK1rNnPv_UBUbmWu0JjOg8HuYVIpQpH5IaETaWYMv4","key":"Region","label":"SeparatorTest","content_type":null,"value":"West
@@ -4524,7 +4524,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%3Acars%3AToyota?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%3Acars%3AToyota?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"-m4jpWya8XjtfuggIIpO8v21VV_JvxTL8sfr5XXM06M","key":"Settings:BackgroundColor:cars:Toyota","label":"SeparatorTest","content_type":null,"value":"Acura","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:19+00:00"}'
@@ -4572,7 +4572,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%3Aship%3A0?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%3Aship%3A0?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"h6JuUHSpgAyLOI1RkzsVFFRhtilrh87zt1QVgDWPg7c","key":"Settings:BackgroundColor:ship:0","label":"SeparatorTest","content_type":null,"value":"ship1","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:19+00:00"}'
@@ -4620,7 +4620,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%3Aship%3A1?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%3Aship%3A1?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"-x-6NAd8zhWqtb5rI3PPTFbROt9FSQAHU4ujCYNIXC0","key":"Settings:BackgroundColor:ship:1","label":"SeparatorTest","content_type":null,"value":"ship2","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:20+00:00"}'
@@ -4668,7 +4668,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Settings%3ABackgroundColor%3Aship%3A2?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/Settings%3ABackgroundColor%3Aship%3A2?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"RyDBR5rA89VgHWpjmaDc7JjWuX1T67F3b8wpgORJDzg","key":"Settings:BackgroundColor:ship:2","label":"SeparatorTest","content_type":null,"value":"ship3","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:21+00:00"}'
@@ -4718,7 +4718,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"4sZTxPIDmwikNm-07UCm8rZvDYJsxhh8At9BL-Tu1WQ","key":".appconfig.featureflag/Beta","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4769,7 +4769,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"Mxz3hjFnnxWTl3sqKCJx_cfkx5Y7O9f0PHoLoWZJbXs","key":".appconfig.featureflag/Percentage","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4823,7 +4823,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"5ukQBt7bQ2ueEX_L6kRai3mW37Q9-HzgO_OYstRhsi0","key":".appconfig.featureflag/Timestamp","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4877,7 +4877,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"zIFeW53LLfDlB8QXXTSal7P2BvoVu3EiKa9mrzTbfI8","key":".appconfig.featureflag/Beta","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4928,7 +4928,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"G0SXvuCDgrJwTglcI6PuyCVuTvGQWoggWOEiwSlVTVo","key":".appconfig.featureflag/Percentage","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4982,7 +4982,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"yOXz9xuIg00O3wxFOS1_-LH1PpMm0MPOivbC2NLBjNU","key":".appconfig.featureflag/Timestamp","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5027,7 +5027,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=SeparatorTest
   response:
     body:
       string: '{"etag":"w9LKwFPM9fSJHCZqP_-Eib96ePTzbrwSO-jGTDbXuFw","items":[{"etag":"zIFeW53LLfDlB8QXXTSal7P2BvoVu3EiKa9mrzTbfI8","key":".appconfig.featureflag/Beta","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5073,7 +5073,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=SeparatorTest
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=SeparatorTest
   response:
     body:
       string: '{"etag":"Kdq6guKj-c6AnZY825I8wYmaP1257i05hh6j_JuO7EA","items":[{"etag":"zIFeW53LLfDlB8QXXTSal7P2BvoVu3EiKa9mrzTbfI8","key":".appconfig.featureflag/Beta","label":"SeparatorTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5118,7 +5118,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -5159,7 +5159,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -5204,7 +5204,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"_Toa4h0JipF5NaSn1MQFXb8fJCQeWFOkArSU_nT2YwE","key":"Color","label":"AltSyntaxTest","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:29+00:00"}'
@@ -5252,7 +5252,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Region?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/Region?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"6dYW2O2X98RUOTrk66HoBwbC4ogkjuX7FrPx8UOvQ08","key":"Region","label":"AltSyntaxTest","content_type":null,"value":"West
@@ -5303,7 +5303,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"d83zRBOzim3gc7cRvbvt0DrOKhBB9GpPn5zv_b5lldg","key":".appconfig.featureflag/Beta","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5354,7 +5354,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"1wXKO-EJVgC8MuoCPFCqYHiiOEXCoFzVOLdLGBVsxco","key":".appconfig.featureflag/Percentage","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5408,7 +5408,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"stNVA3sV23j3qTQoAi45rsQpexIaDKKGRHMR37ppnzI","key":".appconfig.featureflag/Timestamp","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5462,7 +5462,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"lrohI0EaAuNsxQnPddQSsyXa8Ph_u5ANdesCdvY0MXs","key":".appconfig.featureflag/Beta","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5513,7 +5513,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"TuqhNrayq4N0ZvXjjB-mX9nLDG_RvMXDI7SmyIJ7zS4","key":".appconfig.featureflag/Percentage","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5567,7 +5567,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"c3HtffuqsF8WRrEtpSmBv8Fg8w34G04Q806K3lQBAnU","key":".appconfig.featureflag/Timestamp","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5612,7 +5612,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"0E0H_InWWFRB4FSBn1ZEPkt1qxU812W7X14ZV7-FjD8","items":[{"etag":"lrohI0EaAuNsxQnPddQSsyXa8Ph_u5ANdesCdvY0MXs","key":".appconfig.featureflag/Beta","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5658,7 +5658,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=AltSyntaxTest
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=AltSyntaxTest
   response:
     body:
       string: '{"etag":"w7CoDsQVoLSkQ6JIkpfIarz_oE1qfktRtdabKGvjGtY","items":[{"etag":"lrohI0EaAuNsxQnPddQSsyXa8Ph_u5ANdesCdvY0MXs","key":".appconfig.featureflag/Beta","label":"AltSyntaxTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5703,7 +5703,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -5744,7 +5744,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -5790,7 +5790,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"arbj0BvyLMuUH0bky8XEQlyulSFqsbuM_SQWQL-7zpM","key":"Color","label":"RandomConditionsTest","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:38+00:00"}'
@@ -5838,7 +5838,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/Region?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/Region?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"YB1DPGEsf0fCrFP094ZJOk74SaPBiGlch9UTR-lmIko","key":"Region","label":"RandomConditionsTest","content_type":null,"value":"West
@@ -5889,7 +5889,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"b1o-qFNhtWDKuKlB8wwYwUPWlOP-MUhUA5ZYUxIwyNo","key":".appconfig.featureflag/Beta","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5940,7 +5940,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"W7pBz4GAvUv7eU1-US4Da7qmcSB88fWzrtapipEIv9U","key":".appconfig.featureflag/Percentage","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5994,7 +5994,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"VaMBafql1iXZSX6jAvbpBtu5KvjwAl8adFXBy34sHhY","key":".appconfig.featureflag/Timestamp","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -6049,7 +6049,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"AAx-F1mBNo5gnembhuJvUH2nZL8fE3n3ujUet9qHdes","key":".appconfig.featureflag/Beta","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -6100,7 +6100,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"DFEi3qoRe-zyphXL2bWxPfJ0KOkuARIyRAIewKAaB4s","key":".appconfig.featureflag/Percentage","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -6154,7 +6154,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://importtest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"f5eWu6PaBWQlSDbxMxdyDT9KUER255wT6rdm6zpiQpo","key":".appconfig.featureflag/Timestamp","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -6200,7 +6200,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"_bxLr5ld1Wx211FAK9CKqOxhk4NEkNHJN6QsBwuKnLA","items":[{"etag":"AAx-F1mBNo5gnembhuJvUH2nZL8fE3n3ujUet9qHdes","key":".appconfig.featureflag/Beta","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -6247,7 +6247,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://importtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RandomConditionsTest
+    uri: https://importtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RandomConditionsTest
   response:
     body:
       string: '{"etag":"otAixp-st5KaC9AgXruGD-DYNaTTRWB4mvQm4g4Zjsk","items":[{"etag":"AAx-F1mBNo5gnembhuJvUH2nZL8fE3n3ujUet9qHdes","key":".appconfig.featureflag/Beta","label":"RandomConditionsTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/importtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/importtest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001",
         "name": "importtest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/importtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:32+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/importtest000001",
+        "User", "lastModifiedAt": "2026-07-02T21:57:32+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/importtest000001",
         "name": "importtest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_kvset.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_kvset.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001",
-        "name": "kvsetimporttest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000002",
+        "name": "kvsetimporttest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.PCEdHcpkQh1GlBFaIKZ4mH75G8d_wfiLTokUK8C0_y0?api-version=2025-08-01-preview&t=639197348030911748&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=WOW-XedlXpoeWp9ulcwLE4yzXrCn_cbVs62gUPYoTLCe14hkDntH9SP7U3hOAKhbIB1a4C08JhyO06CIBZtLYvAaM91BwcsCHTs74TXEKL2pIqFRg42voHQU9YBFLRNC1DXgmL3JlN9RGmLkaN7HI17bVvfPZD6jAIx1kUnJZgDY5HXjLf5cSeXtR4T_9tjj0ocWLmaCLCXhlFS7-1AUWzBJIuoFz1IgS4u2p5sgWB2jn6MPdxR4yBiPjOLBMtqvgdRGl_gl2H1mYNtQ-GtIm1fWUaOpdytN4oBwJsYABLIPNNVH1aKdbCOwxJ1LVrvmXFWF-vxIHr3EigJk_fDyFg&h=29CJJpD6cpgtGWFkJ4bePZqkPHU3AvGvrW0BmJ0IvB0
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:53:22+00:00", "endpoint": "https://kvsetimporttest000001.azconfig.io",
+        "2026-07-15T17:53:22+00:00", "endpoint": "https://kvsetimporttest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:53:22+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:53:22+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001",
-        "name": "kvsetimporttest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:53:22+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000002",
+        "name": "kvsetimporttest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvsetimporttest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://kvsetimporttest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -392,7 +392,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/.appconfig.featureflag%2Fbeta-enabled?api-version=2023-11-01&label=beta-feature
+    uri: https://kvsetimporttest000002.azconfig.io/kv/.appconfig.featureflag%2Fbeta-enabled?api-version=2023-11-01&label=beta-feature
   response:
     body:
       string: '{"etag":"U-BEbBoCC98K9UuIUD-kvsJVOydzfHBUHaIq1f-vqBc","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -445,7 +445,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/.appconfig.featureflag%2Fbool-feature?api-version=2023-11-01
+    uri: https://kvsetimporttest000002.azconfig.io/kv/.appconfig.featureflag%2Fbool-feature?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Qh5AZDWSyM8HCi-uRboN3sFQOupdgo9dPhE0VwMksJk","key":".appconfig.featureflag/bool-feature","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -500,7 +500,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/.appconfig.featureflag%2Ftheta-enabled?api-version=2023-11-01&label=theta-enabled-label
+    uri: https://kvsetimporttest000002.azconfig.io/kv/.appconfig.featureflag%2Ftheta-enabled?api-version=2023-11-01&label=theta-enabled-label
   response:
     body:
       string: '{"etag":"yTSygBsWa3AjPRsbC5i0sZKF3cgPQJmynVMCiIzFcH4","key":".appconfig.featureflag/theta-enabled","label":"theta-enabled-label","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -553,7 +553,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/TestApp%3ASettings%3ABackgroundColor?api-version=2023-11-01
+    uri: https://kvsetimporttest000002.azconfig.io/kv/TestApp%3ASettings%3ABackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"GAgk-Ad4EXPWXEM3tosrrHHURjDsp4-ra-WBAc0EPi8","key":"TestApp:Settings:BackgroundColor","label":null,"content_type":"","value":"#FBB","tags":{"App":"TesApp"},"locked":false,"last_modified":"2026-07-15T17:54:04+00:00"}'
@@ -601,7 +601,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/TestApp%3ASettings%3AFontColor?api-version=2023-11-01
+    uri: https://kvsetimporttest000002.azconfig.io/kv/TestApp%3ASettings%3AFontColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"AAZ2p__JM4A-NuvLqdjWgnHF00kN6eOWSfGmWGC5qIs","key":"TestApp:Settings:FontColor","label":null,"content_type":"","value":"#999","tags":{"App":"TestApp"},"locked":false,"last_modified":"2026-07-15T17:54:04+00:00"}'
@@ -649,7 +649,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/TestApp%3ASettings%3AFontSize?api-version=2023-11-01
+    uri: https://kvsetimporttest000002.azconfig.io/kv/TestApp%3ASettings%3AFontSize?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"wFi7B4CtOHYeC6Ljz5tdAK3yMERMUdwOmbVf64h8RoE","key":"TestApp:Settings:FontSize","label":null,"content_type":"","value":"30","tags":{"App":"TestApp"},"locked":false,"last_modified":"2026-07-15T17:54:05+00:00"}'
@@ -697,7 +697,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/TestApp%3ASettings%3AMessage?api-version=2023-11-01
+    uri: https://kvsetimporttest000002.azconfig.io/kv/TestApp%3ASettings%3AMessage?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"zSJ34Nd3Zk0tV_m9XHqPZDC4QSY62_COJLxwWMfIs8s","key":"TestApp:Settings:Message","label":null,"content_type":"","value":"Dada
@@ -747,7 +747,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/pratik-top-secret?api-version=2023-11-01
+    uri: https://kvsetimporttest000002.azconfig.io/kv/pratik-top-secret?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"6LN2lXDevnm2Xpc6mGpt4qr8aHILj7bZPNixV7mjD0o","key":"pratik-top-secret","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -796,7 +796,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-1
+    uri: https://kvsetimporttest000002.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-1
   response:
     body:
       string: '{"etag":"53N2x5Ubq60aphguO9JANW7Q-Qg7ZaNnzX1hgvcik0g","key":"sample-1-testkey","label":"sample-1","content_type":"text/json","value":"sample-1-testvalue","tags":{"tag1":"sample","tag2":"sample2"},"locked":false,"last_modified":"2026-07-15T17:54:09+00:00"}'
@@ -844,7 +844,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-2
+    uri: https://kvsetimporttest000002.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-2
   response:
     body:
       string: '{"etag":"wd4KbmXqyOP5nlwmIEfhJvVhusIXY-JuYe8iYykTBy8","key":"sample-1-testkey","label":"sample-2","content_type":"application/json","value":"sample-2-with-label","tags":{},"locked":false,"last_modified":"2026-07-15T17:54:09+00:00"}'
@@ -892,7 +892,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvsetimporttest000001.azconfig.io/kv/sample-2-testkey?api-version=2023-11-01&label=sample-3
+    uri: https://kvsetimporttest000002.azconfig.io/kv/sample-2-testkey?api-version=2023-11-01&label=sample-3
   response:
     body:
       string: '{"etag":"HVS_dvjJtidqgX2BJyYbBuw13Wom_veK24mULNUQFNc","key":"sample-2-testkey","label":"sample-3","content_type":"application/json","value":"sample-2-with-label","tags":{},"locked":false,"last_modified":"2026-07-15T17:54:10+00:00"}'
@@ -933,7 +933,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvsetimporttest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://kvsetimporttest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"1UPvL2UtTHsW1E-VreMiTftskuhBBD6nS2SeyfuwLr8","items":[{"etag":"U-BEbBoCC98K9UuIUD-kvsJVOydzfHBUHaIq1f-vqBc","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -984,7 +984,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvsetimporttest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://kvsetimporttest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"vboYnEEaNeRq7qYiaBFi-HB_gJYXMfNNVfl4gpQtnCQ","items":[{"etag":"U-BEbBoCC98K9UuIUD-kvsJVOydzfHBUHaIq1f-vqBc","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1033,7 +1033,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvsetimporttest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://kvsetimporttest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"1UPvL2UtTHsW1E-VreMiTftskuhBBD6nS2SeyfuwLr8","items":[{"etag":"U-BEbBoCC98K9UuIUD-kvsJVOydzfHBUHaIq1f-vqBc","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1084,7 +1084,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvsetimporttest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://kvsetimporttest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"1UPvL2UtTHsW1E-VreMiTftskuhBBD6nS2SeyfuwLr8","items":[{"etag":"U-BEbBoCC98K9UuIUD-kvsJVOydzfHBUHaIq1f-vqBc","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_kvset.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_kvset.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001",
         "name": "kvsetimporttest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:53:22+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:53:22+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:53:22+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvsetimporttest000001",
         "name": "kvsetimporttest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_naming_conventions.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_naming_conventions.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001",
         "name": "namingconventiontest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:56:07+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:56:07+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:56:07+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001",
         "name": "namingconventiontest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_naming_conventions.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_naming_conventions.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001",
-        "name": "namingconventiontest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000002",
+        "name": "namingconventiontest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.QObXFdv1dT1MIHlx-Ku2U7HJYOxkrtz7i9QWRix1lXE?api-version=2025-08-01-preview&t=639197349673280535&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=Jmv44Qugc24v0Y_nx1JvIwGi2rqKCr_ROMN0REI0zNMyiUk19AtLe0Ysdzn4zlIDpiJdFQC2hGghSSvDXnFFjEYce6YkNAWvut3YjxSdgbYjgHtSO8DnTzKve8TXGT-quV-ruzjdG04feBr_hkRI1sRsC62aKZ3xRFg7ykilXNbHngvHLazEcOpNhCatTV1NxP4f7ToY4UBkr86AYooZduEizsXPVsJTusGHGye9pbxN3HTpL3b-rtd5vwq-IbjAMMTlROT4zHKAhVg4s6OLm-IUfXRYM_Q5l4EajdPtPpfloxAVIpIO8VH7eecSHXlACt-NJZEBfL2J8XfRRIZPEQ&h=hu52E3WeWA-oPDHCdWnqfbaiAvIjSFewoSnBm9XIruI
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:56:07+00:00", "endpoint": "https://namingconventiontest000001.azconfig.io",
+        "2026-07-15T17:56:07+00:00", "endpoint": "https://namingconventiontest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:56:07+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:56:07+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000001",
-        "name": "namingconventiontest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:56:07+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/namingconventiontest000002",
+        "name": "namingconventiontest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -384,7 +384,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -430,7 +430,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"mIwPTJljvOFk4xwPoyv7GT9aCrIjSr3xXQ9LqpGTOnI","key":"Color","label":"NamingConventionTest","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:56:46+00:00"}'
@@ -478,7 +478,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/Region?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/Region?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"bkSXFkuTJTqlQmAmkTK-PzBlPvZN58A2kmVGe68duHc","key":"Region","label":"NamingConventionTest","content_type":null,"value":"West
@@ -529,7 +529,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"GaiLtZDp1JM534iMiNa2i8dXo5XWiP40foGnj-KQYW8","key":".appconfig.featureflag/Beta","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -580,7 +580,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"6GAGHyKudAuiJvbCxlX_ieEGgHQ7Q_4aYwfSrgNJDAA","key":".appconfig.featureflag/Percentage","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -634,7 +634,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"iGziKVpCokMWalSAfcA09BUmb94u9b0FcvOiXe7XBys","key":".appconfig.featureflag/Timestamp","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -688,7 +688,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"_4_8APzJFAc58Dkwk4O99I2bBj3XrgAwSXn3T3wy7OE","key":".appconfig.featureflag/Beta","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -739,7 +739,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FPercentage?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"yy6dym6hThos_roGXHJuhjl7dtY0jgAbEhlRuGYU3fY","key":".appconfig.featureflag/Percentage","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -793,7 +793,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"JiqJ7b2Bi9VlI-kaimtnolKSIhWtlYKKnaHS0ee8RCc","key":".appconfig.featureflag/Timestamp","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -838,7 +838,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"5PJNBzhqMLfisFFoe8Rq4OgCLUkNM4Y8Ahi6PIk9eJ8","items":[{"etag":"_4_8APzJFAc58Dkwk4O99I2bBj3XrgAwSXn3T3wy7OE","key":".appconfig.featureflag/Beta","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -884,7 +884,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NamingConventionTest
+    uri: https://namingconventiontest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NamingConventionTest
   response:
     body:
       string: '{"etag":"hxAsNMcomd3ZmDUpT8aCeNqvCluTf63mbxwW9HHtFkQ","items":[{"etag":"_4_8APzJFAc58Dkwk4O99I2bBj3XrgAwSXn3T3wy7OE","key":".appconfig.featureflag/Beta","label":"NamingConventionTest","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -929,7 +929,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=YamlTests
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -970,7 +970,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=YamlTests
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1015,7 +1015,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=YamlTests
   response:
     body:
       string: '{"etag":"E-AlMin-ZeodTtBBj6C_G51csMda_5TsFlUVNdci3II","key":"Color","label":"YamlTests","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:56:56+00:00"}'
@@ -1062,7 +1062,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/Region?api-version=2023-11-01&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv/Region?api-version=2023-11-01&label=YamlTests
   response:
     body:
       string: '{"etag":"0hNgMwB4fbROYD7eA6Kh-490Xu2YzxjkQ83EdhLzG98","key":"Region","label":"YamlTests","content_type":null,"value":"West
@@ -1112,7 +1112,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=YamlTests
   response:
     body:
       string: '{"etag":"-Sc3ZNz_xtFK3Zc6IrnQCazY4ZWHGegdLJcQ1yoXQlk","key":".appconfig.featureflag/Beta","label":"YamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1166,7 +1166,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=YamlTests
   response:
     body:
       string: '{"etag":"fImAlEur0IL7Iy_ERl5sTGoibwU9RMOrgQ6t6u4rHs0","key":".appconfig.featureflag/Timestamp","label":"YamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1219,7 +1219,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01&label=YamlTests
   response:
     body:
       string: '{"etag":"Ior5lcHRH2fKQh4_VeCw0JiVvCAzf0Av6RLBXSPu7A4","key":".appconfig.featureflag/Beta","label":"YamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1273,7 +1273,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://namingconventiontest000001.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv/.appconfig.featureflag%2FTimestamp?api-version=2023-11-01&label=YamlTests
   response:
     body:
       string: '{"etag":"y8H65vVmOxQ5BDT_4rW4NGmVY3SLlRv5DHwirPWe3_I","key":".appconfig.featureflag/Timestamp","label":"YamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1318,7 +1318,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=YamlTests
   response:
     body:
       string: '{"etag":"HRqNNZOyxo2F2rs1euM9Ml2Oc8ELntr9GTWhshcQXMw","items":[{"etag":"Ior5lcHRH2fKQh4_VeCw0JiVvCAzf0Av6RLBXSPu7A4","key":".appconfig.featureflag/Beta","label":"YamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1363,7 +1363,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://namingconventiontest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=YamlTests
+    uri: https://namingconventiontest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=YamlTests
   response:
     body:
       string: '{"etag":"BnK1NK-I66CS8NA97VVsIpvK1iITHfIMO0piyA-ZXpA","items":[{"etag":"Ior5lcHRH2fKQh4_VeCw0JiVvCAzf0Av6RLBXSPu7A4","key":".appconfig.featureflag/Beta","label":"YamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_new_fm_schema.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_new_fm_schema.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001",
-        "name": "newfmimport000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000002",
+        "name": "newfmimport000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.L2LHpX78GUiq9jFxKKoGHezZajSby3Q8pQNWPdpFYn0?api-version=2025-08-01-preview&t=639197348554717088&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=a_F3kqOJ4Y-Vmj03NGMtt8GnMAA4kf4cO205QusAMzCQB7d4LVUBcS2uAUW9-ibxMPFOcR7TalFdoVqb1oEYQOcnxMhYAXnv8APbR7AhdPL73qKffO3XWq8QPoBqUqNZ15gDNYWuFXcM9JSiNM-HVr0qi07v2MFLJnWk_zRXkUOglFc2uX1qCfW_ahL500r41JUGyjToUUdDOspRIBAAWOcZRA7lHFCjbrBZ2IchjfhftaqTaYZNMZVef3DQIrPK2xpWeA76KXVxFJaqOsQqwEYM84jDQs5mwOGv2WB5dWTlDh6O4nIGUQxDyeoYW1z_uTSHCUVNxiEOOELgivhBXg&h=fl4FlvG7iiV0jTuvYnGcHBeYkvK6_Lf6Fjydndb8XJ8
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:54:15+00:00", "endpoint": "https://newfmimport000001.azconfig.io",
+        "2026-07-15T17:54:15+00:00", "endpoint": "https://newfmimport000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:54:15+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:54:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001",
-        "name": "newfmimport000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:54:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000002",
+        "name": "newfmimport000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=KeyValuesWithFeaturesFFV2
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=KeyValuesWithFeaturesFFV2
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -384,7 +384,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeaturesFFV2
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeaturesFFV2
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -436,7 +436,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/.appconfig.featureflag%2FTestVariants?api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
+    uri: https://newfmimport000002.azconfig.io/kv/.appconfig.featureflag%2FTestVariants?api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
   response:
     body:
       string: '{"etag":"bFGHcGHbCa0VgUcIaoC05akZzLGh-leQ9djkUC09aQY","key":".appconfig.featureflag/TestVariants","label":"KeyValuesWithFeaturesFFV2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -494,7 +494,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_False?api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
+    uri: https://newfmimport000002.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_False?api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
   response:
     body:
       string: '{"etag":"6fN_JPgf7MPNyZp2EFUgMS9V0Ya3Apv2aUzSJlx6Hok","key":".appconfig.featureflag/Variant_Override_False","label":"KeyValuesWithFeaturesFFV2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -550,7 +550,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_True?api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
+    uri: https://newfmimport000002.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_True?api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
   response:
     body:
       string: '{"etag":"a7P2LzF1am-yAxeD5N2rsPi4hKnr5x9RHY5vgFojqas","key":".appconfig.featureflag/Variant_Override_True","label":"KeyValuesWithFeaturesFFV2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -595,7 +595,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=KeyValuesWithFeaturesFFV2
   response:
     body:
       string: '{"etag":"tH76ZPQlp1Dg3igaOTtQhM--rQS9Q49ES6qSFMejNAs","items":[{"etag":"bFGHcGHbCa0VgUcIaoC05akZzLGh-leQ9djkUC09aQY","key":".appconfig.featureflag/TestVariants","label":"KeyValuesWithFeaturesFFV2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -648,7 +648,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeaturesFFV2
+    uri: https://newfmimport000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=KeyValuesWithFeaturesFFV2
   response:
     body:
       string: '{"etag":"tH76ZPQlp1Dg3igaOTtQhM--rQS9Q49ES6qSFMejNAs","items":[{"etag":"bFGHcGHbCa0VgUcIaoC05akZzLGh-leQ9djkUC09aQY","key":".appconfig.featureflag/TestVariants","label":"KeyValuesWithFeaturesFFV2","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -701,7 +701,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=NewFmSchemaYamlTests
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=NewFmSchemaYamlTests
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -742,7 +742,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NewFmSchemaYamlTests
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NewFmSchemaYamlTests
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -792,7 +792,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_True?api-version=2023-11-01&label=NewFmSchemaYamlTests
+    uri: https://newfmimport000002.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_True?api-version=2023-11-01&label=NewFmSchemaYamlTests
   response:
     body:
       string: '{"etag":"3saGAokrkLmyzEYOhLpmpJmzwbNNODum0pfsyOVPk-s","key":".appconfig.featureflag/Variant_Override_True","label":"NewFmSchemaYamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -848,7 +848,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_False?api-version=2023-11-01&label=NewFmSchemaYamlTests
+    uri: https://newfmimport000002.azconfig.io/kv/.appconfig.featureflag%2FVariant_Override_False?api-version=2023-11-01&label=NewFmSchemaYamlTests
   response:
     body:
       string: '{"etag":"Qnx92NVG3VWAKBMRiyK68CsSDfgVeHyP2RABUXq3RSk","key":".appconfig.featureflag/Variant_Override_False","label":"NewFmSchemaYamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -907,7 +907,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/.appconfig.featureflag%2FTestVariants?api-version=2023-11-01&label=NewFmSchemaYamlTests
+    uri: https://newfmimport000002.azconfig.io/kv/.appconfig.featureflag%2FTestVariants?api-version=2023-11-01&label=NewFmSchemaYamlTests
   response:
     body:
       string: '{"etag":"Q_8nMWZoskT3WUbmaM4BBiyAS_cIInMYK6fBUSGOepY","key":".appconfig.featureflag/TestVariants","label":"NewFmSchemaYamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -955,7 +955,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=NewFmSchemaYamlTests
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=NewFmSchemaYamlTests
   response:
     body:
       string: '{"etag":"VIJPPJXQOosSmd8z4fE1bCNRtVv-N_gyKIiecsFGY-Q","items":[{"etag":"Q_8nMWZoskT3WUbmaM4BBiyAS_cIInMYK6fBUSGOepY","key":".appconfig.featureflag/TestVariants","label":"NewFmSchemaYamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1009,7 +1009,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NewFmSchemaYamlTests
+    uri: https://newfmimport000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=NewFmSchemaYamlTests
   response:
     body:
       string: '{"etag":"VIJPPJXQOosSmd8z4fE1bCNRtVv-N_gyKIiecsFGY-Q","items":[{"etag":"Q_8nMWZoskT3WUbmaM4BBiyAS_cIInMYK6fBUSGOepY","key":".appconfig.featureflag/TestVariants","label":"NewFmSchemaYamlTests","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1063,7 +1063,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1109,7 +1109,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B0%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B0%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"Xgpd0JpV323fDaKlE8Dn7sOHs1zB75SDgWLoZDVOr-E","key":"feature-management.FeatureSample.enabled-for[0].Name","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"Filter1","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:05+00:00"}'
@@ -1157,7 +1157,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B0%5D.Parameters.paramforfilter1?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B0%5D.Parameters.paramforfilter1?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"PW1fTq7wrPuPCsufG2UPoyudqiRbFnlrAoPX2fJhF9o","key":"feature-management.FeatureSample.enabled-for[0].Parameters.paramforfilter1","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"value1","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:06+00:00"}'
@@ -1205,7 +1205,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B1%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B1%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"iGSnb1rVGsVvZS37A--b1oVI0twuYnC3T6VUCSNMPeE","key":"feature-management.FeatureSample.enabled-for[1].Name","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"Filter2","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:07+00:00"}'
@@ -1253,7 +1253,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B2%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B2%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"AHJjtydsm5ejjirNkT7L5uIWztmXizukpvEH1m0GpfI","key":"feature-management.FeatureSample.enabled-for[2].Name","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"Filter@3","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:07+00:00"}'
@@ -1301,7 +1301,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B3%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B3%5D.Name?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"kJkCoZM1PkR5UR-JjO3MDbHSFiXnfilU_Zx03OVFBNM","key":"feature-management.FeatureSample.enabled-for[3].Name","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"filter.4","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:08+00:00"}'
@@ -1349,7 +1349,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B3%5D.Parameters.EmptyValue?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B3%5D.Parameters.EmptyValue?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"V6QCk9YI0Cxh5GZW51rGO0i2-3wqVybTZyQo8mGNrJE","key":"feature-management.FeatureSample.enabled-for[3].Parameters.EmptyValue","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:09+00:00"}'
@@ -1397,7 +1397,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B3%5D.Parameters.dotInFilter.Param?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FeatureSample.enabled-for%5B3%5D.Parameters.dotInFilter.Param?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"upCAy2v19X48d9AAiYgjzt8b5XhNuNdMbNdQy2bK3wI","key":"feature-management.FeatureSample.enabled-for[3].Parameters.dotInFilter.Param","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"?","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:10+00:00"}'
@@ -1445,7 +1445,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.TrueFeature?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.TrueFeature?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"qSMbyep_gulgJTkS5w320WFDQ4E6d2ReTrd_G06c7mQ","key":"feature-management.TrueFeature","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"true","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:10+00:00"}'
@@ -1493,7 +1493,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/feature-management.FalseFeature?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/feature-management.FalseFeature?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"O7xXCf5SNeGV_ekX5QUXOYRx0yIrFTuBRBMKS_Uktlo","key":"feature-management.FalseFeature","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"false","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:11+00:00"}'
@@ -1541,7 +1541,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/Color?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/Color?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"maAaa9U1ZBpfWQ9d6U6rneOy1aI7c5_GAni3PRRJaVc","key":"Color","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:12+00:00"}'
@@ -1589,7 +1589,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://newfmimport000001.azconfig.io/kv/Region?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv/Region?api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"iSnvpE_Da38QE__cKqrzHKhkSsMRJ230-GaZ7aCldak","key":"Region","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"West
@@ -1631,7 +1631,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://newfmimport000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=NewFmSchemaPropertiesTests
+    uri: https://newfmimport000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=NewFmSchemaPropertiesTests
   response:
     body:
       string: '{"etag":"Yc0IIoGzkkRsU9xVjLoavcly5kihz7zF98nLolVoJhc","items":[{"etag":"maAaa9U1ZBpfWQ9d6U6rneOy1aI7c5_GAni3PRRJaVc","key":"Color","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"Red","tags":{},"locked":false,"last_modified":"2026-07-15T17:55:12+00:00"},{"etag":"iSnvpE_Da38QE__cKqrzHKhkSsMRJ230-GaZ7aCldak","key":"Region","label":"NewFmSchemaPropertiesTests","content_type":null,"value":"West

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_new_fm_schema.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_new_fm_schema.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001",
         "name": "newfmimport000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:54:15+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:54:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001",
+        "User", "lastModifiedAt": "2026-07-15T17:54:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/newfmimport000001",
         "name": "newfmimport000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_respect_both_schemas_naming_conventions.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_respect_both_schemas_naming_conventions.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001",
         "name": "bothschematest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:57:02+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:57:02+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:57:02+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001",
         "name": "bothschematest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_respect_both_schemas_naming_conventions.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_import_export_respect_both_schemas_naming_conventions.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001",
-        "name": "bothschematest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000002",
+        "name": "bothschematest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.V4nDkV_H4tvfAq8GDQxWDRg9JhEjj6MSvfLwFse_GYI?api-version=2025-08-01-preview&t=639197350229204491&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=iU47bSZ3h_IMcHtpz5I1tch5sMp8ZYR92vvIfTXoqb2f8AJ0dUuYTEwwsFz30sQoKUh13um2Re8f99OgP-lBCw8okbtqoj7V2s54QV1y645QDoe8YMuMl4bCpz4KNwCM61L_g3lQIXxnJn6mLy5fdzYnauniVbWAQWhLojes31IaDk-STuxRg4PpDBqFt7cioR7U6bjbQ5CnvQCxD28aS30dCV1E9bxbdXQPk92L6e68yZVoOJbtZpLtCZaZC-k_rUEBvJEo-l61M9DJ77x6IQI9Bmybq09xm_hUXHt-AwkzVg6J4rAtXRyVsZuycUcoaqb4lEuh8yjxI5MgL0SLIA&h=TDLxMNqNWoUGu_FOJiPsDxBqQZYEijIjRZ013xdnuGg
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:57:02+00:00", "endpoint": "https://bothschematest000001.azconfig.io",
+        "2026-07-15T17:57:02+00:00", "endpoint": "https://bothschematest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:57:02+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:57:02+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000001",
-        "name": "bothschematest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:57:02+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/bothschematest000002",
+        "name": "bothschematest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasCamelCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasCamelCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -384,7 +384,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasCamelCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasCamelCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -433,7 +433,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
   response:
     body:
       string: '{"etag":"m1TB32qyrguoSh2CfpVx1QJ5qcaCaEtxKFSZNi_YuVA","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasCamelCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -485,7 +485,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
   response:
     body:
       string: '{"etag":"cQvywUW4snWkQyvOtzdmmqLWmLSwN81b_NO39cafb9Q","key":".appconfig.featureflag/FeatureY","label":"RespectBothFmSchemasCamelCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -535,7 +535,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
   response:
     body:
       string: '{"etag":"S8kIE1YpMuN28m3e2aGRz6FqXEQZ1Ke5REAiRIooKBw","key":".appconfig.featureflag/FeatureZ","label":"RespectBothFmSchemasCamelCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -577,7 +577,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasCamelCase
   response:
     body:
       string: '{"etag":"70GW7Z52LiTy07xx0cDaI_u_fzb58Z6Pj1O_SPrO3EY","items":[{"etag":"m1TB32qyrguoSh2CfpVx1QJ5qcaCaEtxKFSZNi_YuVA","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasCamelCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -621,7 +621,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasCamelCase
+    uri: https://bothschematest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasCamelCase
   response:
     body:
       string: '{"etag":"70GW7Z52LiTy07xx0cDaI_u_fzb58Z6Pj1O_SPrO3EY","items":[{"etag":"m1TB32qyrguoSh2CfpVx1QJ5qcaCaEtxKFSZNi_YuVA","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasCamelCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -665,7 +665,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasPascalCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasPascalCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -706,7 +706,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasPascalCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasPascalCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -755,7 +755,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
   response:
     body:
       string: '{"etag":"FNO8HvS3J_xfs8M-kchv3BcXrTfscSYn-61E5jjsDD4","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasPascalCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -807,7 +807,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
   response:
     body:
       string: '{"etag":"ucJZYuEUzIyNhWUCzDTTWTSsIsRKo7hj6uvWJ0Ur4Qc","key":".appconfig.featureflag/FeatureY","label":"RespectBothFmSchemasPascalCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -857,7 +857,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
   response:
     body:
       string: '{"etag":"HeYCLJulKqGOomMewK32Z4VjcxKVpX-GRi1xgxh04wY","key":".appconfig.featureflag/FeatureZ","label":"RespectBothFmSchemasPascalCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -899,7 +899,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasPascalCase
   response:
     body:
       string: '{"etag":"n0D1V6Zz4RgmyEbw5uWsj8LoqE8Opurzl0sQTYN0BxM","items":[{"etag":"FNO8HvS3J_xfs8M-kchv3BcXrTfscSYn-61E5jjsDD4","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasPascalCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -943,7 +943,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasPascalCase
+    uri: https://bothschematest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasPascalCase
   response:
     body:
       string: '{"etag":"n0D1V6Zz4RgmyEbw5uWsj8LoqE8Opurzl0sQTYN0BxM","items":[{"etag":"FNO8HvS3J_xfs8M-kchv3BcXrTfscSYn-61E5jjsDD4","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasPascalCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -987,7 +987,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasHyphenCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasHyphenCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1028,7 +1028,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasHyphenCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasHyphenCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1077,7 +1077,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
   response:
     body:
       string: '{"etag":"toTpiCFpgarR1nKfB4fyUYx_Fwt7wAdMXKBvkzOv5io","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasHyphenCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1129,7 +1129,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
   response:
     body:
       string: '{"etag":"OGCYHfv6R0fmroeI7z6EQwmbxuVUOaFyn_h_26zC_wM","key":".appconfig.featureflag/FeatureY","label":"RespectBothFmSchemasHyphenCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1179,7 +1179,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
   response:
     body:
       string: '{"etag":"ntAWgNboUOxr37E4IMJzl-cSxB51G5nKvsxX3w5df7g","key":".appconfig.featureflag/FeatureZ","label":"RespectBothFmSchemasHyphenCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1221,7 +1221,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasHyphenCase
   response:
     body:
       string: '{"etag":"WKEeUP3ZL1caHoP3D5Zli8qrJ89hVWK3F3pTyAEepqw","items":[{"etag":"toTpiCFpgarR1nKfB4fyUYx_Fwt7wAdMXKBvkzOv5io","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasHyphenCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1265,7 +1265,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasHyphenCase
+    uri: https://bothschematest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasHyphenCase
   response:
     body:
       string: '{"etag":"WKEeUP3ZL1caHoP3D5Zli8qrJ89hVWK3F3pTyAEepqw","items":[{"etag":"toTpiCFpgarR1nKfB4fyUYx_Fwt7wAdMXKBvkzOv5io","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasHyphenCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1309,7 +1309,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasUnderscoreCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=RespectBothFmSchemasUnderscoreCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1350,7 +1350,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasUnderscoreCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasUnderscoreCase
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1399,7 +1399,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureX?api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
   response:
     body:
       string: '{"etag":"qUqtGXOSDNEV4eydp4ojADZ72gePDlvjihTxWYYLO6Y","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasUnderscoreCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1451,7 +1451,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureY?api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
   response:
     body:
       string: '{"etag":"CLV9O1ByVsw5LUKDcgr9TmG-gU6_WBGd3nOLNIp8hXE","key":".appconfig.featureflag/FeatureY","label":"RespectBothFmSchemasUnderscoreCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1501,7 +1501,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
   response:
     body:
       string: '{"etag":"Nl9XModcWCfhN8ZfU8o0y0d2SqKVC_ClIXewQkFf7Hw","key":".appconfig.featureflag/FeatureZ","label":"RespectBothFmSchemasUnderscoreCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1543,7 +1543,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=RespectBothFmSchemasUnderscoreCase
   response:
     body:
       string: '{"etag":"q63I8dYmBZEHXlNZIxdnOlwHtnp5owxcUJefyPEhRvw","items":[{"etag":"qUqtGXOSDNEV4eydp4ojADZ72gePDlvjihTxWYYLO6Y","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasUnderscoreCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1587,7 +1587,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasUnderscoreCase
+    uri: https://bothschematest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=RespectBothFmSchemasUnderscoreCase
   response:
     body:
       string: '{"etag":"q63I8dYmBZEHXlNZIxdnOlwHtnp5owxcUJefyPEhRvw","items":[{"etag":"qUqtGXOSDNEV4eydp4ojADZ72gePDlvjihTxWYYLO6Y","key":".appconfig.featureflag/FeatureX","label":"RespectBothFmSchemasUnderscoreCase","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1631,7 +1631,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=DuplicateFeaturesBothSchemas
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=DuplicateFeaturesBothSchemas
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1672,7 +1672,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DuplicateFeaturesBothSchemas
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DuplicateFeaturesBothSchemas
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1719,7 +1719,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureA?api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureA?api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
   response:
     body:
       string: '{"etag":"G_j5E0H7rKIDQLXFELYpfZ2EDfve9MbUZ97mZEQxsyY","key":".appconfig.featureflag/FeatureA","label":"DuplicateFeaturesBothSchemas","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1770,7 +1770,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureB?api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureB?api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
   response:
     body:
       string: '{"etag":"XGnxVKD5EWEe2D_W2E7hfV_fWP_IFoNuqvYV43sFQ4w","key":".appconfig.featureflag/FeatureB","label":"DuplicateFeaturesBothSchemas","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1820,7 +1820,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://bothschematest000001.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
+    uri: https://bothschematest000002.azconfig.io/kv/.appconfig.featureflag%2FFeatureZ?api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
   response:
     body:
       string: '{"etag":"1W0btlKHSLNcSRRypbZWiBOHJPsIKolWbHZbDyQrDRg","key":".appconfig.featureflag/FeatureZ","label":"DuplicateFeaturesBothSchemas","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1862,7 +1862,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
+    uri: https://bothschematest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=DuplicateFeaturesBothSchemas
   response:
     body:
       string: '{"etag":"jJkGOeBDe9wK_5cpVrSY3DNDaF3XypclKbd3nn6OJXQ","items":[{"etag":"G_j5E0H7rKIDQLXFELYpfZ2EDfve9MbUZ97mZEQxsyY","key":".appconfig.featureflag/FeatureA","label":"DuplicateFeaturesBothSchemas","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1904,7 +1904,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://bothschematest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DuplicateFeaturesBothSchemas
+    uri: https://bothschematest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=DuplicateFeaturesBothSchemas
   response:
     body:
       string: '{"etag":"jJkGOeBDe9wK_5cpVrSY3DNDaF3XypclKbd3nn6OJXQ","items":[{"etag":"G_j5E0H7rKIDQLXFELYpfZ2EDfve9MbUZ97mZEQxsyY","key":".appconfig.featureflag/FeatureA","label":"DuplicateFeaturesBothSchemas","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_json_content_type.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_json_content_type.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
-        "name": "source000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002",
+        "name": "source000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.RIGIKIn8rF3glFUOEWX6A0HL6gSZex5Qq1o_Q2FaFaI?api-version=2025-08-01-preview&t=639186261998384662&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=EkSpp80IawzEtkCCGj-hYK6JYkCyOzZg7nrY3VPfZfy34g5hexqNFCLcUjCtOajsGykYXSjpLjTSqT-rldbDs-Ov5Qo5hxgfi3VCC6Nkdoo1lYICKUntN8gW7FPol1Gh787o0ZFzF3M78vDqCNFuXHLIWLeqD7cJlfeKvRS8sz3vON6BnMEb7aF59nvC-OEdc5CfKqJl3ysDemRAzrc6DTsZrejE8kXPvfiixlMAHjvSXDC82dZis06u0Ud531IIGg2CkPRIk3xWliiGnd7ylOEptXSadOdV5w_1c--TjqlSgjbMvoKkphEjm9O6oCtSrR1ghrl4Vz-zGGIzIkQuDQ&h=YzIr4QWXN-n113JsVPKn_tJKmqWlfE1qHZNd8zUMOZc
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:56:39+00:00", "endpoint": "https://source000001.azconfig.io",
+        "2026-07-02T21:56:39+00:00", "endpoint": "https://source000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
-        "name": "source000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000002",
+        "name": "source000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -353,7 +353,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -362,8 +362,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
-        "name": "destination000002", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003",
+        "name": "destination000003", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.bvFuv8XAmUNddKVh3pslF7K3jSQZYpuCLnpV3F-jgkM?api-version=2025-08-01-preview&t=639186262373453553&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=JyIawXI7zfnQAH9dCJm1WMUR69JgHkeYZf0v5RE2BqDS2Bz0Ig4TSEy5_5IRfCUYoe3N5w0_rBOWX-5srz8bZ8hZfSSfpK-1bjdTbaSTOMtAqn0qhpfdMcv6ZC1fnFYWObwd2M_GMuJeLWNc8kY8K6eTWkAGzNpU4Z0YgThWRn-mZaDTg48pOmZ8iA3yNjcuiZT8AbGbxvs35P5fdXqORx7pBOC7SJUBQTHUifd0WkJ8i7q16_D9fSl8aIQeXbGE9KKAkZbOCM3LM2-Y85pxoay8NCZlU36Jc2xm_-zeA5q4Tx7yVdzWX25oOLLZZ56gaH4yYuMTogJABckhB0jpwQ&h=ArcQ8DGScrM-hmqj30t3fuXFYj09KxguxqLvaIJhlRQ
@@ -620,12 +620,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:57:17+00:00", "endpoint": "https://destination000002.azconfig.io",
+        "2026-07-02T21:57:17+00:00", "endpoint": "https://destination000003.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -633,8 +633,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:17+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
-        "name": "destination000002", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000003",
+        "name": "destination000003", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -676,7 +676,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key01?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key01?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -719,7 +719,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key01?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key01?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"F5x1CUnwOl93dmOojS8ao4L0a81KrBWTJaOR15c_VJA","key":"Key01","label":null,"content_type":"application/json","value":"\"Red\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:55+00:00"}'
@@ -760,7 +760,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key02?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key02?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -803,7 +803,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key02?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key02?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"RWONF0eIjvs5ZdegnGuNelBM5bXmTwLsqWRxe_xbdbA","key":"Key02","label":null,"content_type":"application/json;charset=utf-8","value":"\"RedRobinHood\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:56+00:00"}'
@@ -844,7 +844,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key03?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key03?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -887,7 +887,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key03?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key03?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"UdEikfNzhvNuagLPngejuvXKojydRiS2XaA80sdKrC4","key":"Key03","label":null,"content_type":"application/boolean+json;","value":"true","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:58+00:00"}'
@@ -928,7 +928,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key04?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key04?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -971,7 +971,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key04?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key04?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HgKF5z0mwkjrDR1ZO0Mi7M9_QOERx1b2VoAagi2Ln5c","key":"Key04","label":null,"content_type":"application/json+text+number;charset=utf-8;param1=value1","value":"45.6","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:59+00:00"}'
@@ -1012,7 +1012,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key05?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key05?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1055,7 +1055,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key05?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key05?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"lIcax6J88nfrmYjrzbKu-m9M1tnJg0C5nAELDpEk0yw","key":"Key05","label":null,"content_type":"application/string+json;","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:01+00:00"}'
@@ -1096,7 +1096,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key06?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key06?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1139,7 +1139,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key06?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key06?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"PJ6sHjOfLMYPtehF3H-j_lqTemwA40vWToT0oZsRuLc","key":"Key06","label":null,"content_type":"application/string+json;","value":"\"999\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:02+00:00"}'
@@ -1180,7 +1180,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key07?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key07?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1223,7 +1223,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key07?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key07?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"xSiTGkFo3-FfDJxfL4KtYCEiEAGETzagArwC8z-I2Lw","key":"Key07","label":null,"content_type":"application/json+null;charset=utf-8;","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:04+00:00"}'
@@ -1264,7 +1264,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key08?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key08?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1307,7 +1307,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key08?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key08?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"2vfGIvtA6tV9MgAb71wToPqhmyz4G6HBDXybDItGi0g","key":"Key08","label":null,"content_type":"application/vnd.numericarray+json","value":"[1,2,3,4]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:05+00:00"}'
@@ -1348,7 +1348,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key09?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key09?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1391,7 +1391,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key09?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key09?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_YP_6H4OJH6gY9mVpGmj0xQzxdEV9fVyAQphp45Ve-E","key":"Key09","label":null,"content_type":"application/vnd.stringarray+json","value":"[\"abc\",\"def\"]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"}'
@@ -1432,7 +1432,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key10?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key10?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1475,7 +1475,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key10?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key10?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"eOaJFpoysMRR4H1ch9aD1DF9uylB78q3-D8-_0szM2I","key":"Key10","label":null,"content_type":"application/json+hybridarray","value":"[\"text\",true,null]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:08+00:00"}'
@@ -1516,7 +1516,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key11?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key11?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1559,7 +1559,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key11?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key11?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"ZFRPRGNNZ-WRKDRc5J6jg4SsHGUDDHTXT4eewlUNVW4","key":"Key11","label":null,"content_type":"application/json","value":"{\"Name\":\"Value\"}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:10+00:00"}'
@@ -1600,7 +1600,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key12?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key12?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1644,7 +1644,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key12?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key12?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dxxeEq4qsnXj0bMm1azgVRdVn7EsOTIaL6jSUirjeJc","key":"Key12","label":null,"content_type":"application/json","value":"{\"MyNullValue\":null,\"MyObject\":{\"Property\":{\"Name\":{\"Name1\":\"Value1\",\"Name2\":[\"qqq\",\"rrr\"]}}},\"MyArray\":[1,2,3]}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:12+00:00"}'
@@ -1685,7 +1685,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key13?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key13?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1728,7 +1728,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key13?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key13?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Ez2Zbe96Cdf8rs2Hm3y_PZ8w8Vl6SeNkEkdf2Em0z54","key":"Key13","label":null,"content_type":"application/null+json+empty","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"}'
@@ -1769,7 +1769,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1804,7 +1804,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1839,7 +1839,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1874,7 +1874,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1917,7 +1917,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"gzVkpgbYPR2JVAW-FRuZs1_ZzxnqeuYjMQxr62LYGag","key":"Key14","label":null,"content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:17+00:00"}'
@@ -1958,7 +1958,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"gzVkpgbYPR2JVAW-FRuZs1_ZzxnqeuYjMQxr62LYGag","key":"Key14","label":null,"content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:17+00:00"}'
@@ -1999,7 +1999,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -2044,7 +2044,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"eUCvbWcBSSc7HqKRIHuDP_f4-UZ0LzuUe1r7AR2FD88","key":"Key15","label":null,"content_type":"application/json","value":"{\"key1\":
@@ -2087,7 +2087,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"eUCvbWcBSSc7HqKRIHuDP_f4-UZ0LzuUe1r7AR2FD88","key":"Key15","label":null,"content_type":"application/json","value":"{\"key1\":
@@ -2130,7 +2130,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"eUCvbWcBSSc7HqKRIHuDP_f4-UZ0LzuUe1r7AR2FD88","key":"Key15","label":null,"content_type":"application/json","value":"{\"key1\":
@@ -2173,7 +2173,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"eUCvbWcBSSc7HqKRIHuDP_f4-UZ0LzuUe1r7AR2FD88","key":"Key15","label":null,"content_type":"application/json","value":"{\"key1\":
@@ -2216,7 +2216,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -2261,7 +2261,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2304,7 +2304,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -2348,7 +2348,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"JBwrPfY210PTyka2_zO9BW3mrHR_hOWMYXeJPuIJpfw","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -2390,7 +2390,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"7nQ8fMcEPuMWq01T3mik4U99j6NZdp7g_jJro5fJybg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2436,7 +2436,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"ikWNzicghKr8ImcfBldA_8tgEedxdCk_LgHVK8tcAmg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -2477,7 +2477,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2518,7 +2518,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2565,7 +2565,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"l-iuLykbPyQeEVivUCjW83h2V6J2UMezxoV2kUMdGQw","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"uri\":
@@ -2614,7 +2614,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key01?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key01?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"og7YPErEdIWXk5wQl-6iZMzBlu_ls5kP3hqUB3VYgpI","key":"Key01","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Red\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:30+00:00"}'
@@ -2662,7 +2662,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key02?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key02?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"XmkVaUYj5A0B3N_FWdqR6f3oBYyD-pSVAGKw9IrGXUM","key":"Key02","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"RedRobinHood\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:31+00:00"}'
@@ -2710,7 +2710,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key03?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key03?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"uSoEVXc8HmH7yw-U-7gWirIdMlSbq6gax-ftW2hz6rc","key":"Key03","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"true","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:32+00:00"}'
@@ -2758,7 +2758,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key04?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key04?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"AZA-159vImzpmsrsAHhLb-G1dkDQ941OnjbxRCi0_aA","key":"Key04","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"45.6","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:33+00:00"}'
@@ -2806,7 +2806,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key05?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key05?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"yuFPKzJXGib2gVJQGJgNv5ePMDqQ0t7LOSW2kQEkH-s","key":"Key05","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:33+00:00"}'
@@ -2854,7 +2854,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key06?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key06?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"OnS4FzJaxo0lFvDHVQSqBoretObE3tqmAgUeUBC2lb0","key":"Key06","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"999\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:34+00:00"}'
@@ -2902,7 +2902,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key07?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key07?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"QWid4Wu_f4CAdumCpwf8XFLsXPixNqesHrzoQtOOZ9c","key":"Key07","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:35+00:00"}'
@@ -2950,7 +2950,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key08?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key08?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"vz1g0OwasfSPHKE5awR4qTK9hSIxghE8xwDYZFEAllU","key":"Key08","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[1,2,3,4]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:36+00:00"}'
@@ -2998,7 +2998,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key09?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key09?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"bUU52yPz9OC9GFwJ-ohLkWSpnUwDixhsXUMW4fmQ1FI","key":"Key09","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[\"abc\",\"def\"]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:37+00:00"}'
@@ -3046,7 +3046,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key10?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key10?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"q-VIOPl5Qc_FEIB4KYQa9xLTnSVHTO1mwxJYvmR9sF0","key":"Key10","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[\"text\",true,null]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:37+00:00"}'
@@ -3094,7 +3094,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key11?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key11?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dXvY5LbpYBo8N_WzE_LMa5gJUhTFyEMg6_OvLCZhufQ","key":"Key11","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"Name\":\"Value\"}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:38+00:00"}'
@@ -3143,7 +3143,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key12?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key12?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"RxaDNM0kCxrIND5AxuuSifZ9EKHcgAwX1BUN6INeaRY","key":"Key12","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"MyNullValue\":null,\"MyObject\":{\"Property\":{\"Name\":{\"Name1\":\"Value1\",\"Name2\":[\"qqq\",\"rrr\"]}}},\"MyArray\":[1,2,3]}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:39+00:00"}'
@@ -3191,7 +3191,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key13?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key13?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"TT6MfZjYDx9vyVLn17gy-Puw_jTXRuYOtOdMD19m7KA","key":"Key13","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"}'
@@ -3239,7 +3239,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Fi-e44now8JNvD7XScXXyqj0VwnsMCsfRHH58_0bH6c","key":"Key14","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"}'
@@ -3289,7 +3289,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"obQcKRV8Jb1b1V6xk8dJFIKjhYTq6nrNOcfSd5RNPYk","key":"Key15","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"key1\":
@@ -3341,7 +3341,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"2Fnd7pbVA2cIo8dfX1XYzUxbn7324GmxbJNOxsNf9MQ","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3393,7 +3393,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"pSYXpjmnbFhl7nJTOovdgKQqk4rZoww_VMcpPi0SVxM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3436,7 +3436,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"7nQ8fMcEPuMWq01T3mik4U99j6NZdp7g_jJro5fJybg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3480,7 +3480,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"ikWNzicghKr8ImcfBldA_8tgEedxdCk_LgHVK8tcAmg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3521,7 +3521,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"ZWEGEw8XklweNLDjojkfkLY7QnAIp0msQYrKxK6Thzk","items":[{"etag":"pSYXpjmnbFhl7nJTOovdgKQqk4rZoww_VMcpPi0SVxM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3565,7 +3565,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"5NHABKPZVNAae249J9ue93hzNp_qjyYUzF59tzzB-qU","items":[{"etag":"pSYXpjmnbFhl7nJTOovdgKQqk4rZoww_VMcpPi0SVxM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3606,7 +3606,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"ZWEGEw8XklweNLDjojkfkLY7QnAIp0msQYrKxK6Thzk","items":[{"etag":"pSYXpjmnbFhl7nJTOovdgKQqk4rZoww_VMcpPi0SVxM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3656,7 +3656,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"pSYXpjmnbFhl7nJTOovdgKQqk4rZoww_VMcpPi0SVxM","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -3705,7 +3705,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"l-iuLykbPyQeEVivUCjW83h2V6J2UMezxoV2kUMdGQw","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"uri\":
@@ -3753,7 +3753,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key01?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key01?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"og7YPErEdIWXk5wQl-6iZMzBlu_ls5kP3hqUB3VYgpI","key":"Key01","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Red\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:30+00:00"}'
@@ -3800,7 +3800,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key02?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key02?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"XmkVaUYj5A0B3N_FWdqR6f3oBYyD-pSVAGKw9IrGXUM","key":"Key02","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"RedRobinHood\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:31+00:00"}'
@@ -3847,7 +3847,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key03?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key03?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"uSoEVXc8HmH7yw-U-7gWirIdMlSbq6gax-ftW2hz6rc","key":"Key03","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"true","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:32+00:00"}'
@@ -3894,7 +3894,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key04?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key04?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"AZA-159vImzpmsrsAHhLb-G1dkDQ941OnjbxRCi0_aA","key":"Key04","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"45.6","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:33+00:00"}'
@@ -3941,7 +3941,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key05?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key05?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"yuFPKzJXGib2gVJQGJgNv5ePMDqQ0t7LOSW2kQEkH-s","key":"Key05","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:33+00:00"}'
@@ -3988,7 +3988,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key06?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key06?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"OnS4FzJaxo0lFvDHVQSqBoretObE3tqmAgUeUBC2lb0","key":"Key06","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"999\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:34+00:00"}'
@@ -4035,7 +4035,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key07?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key07?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"QWid4Wu_f4CAdumCpwf8XFLsXPixNqesHrzoQtOOZ9c","key":"Key07","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:35+00:00"}'
@@ -4082,7 +4082,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key08?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key08?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"vz1g0OwasfSPHKE5awR4qTK9hSIxghE8xwDYZFEAllU","key":"Key08","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[1,2,3,4]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:36+00:00"}'
@@ -4129,7 +4129,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key09?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key09?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"bUU52yPz9OC9GFwJ-ohLkWSpnUwDixhsXUMW4fmQ1FI","key":"Key09","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[\"abc\",\"def\"]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:37+00:00"}'
@@ -4176,7 +4176,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key10?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key10?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"q-VIOPl5Qc_FEIB4KYQa9xLTnSVHTO1mwxJYvmR9sF0","key":"Key10","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[\"text\",true,null]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:37+00:00"}'
@@ -4223,7 +4223,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key11?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key11?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dXvY5LbpYBo8N_WzE_LMa5gJUhTFyEMg6_OvLCZhufQ","key":"Key11","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"Name\":\"Value\"}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:38+00:00"}'
@@ -4270,7 +4270,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key12?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key12?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"RxaDNM0kCxrIND5AxuuSifZ9EKHcgAwX1BUN6INeaRY","key":"Key12","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"MyNullValue\":null,\"MyObject\":{\"Property\":{\"Name\":{\"Name1\":\"Value1\",\"Name2\":[\"qqq\",\"rrr\"]}}},\"MyArray\":[1,2,3]}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:39+00:00"}'
@@ -4317,7 +4317,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key13?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key13?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"TT6MfZjYDx9vyVLn17gy-Puw_jTXRuYOtOdMD19m7KA","key":"Key13","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"}'
@@ -4364,7 +4364,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Fi-e44now8JNvD7XScXXyqj0VwnsMCsfRHH58_0bH6c","key":"Key14","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:40+00:00"}'
@@ -4411,7 +4411,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"obQcKRV8Jb1b1V6xk8dJFIKjhYTq6nrNOcfSd5RNPYk","key":"Key15","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{\"key1\":
@@ -4454,7 +4454,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"7nQ8fMcEPuMWq01T3mik4U99j6NZdp7g_jJro5fJybg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4498,7 +4498,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"ikWNzicghKr8ImcfBldA_8tgEedxdCk_LgHVK8tcAmg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -4539,7 +4539,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4578,7 +4578,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -4625,7 +4625,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"BAOiQumaAhfOdT2U-IHOJ-WO3L21-JFfSqqtncmOwOw","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -4674,7 +4674,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key01?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key01?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"H8Aedm60VBJVvkvmyWu2hIBPLmGnnmcal-lW5rAz9yw","key":"Key01","label":null,"content_type":"application/json","value":"\"Red\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:04+00:00"}'
@@ -4722,7 +4722,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key02?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key02?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"8_z3CmqfeuKVcGPY3_F-I-hqnkpwJyba11bTKukMZiw","key":"Key02","label":null,"content_type":"application/json;charset=utf-8","value":"\"RedRobinHood\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:05+00:00"}'
@@ -4770,7 +4770,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key03?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key03?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"VIZblB1oXPcu8hxgGOJZPrxyIM2sU4_YLbb6cUA54Pw","key":"Key03","label":null,"content_type":"application/boolean+json;","value":"true","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:05+00:00"}'
@@ -4818,7 +4818,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key04?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key04?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"mw0T2duUc3IWxO1MkGpYw_Pn2uBuv7qFRahijhTd2Fk","key":"Key04","label":null,"content_type":"application/json+text+number;charset=utf-8;param1=value1","value":"45.6","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:06+00:00"}'
@@ -4866,7 +4866,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key05?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key05?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"WG_eRckKU4SyulhPsteOTs-dtjmN4owxO35BzVw4LgY","key":"Key05","label":null,"content_type":"application/string+json;","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:07+00:00"}'
@@ -4914,7 +4914,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key06?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key06?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"MzzX6HS2LSjfLNFqoSfnQ1iXnNnYBqyudFN_InBIyXk","key":"Key06","label":null,"content_type":"application/string+json;","value":"\"999\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:08+00:00"}'
@@ -4962,7 +4962,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key07?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key07?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"sVyAGmb1bVNgiJyO6CGCSEyEad0FoYh1OWjpZOkPkLg","key":"Key07","label":null,"content_type":"application/json+null;charset=utf-8;","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:08+00:00"}'
@@ -5010,7 +5010,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key08?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key08?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"bRsCSD7Tib3UFuxCmFAzLklT7BbJXWY1QlRha02G-bA","key":"Key08","label":null,"content_type":"application/vnd.numericarray+json","value":"[1,2,3,4]","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:09+00:00"}'
@@ -5058,7 +5058,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key09?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key09?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"qy3DG3mgcvaIRobDzw2tHMU8mle_5QHlM7S8F8kLeVw","key":"Key09","label":null,"content_type":"application/vnd.stringarray+json","value":"[\"abc\",\"def\"]","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:10+00:00"}'
@@ -5106,7 +5106,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key10?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key10?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Uz2Dp9HkO8FDx2mkzkfw_8WfoJCFlGGsqewU1B-qLXg","key":"Key10","label":null,"content_type":"application/json+hybridarray","value":"[\"text\",true,null]","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:11+00:00"}'
@@ -5154,7 +5154,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key11?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key11?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"df9AW3Uce8moroxlm6KUJSdfmWxMREsy73vdPPABE_0","key":"Key11","label":null,"content_type":"application/json","value":"{\"Name\":\"Value\"}","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:11+00:00"}'
@@ -5202,7 +5202,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key12?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key12?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"7FhpXARGFO17nqlMBM7l9dfv-KrBursQZmqcMtx2ICM","key":"Key12","label":null,"content_type":"application/json","value":"{\"MyNullValue\":null,\"MyObject\":{\"Property\":{\"Name\":{\"Name1\":\"Value1\",\"Name2\":[\"qqq\",\"rrr\"]}}},\"MyArray\":[1,2,3]}","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:12+00:00"}'
@@ -5250,7 +5250,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key13?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key13?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_ysmeUR5voV0SAMWCkCERHWxbC6xcmlM_6wkaTzS_tY","key":"Key13","label":null,"content_type":"application/null+json+empty","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:13+00:00"}'
@@ -5298,7 +5298,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"h4lftWXTjTCD35j9ARTglWf57xxvEI2--b9y2WxGQo4","key":"Key14","label":null,"content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:13+00:00"}'
@@ -5347,7 +5347,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"9Ch7PKBB60BzzJaNrOxYt6KkSBktbtprNNgcqtBDIYk","key":"Key15","label":null,"content_type":"application/json","value":"{\"key1\":
@@ -5399,7 +5399,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"zkYzUIsw2UDsZHIgHbLRsENUICVLejD-TZlg1PxItBo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5442,7 +5442,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"7nQ8fMcEPuMWq01T3mik4U99j6NZdp7g_jJro5fJybg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5486,7 +5486,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"ikWNzicghKr8ImcfBldA_8tgEedxdCk_LgHVK8tcAmg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5527,7 +5527,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"7W02PMXfW2hBcqXrtlPNs7nXg0X2x3F7obyfgYQ1DxQ","items":[{"etag":"zkYzUIsw2UDsZHIgHbLRsENUICVLejD-TZlg1PxItBo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5571,7 +5571,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://destination000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"v9iF_HAppyGQUfLBY-lQ3aTdB_e7cBcU6JFObxFMpHk","items":[{"etag":"zkYzUIsw2UDsZHIgHbLRsENUICVLejD-TZlg1PxItBo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5612,7 +5612,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"7nQ8fMcEPuMWq01T3mik4U99j6NZdp7g_jJro5fJybg","items":[{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5662,7 +5662,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"sdoEur8phvsLNd1KkaMVgZy2KcGqnfjQvlGvKC9giQw","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -5711,7 +5711,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"JBwrPfY210PTyka2_zO9BW3mrHR_hOWMYXeJPuIJpfw","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -5759,7 +5759,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key01?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key01?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"F5x1CUnwOl93dmOojS8ao4L0a81KrBWTJaOR15c_VJA","key":"Key01","label":null,"content_type":"application/json","value":"\"Red\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:55+00:00"}'
@@ -5806,7 +5806,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key02?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key02?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"RWONF0eIjvs5ZdegnGuNelBM5bXmTwLsqWRxe_xbdbA","key":"Key02","label":null,"content_type":"application/json;charset=utf-8","value":"\"RedRobinHood\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:56+00:00"}'
@@ -5853,7 +5853,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key03?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key03?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"UdEikfNzhvNuagLPngejuvXKojydRiS2XaA80sdKrC4","key":"Key03","label":null,"content_type":"application/boolean+json;","value":"true","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:58+00:00"}'
@@ -5900,7 +5900,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key04?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key04?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HgKF5z0mwkjrDR1ZO0Mi7M9_QOERx1b2VoAagi2Ln5c","key":"Key04","label":null,"content_type":"application/json+text+number;charset=utf-8;param1=value1","value":"45.6","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:59+00:00"}'
@@ -5947,7 +5947,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key05?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key05?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"lIcax6J88nfrmYjrzbKu-m9M1tnJg0C5nAELDpEk0yw","key":"Key05","label":null,"content_type":"application/string+json;","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:01+00:00"}'
@@ -5994,7 +5994,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key06?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key06?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"PJ6sHjOfLMYPtehF3H-j_lqTemwA40vWToT0oZsRuLc","key":"Key06","label":null,"content_type":"application/string+json;","value":"\"999\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:02+00:00"}'
@@ -6041,7 +6041,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key07?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key07?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"xSiTGkFo3-FfDJxfL4KtYCEiEAGETzagArwC8z-I2Lw","key":"Key07","label":null,"content_type":"application/json+null;charset=utf-8;","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:04+00:00"}'
@@ -6088,7 +6088,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key08?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key08?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"2vfGIvtA6tV9MgAb71wToPqhmyz4G6HBDXybDItGi0g","key":"Key08","label":null,"content_type":"application/vnd.numericarray+json","value":"[1,2,3,4]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:05+00:00"}'
@@ -6135,7 +6135,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key09?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key09?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_YP_6H4OJH6gY9mVpGmj0xQzxdEV9fVyAQphp45Ve-E","key":"Key09","label":null,"content_type":"application/vnd.stringarray+json","value":"[\"abc\",\"def\"]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"}'
@@ -6182,7 +6182,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key10?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key10?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"eOaJFpoysMRR4H1ch9aD1DF9uylB78q3-D8-_0szM2I","key":"Key10","label":null,"content_type":"application/json+hybridarray","value":"[\"text\",true,null]","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:08+00:00"}'
@@ -6229,7 +6229,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key11?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key11?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"ZFRPRGNNZ-WRKDRc5J6jg4SsHGUDDHTXT4eewlUNVW4","key":"Key11","label":null,"content_type":"application/json","value":"{\"Name\":\"Value\"}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:10+00:00"}'
@@ -6276,7 +6276,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key12?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key12?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dxxeEq4qsnXj0bMm1azgVRdVn7EsOTIaL6jSUirjeJc","key":"Key12","label":null,"content_type":"application/json","value":"{\"MyNullValue\":null,\"MyObject\":{\"Property\":{\"Name\":{\"Name1\":\"Value1\",\"Name2\":[\"qqq\",\"rrr\"]}}},\"MyArray\":[1,2,3]}","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:12+00:00"}'
@@ -6323,7 +6323,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key13?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key13?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Ez2Zbe96Cdf8rs2Hm3y_PZ8w8Vl6SeNkEkdf2Em0z54","key":"Key13","label":null,"content_type":"application/null+json+empty","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"}'
@@ -6370,7 +6370,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"gzVkpgbYPR2JVAW-FRuZs1_ZzxnqeuYjMQxr62LYGag","key":"Key14","label":null,"content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:17+00:00"}'
@@ -6417,7 +6417,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://source000001.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"eUCvbWcBSSc7HqKRIHuDP_f4-UZ0LzuUe1r7AR2FD88","key":"Key15","label":null,"content_type":"application/json","value":"{\"key1\":
@@ -6460,7 +6460,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://destination000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://destination000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"7W02PMXfW2hBcqXrtlPNs7nXg0X2x3F7obyfgYQ1DxQ","items":[{"etag":"zkYzUIsw2UDsZHIgHbLRsENUICVLejD-TZlg1PxItBo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -6510,7 +6510,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"zkYzUIsw2UDsZHIgHbLRsENUICVLejD-TZlg1PxItBo","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -6559,7 +6559,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"BAOiQumaAhfOdT2U-IHOJ-WO3L21-JFfSqqtncmOwOw","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -6607,7 +6607,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key01?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key01?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"H8Aedm60VBJVvkvmyWu2hIBPLmGnnmcal-lW5rAz9yw","key":"Key01","label":null,"content_type":"application/json","value":"\"Red\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:04+00:00"}'
@@ -6654,7 +6654,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key02?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key02?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"8_z3CmqfeuKVcGPY3_F-I-hqnkpwJyba11bTKukMZiw","key":"Key02","label":null,"content_type":"application/json;charset=utf-8","value":"\"RedRobinHood\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:05+00:00"}'
@@ -6701,7 +6701,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key03?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key03?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"VIZblB1oXPcu8hxgGOJZPrxyIM2sU4_YLbb6cUA54Pw","key":"Key03","label":null,"content_type":"application/boolean+json;","value":"true","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:05+00:00"}'
@@ -6748,7 +6748,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key04?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key04?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"mw0T2duUc3IWxO1MkGpYw_Pn2uBuv7qFRahijhTd2Fk","key":"Key04","label":null,"content_type":"application/json+text+number;charset=utf-8;param1=value1","value":"45.6","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:06+00:00"}'
@@ -6795,7 +6795,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key05?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key05?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"WG_eRckKU4SyulhPsteOTs-dtjmN4owxO35BzVw4LgY","key":"Key05","label":null,"content_type":"application/string+json;","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:07+00:00"}'
@@ -6842,7 +6842,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key06?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key06?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"MzzX6HS2LSjfLNFqoSfnQ1iXnNnYBqyudFN_InBIyXk","key":"Key06","label":null,"content_type":"application/string+json;","value":"\"999\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:08+00:00"}'
@@ -6889,7 +6889,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key07?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key07?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"sVyAGmb1bVNgiJyO6CGCSEyEad0FoYh1OWjpZOkPkLg","key":"Key07","label":null,"content_type":"application/json+null;charset=utf-8;","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:08+00:00"}'
@@ -6936,7 +6936,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key08?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key08?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"bRsCSD7Tib3UFuxCmFAzLklT7BbJXWY1QlRha02G-bA","key":"Key08","label":null,"content_type":"application/vnd.numericarray+json","value":"[1,2,3,4]","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:09+00:00"}'
@@ -6983,7 +6983,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key09?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key09?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"qy3DG3mgcvaIRobDzw2tHMU8mle_5QHlM7S8F8kLeVw","key":"Key09","label":null,"content_type":"application/vnd.stringarray+json","value":"[\"abc\",\"def\"]","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:10+00:00"}'
@@ -7030,7 +7030,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key10?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key10?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Uz2Dp9HkO8FDx2mkzkfw_8WfoJCFlGGsqewU1B-qLXg","key":"Key10","label":null,"content_type":"application/json+hybridarray","value":"[\"text\",true,null]","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:11+00:00"}'
@@ -7077,7 +7077,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key11?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key11?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"df9AW3Uce8moroxlm6KUJSdfmWxMREsy73vdPPABE_0","key":"Key11","label":null,"content_type":"application/json","value":"{\"Name\":\"Value\"}","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:11+00:00"}'
@@ -7124,7 +7124,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key12?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key12?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"7FhpXARGFO17nqlMBM7l9dfv-KrBursQZmqcMtx2ICM","key":"Key12","label":null,"content_type":"application/json","value":"{\"MyNullValue\":null,\"MyObject\":{\"Property\":{\"Name\":{\"Name1\":\"Value1\",\"Name2\":[\"qqq\",\"rrr\"]}}},\"MyArray\":[1,2,3]}","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:12+00:00"}'
@@ -7171,7 +7171,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key13?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key13?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_ysmeUR5voV0SAMWCkCERHWxbC6xcmlM_6wkaTzS_tY","key":"Key13","label":null,"content_type":"application/null+json+empty","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:13+00:00"}'
@@ -7218,7 +7218,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key14?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key14?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"h4lftWXTjTCD35j9ARTglWf57xxvEI2--b9y2WxGQo4","key":"Key14","label":null,"content_type":"","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:13+00:00"}'
@@ -7265,7 +7265,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://destination000002.azconfig.io/kv/Key15?api-version=2023-11-01
+    uri: https://destination000003.azconfig.io/kv/Key15?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"9Ch7PKBB60BzzJaNrOxYt6KkSBktbtprNNgcqtBDIYk","key":"Key15","label":null,"content_type":"application/json","value":"{\"key1\":
@@ -7308,7 +7308,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -7349,7 +7349,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -7396,7 +7396,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Array?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Array?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"lvER4wCoIeN_5AexutuAoBoeONzdbqZbsw3GqOShYeA","key":"Array","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[\"StringBoolValue\",
@@ -7448,7 +7448,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyHybridList?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyHybridList?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Sk_2-83m5jI9E96nnskkvMivWsoWYgX8uTRj7NBlhdY","key":"ComplexSettings:MyHybridList","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[1000,
@@ -7501,7 +7501,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyListOfHybridLists?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyListOfHybridLists?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"pI7F_NjHIz7-y1GbGXQbU6KV6K_E36BwApYwwjFR-bk","key":"ComplexSettings:MyListOfHybridLists","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[[\"NestedArray4\",
@@ -7554,7 +7554,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyListOfStringLists?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyListOfStringLists?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"31KXaG6JAuOvobOB9gpwbFl8P-UyUX4r6Ma9f166Jnw","key":"ComplexSettings:MyListOfStringLists","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[[\"NestedArray1\",
@@ -7604,7 +7604,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyNestedObjects%3AObject1?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyNestedObjects%3AObject1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"uA0a0AR_zHXoVDjaFKQSrdqUOrbmkcG2moAXeE2KVd8","key":"ComplexSettings:MyNestedObjects:Object1","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Value1\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:51+00:00"}'
@@ -7653,7 +7653,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyNestedObjects%3AObject2%3AProperty%3AName%3AName1?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyNestedObjects%3AObject2%3AProperty%3AName%3AName1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"-EEA1Q0RlnU5aG29Xi_SGg43nMzVl48QqLSyOzthjTU","key":"ComplexSettings:MyNestedObjects:Object2:Property:Name:Name1","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Value1\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:52+00:00"}'
@@ -7702,7 +7702,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyNestedObjects%3AObject2%3AProperty%3AName%3AName2?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyNestedObjects%3AObject2%3AProperty%3AName%3AName2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"nWxv1sT1e5KBvL2xoFCwD2XrB1nF458VKOybBDsT2Mk","key":"ComplexSettings:MyNestedObjects:Object2:Property:Name:Name2","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Value2\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:52+00:00"}'
@@ -7751,7 +7751,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyNullValue?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyNullValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"I99BBqCpUD4Df4FcNlN6KscpxlmaXxZlsYiOnm8qMh4","key":"ComplexSettings:MyNullValue","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:53+00:00"}'
@@ -7800,7 +7800,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyNumberList?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyNumberList?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"2QKqQQJIDKqQhXlS16dsnSNkObWmUFuN_CwDrgBKliI","key":"ComplexSettings:MyNumberList","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[10,
@@ -7850,7 +7850,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyObject%3AObjectSetting%3ALogging%3ADefault?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyObject%3AObjectSetting%3ALogging%3ADefault?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"jTu8wVRgNZFZJWVDcO8iztINkMU1W0wjxJAFm-0vjjg","key":"ComplexSettings:MyObject:ObjectSetting:Logging:Default","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Debug\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:54+00:00"}'
@@ -7899,7 +7899,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyObject%3AObjectSetting%3ALogging%3ALogLevel?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyObject%3AObjectSetting%3ALogging%3ALogLevel?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"47A6OsFcRsMS1PGmGa7Ryj460MGRm_VJtjRAvLc4Qqc","key":"ComplexSettings:MyObject:ObjectSetting:Logging:LogLevel","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Information\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:55+00:00"}'
@@ -7948,7 +7948,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/ComplexSettings%3AMyStringList?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/ComplexSettings%3AMyStringList?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"yOoAzKTCzMODygbXElRxYVm8NmQcohmfQnOO23zwTMU","key":"ComplexSettings:MyStringList","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[\"abc\",
@@ -7998,7 +7998,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/KeyVaultRef2%3Auri?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/KeyVaultRef2%3Auri?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"hvnX9PicHE9asD7Sb82CyHcADMHissEqSsqC-cOJHnA","key":"KeyVaultRef2:uri","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"https://keyvault-importexport.vault.azure.net/secrets/ManuallyCreatedSecret\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:57+00:00"}'
@@ -8047,7 +8047,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/KeyVaultRef%3Auri?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/KeyVaultRef%3Auri?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"wn7GJeU1rJGmc0xTtFxM16jA0x1ebfggluCh6bOzvx8","key":"KeyVaultRef:uri","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"https://keyvault-importexport.vault.azure.net/secrets/ManuallyCreatedCert\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:57+00:00"}'
@@ -8095,7 +8095,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Object1%3AObj1?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Object1%3AObj1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"EViWkvrSud-h1p02ohwSx8bjRzAEJEY9zk0mme8J3BQ","key":"Object1:Obj1","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"null\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:58+00:00"}'
@@ -8143,7 +8143,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Object1%3AObj2?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Object1%3AObj2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"DP580HJOXAp6mrbzrxf-Bv9BQNxzC73N1fJcUDcx1y4","key":"Object1:Obj2","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:59+00:00"}'
@@ -8191,7 +8191,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Object1%3AObj3?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Object1%3AObj3?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"fOd7llCCjwetV8sdcHIhmmQWv9meLyF1ZLUz-vMR5gM","key":"Object1:Obj3","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"33\"","tags":{},"locked":false,"last_modified":"2026-07-02T21:59:59+00:00"}'
@@ -8239,7 +8239,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Object2%3AObj1?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Object2%3AObj1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"FqCh7Mr5BSxSQcOEM5ZCm-48XNr63gx4BlVQI6R2aMg","key":"Object2:Obj1","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:00+00:00"}'
@@ -8287,7 +8287,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Object2%3AObj2?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Object2%3AObj2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"5hW-CtrO-1dtJ0ZlBrabERZW4_zQkOsvw2ZU5Q8VJ8Y","key":"Object2:Obj2","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"false","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:01+00:00"}'
@@ -8335,7 +8335,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/Object2%3AObj3?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/Object2%3AObj3?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"E4Ms21Z_HyipstriTqoi04hzThmda3mY1Ck_I41P1UY","key":"Object2:Obj3","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"666","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:01+00:00"}'
@@ -8384,7 +8384,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AAppName?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AAppName?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"4CxGig_oZCM3y2UOzwDQAR8-3eRzHeu4MD3GBLAclx0","key":"SimpleSettings:AppName","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Azure
@@ -8434,7 +8434,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3ABackgroundColor?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3ABackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"yfAFL4SvcdErMb3xQHcHoC_--6YLc1U0QeWywBTsUf8","key":"SimpleSettings:BackgroundColor","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Yellow\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:03+00:00"}'
@@ -8482,7 +8482,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AFontSize?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AFontSize?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"oADUPb6lHCgpuYPpf4wq_G2HQJTL4SCPZV5vBEwEMzM","key":"SimpleSettings:FontSize","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"50","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:04+00:00"}'
@@ -8531,7 +8531,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3ALanguage?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3ALanguage?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"yfg6qR9gtDQ5wCp4jk0T_ZeOGJaUCL5PGPbruKWaddg","key":"SimpleSettings:Language","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"English\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:05+00:00"}'
@@ -8580,7 +8580,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMessages?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMessages?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"6fXbcvon7LWojKtvNdBhPsczu_rjoWGR93FNzMUTW2M","key":"SimpleSettings:Messages","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Hello
@@ -8630,7 +8630,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyBoolValue?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyBoolValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"TTpLhQ7Myf5uRixcf9uHIi0n-Yop1IGcUBhr9Dr6U7k","key":"SimpleSettings:MyBoolValue","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"true","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:06+00:00"}'
@@ -8679,7 +8679,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyDateTime?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyDateTime?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"t5PnvmjU2PlCaxrxIfLPBAV9W0HiR6-R-gcxSGWAz8A","key":"SimpleSettings:MyDateTime","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"2020-01-01T12:34:56.789Z\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:07+00:00"}'
@@ -8727,7 +8727,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyEmptyList?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyEmptyList?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"dSfEJ1d2soTXoY2wL9b4FuqjjVwVoIobtwteLAmNx_8","key":"SimpleSettings:MyEmptyList","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[]","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:07+00:00"}'
@@ -8776,7 +8776,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyEmptyObject?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyEmptyObject?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"vF9nf9u1WpLpbq1_-zZuLvDFfV32kv3ItwYPNMnNFcA","key":"SimpleSettings:MyEmptyObject","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"{}","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:08+00:00"}'
@@ -8825,7 +8825,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyNullValue?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyNullValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"Zhgw0ucQokqoyxa17I4iDce4gbQyLSiShcAUwS3exZk","key":"SimpleSettings:MyNullValue","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"null","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:09+00:00"}'
@@ -8874,7 +8874,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyNumberList?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyNumberList?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"ROl99eW7X0f3Ers0L7tqQ30hdZbh4S4maPPQwzcrt6I","key":"SimpleSettings:MyNumberList","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[10,
@@ -8924,7 +8924,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyObject%3AObjectSetting%3ALogging%3ADefault?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyObject%3AObjectSetting%3ALogging%3ADefault?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"SwpiWNOjh0sRXJh_1lRs7zzW_88H5mcIBSS45yMSNYY","key":"SimpleSettings:MyObject:ObjectSetting:Logging:Default","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Debug\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:10+00:00"}'
@@ -8973,7 +8973,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyObject%3AObjectSetting%3ALogging%3ALogLevel?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyObject%3AObjectSetting%3ALogging%3ALogLevel?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"AH5uPVIllp_ho0g-km_H2o3VJYyzL0_GOeLnP_Z3yN8","key":"SimpleSettings:MyObject:ObjectSetting:Logging:LogLevel","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"Information\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:11+00:00"}'
@@ -9022,7 +9022,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AMyStringList?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AMyStringList?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"6ws58hUnTOQutTJQ3tgg1mMUXEIOvth931nzxibB0PM","key":"SimpleSettings:MyStringList","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"[\"abc\",
@@ -9072,7 +9072,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3ARefreshRate?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3ARefreshRate?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"UcCzz8OkEH3lXG6M8VY0-Fkitn4MXFhbMBWFyIZV1-o","key":"SimpleSettings:RefreshRate","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"3000","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:12+00:00"}'
@@ -9120,7 +9120,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/SimpleSettings%3AVersion?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/SimpleSettings%3AVersion?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"fF4LGVW3TUeY6WVQ0HROspCzvFHgqC8SnTZDLlfoe2c","key":"SimpleSettings:Version","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"1.1","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:13+00:00"}'
@@ -9168,7 +9168,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/StringBoolValue?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/StringBoolValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"o7HJCMfn1PXzIo99Cv9irIIlvVGCqWZCR-6STe-SCgw","key":"StringBoolValue","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"true\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:14+00:00"}'
@@ -9216,7 +9216,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/StringNullValue?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/StringNullValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"PgUHnaFiTRF51KnLDUFAT-KhL8-AK1R6uqItmHjF2MY","key":"StringNullValue","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"null\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:14+00:00"}'
@@ -9264,7 +9264,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/StringNumberValue?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/StringNumberValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"mAZ4sMfti7-LrLYkL6-RIuOgY7T2xAP28808HJxjX-I","key":"StringNumberValue","label":null,"content_type":"application/vnd.microsoft.appconfig.aichatcompletion+json;charset=utf-8","value":"\"20.2\"","tags":{},"locked":false,"last_modified":"2026-07-02T22:00:15+00:00"}'
@@ -9316,7 +9316,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"a0ZE6SISWn63Bvk0LjcHuoI3Vab469BzDAhHSWFD9bU","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9370,7 +9370,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FDisabledFeature?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FDisabledFeature?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"QnvqayPUK6I0VggJ_r3atudGJFlC32UedhQ1WqMVjYg","key":".appconfig.featureflag/DisabledFeature","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9421,7 +9421,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FEnabledFeature?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FEnabledFeature?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"ZJcIaYs9yok6M_6yJSjJ56aPU8cwD6KHE7Pu3OxXs8w","key":".appconfig.featureflag/EnabledFeature","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9473,7 +9473,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FFeature1?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FFeature1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"0cYVgPYJug-B9aiLOJVhZmNliCva6u7LSXKkEIQx3dQ","key":".appconfig.featureflag/Feature1","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9525,7 +9525,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FFeature2?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FFeature2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"xss5EWIiGwAo0SPtonraerEefDpVoUI9Cw3V6hsYaKw","key":".appconfig.featureflag/Feature2","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9579,7 +9579,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2Flevel?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2Flevel?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"495ToDVqclyKfySfudYlDSmtTHWb2XU5l-CNkMt5Zfw","key":".appconfig.featureflag/level","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9634,7 +9634,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2Ftesting?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2Ftesting?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"upfdPSI6Zs765XWn5H9ItV5LCeD8sJGjnpXM4GMbNgQ","key":".appconfig.featureflag/testing","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9688,7 +9688,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"VszKDJZZzF5e6aTU0RGo7knJo-ffexrWIVhp3hZRCRQ","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9742,7 +9742,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FDisabledFeature?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FDisabledFeature?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"P-G76G-Ds7ox3WvHLvTU-sUdXKKSGcE_vKHSWGnf1qY","key":".appconfig.featureflag/DisabledFeature","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9793,7 +9793,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FEnabledFeature?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FEnabledFeature?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_uPuPbWT5ICC3dHSOmq1svLuiY-PcM9H8gnOhJA_hK4","key":".appconfig.featureflag/EnabledFeature","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9845,7 +9845,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FFeature1?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FFeature1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"3LTjV2Vwc1YBaZr2LaqCMN3SkvXLFlH3iJoXW_mC34o","key":".appconfig.featureflag/Feature1","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9897,7 +9897,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2FFeature2?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2FFeature2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"tqizJLQiV4HxaGwF_-yZgkcFyeYIFEbz77usbWpYUBw","key":".appconfig.featureflag/Feature2","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -9951,7 +9951,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2Flevel?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2Flevel?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"MoCQ8LDJ3cJ8uQWu9mFLMYQxOtjyw4ilwRWuCxepwqk","key":".appconfig.featureflag/level","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -10006,7 +10006,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://source000001.azconfig.io/kv/.appconfig.featureflag%2Ftesting?api-version=2023-11-01
+    uri: https://source000002.azconfig.io/kv/.appconfig.featureflag%2Ftesting?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"obi8fWAYLCaVJNYBLhU1_rEBFRhuiswJuJYREG7nlC4","key":".appconfig.featureflag/testing","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -10049,7 +10049,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"LJHO7nwf95j3iolydDTWuRUJDa8P1NSsZwvIaFzuGZE","items":[{"etag":"VszKDJZZzF5e6aTU0RGo7knJo-ffexrWIVhp3hZRCRQ","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -10121,7 +10121,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"_IDf-zfjeevids5XqzsGI46DNChFfMVP9ky6WaLPYQM","items":[{"etag":"VszKDJZZzF5e6aTU0RGo7knJo-ffexrWIVhp3hZRCRQ","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -10180,7 +10180,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://source000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"LJHO7nwf95j3iolydDTWuRUJDa8P1NSsZwvIaFzuGZE","items":[{"etag":"VszKDJZZzF5e6aTU0RGo7knJo-ffexrWIVhp3hZRCRQ","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -10252,7 +10252,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://source000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://source000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"_IDf-zfjeevids5XqzsGI46DNChFfMVP9ky6WaLPYQM","items":[{"etag":"VszKDJZZzF5e6aTU0RGo7knJo-ffexrWIVhp3hZRCRQ","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_json_content_type.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_json_content_type.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
         "name": "source000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/source000001",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/source000001",
         "name": "source000001", "tags": {}}'
     headers:
       cache-control:
@@ -353,7 +353,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -362,7 +362,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
         "name": "destination000002", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -620,7 +620,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -633,7 +633,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:17+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
+        "User", "lastModifiedAt": "2026-07-02T21:57:17+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/destination000002",
         "name": "destination000002", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_key_validation.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_key_validation.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
         "name": "kvtest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
         "name": "kvtest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_key_validation.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_key_validation.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
-        "name": "kvtest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002",
+        "name": "kvtest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.UXAvA-0espmPUj3Cz6O3f884-Y_czb_9DB_T4runXOo?api-version=2025-08-01-preview&t=639186261999025668&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=X4iqUyyce68bJlZqnNCrtOVfA0HTBcO-ZU3ezUymvCmOujgcUouafhsOy1QuTOp6FSkvm-4GyzQTUbHus6v9EZ-NpyfP_WSpBLiNx3vhsqcvZoaHCvveNfd-fPODAHi__HILkrPNoD_qB94iEkGCZL1NVPvtORTN3OBnxs5I9KJKzYOHBu8aJ4J1NDH3xVc0QcXcA9ANUPpO-KPyXfAzpr8euPrj5FGhZU_3QXlKT5NPByKhPEsftqtSPaFzyNr0WcdI4QTxVwaFgH2lV4Cju6s5V_MbUFnMMTMiihu17UIYOq4TcSLfqDFo3t6Cf8KsCTo9IfhOX8tsGN0JOOzmBw&h=5p5wOPpxhIX-JwTVQ8AP0y1mronSV_hHCD518XehFyY
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:56:39+00:00", "endpoint": "https://kvtest000001.azconfig.io",
+        "2026-07-02T21:56:39+00:00", "endpoint": "https://kvtest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
-        "name": "kvtest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002",
+        "name": "kvtest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -384,7 +384,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -429,7 +429,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/Language?api-version=2023-11-01
+    uri: https://kvtest000002.azconfig.io/kv/Language?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"UPcMgb6slZll8rBRUAtmPeX2FieC9zZ945KNJNONfzs","key":"Language","label":null,"content_type":null,"value":"spanish","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:20+00:00"}'
@@ -478,7 +478,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://kvtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"-KnxqlVGKbfg1_IvG_tQJlqB5e1spKqJU5f9T71C3tE","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -528,7 +528,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
+    uri: https://kvtest000002.azconfig.io/kv/.appconfig.featureflag%2FBeta?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_4GL8Yv7vAmMyBc57a4UJJAXsrq468Ib8J79xi7JCQE","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -570,7 +570,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&label=%00
   response:
     body:
       string: '{"etag":"7RpTbJoHBbKukXc2ghQ3OC9b_uPJlPQIBtduRlbY_Bg","items":[{"etag":"_4GL8Yv7vAmMyBc57a4UJJAXsrq468Ib8J79xi7JCQE","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -610,7 +610,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://kvtest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"nydQm_-YuA2P2bX0GDQU459CaLMm1k8--Zy1k-RzEYs","items":[{"etag":"_4GL8Yv7vAmMyBc57a4UJJAXsrq468Ib8J79xi7JCQE","key":".appconfig.featureflag/Beta","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
         "name": "kvtest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
         "name": "kvtest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
-        "name": "kvtest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002",
+        "name": "kvtest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.-ncrwZZgbgY-b2MrCPhvh8CLSHSy4L02efYfb-3fxQo?api-version=2025-08-01-preview&t=639186262451670648&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=N37d8pz76h9BD-Y88UkSLpxlbzFJ9jD5KNKQHOV0US08_6JfwCgX_CXc-XP60JcPfVjo6FDlqJOkljqDlZAQL3LITZ_hLgH3UEQxkWQpLBHRlKmxvf4OzIfztLaBMyhPuUJUfDJKLT6FYSfdu2YPcCbWQaUPaCSE2-Z0tTJChwrQwA9e1l9ju2vgzlOQkZ10fEWBSVW7J_L2dTeRhW9zRKn2zbMEPxaSxvFncNTp-d3iMB7iTuxUOS9gtivE7rnq6uDeHtoxJZQ1Jf3ZUxaVSgldG2wxI_7wMKLlxAvOfmOUC6oKurcOdgK25g5JolyPUqG4yGICYifcAS4lFuLgtQ&h=2SnKpdP2Eb1GsMXfkBfefIAhcefDsoEtnCLyKVfkIZM
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:57:25+00:00", "endpoint": "https://kvtest000001.azconfig.io",
+        "2026-07-02T21:57:25+00:00", "endpoint": "https://kvtest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:57:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000001",
-        "name": "kvtest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:57:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvtest000002",
+        "name": "kvtest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: ''
@@ -386,7 +386,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: '{"etag":"pJTyCF_bDjOUts05WueCvbx7NOh7Ia9x7KeRcBCkbFE","key":"Color","label":"v1.0.0","content_type":"","value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:03+00:00"}'
@@ -427,7 +427,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: '{"etag":"pJTyCF_bDjOUts05WueCvbx7NOh7Ia9x7KeRcBCkbFE","key":"Color","label":"v1.0.0","content_type":"","value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:03+00:00"}'
@@ -477,7 +477,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: '{"etag":"tMGQllBjAbH6z6-KpBdwP79fIUhh78dgCF3imUUlnQs","key":"Color","label":"v1.0.0","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:05+00:00"}'
@@ -518,7 +518,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: ''
@@ -562,7 +562,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"i82gzm6-G_780u56xFybUknGIhr7j3eARoBXAJNH-Ac","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"}'
@@ -603,7 +603,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"i82gzm6-G_780u56xFybUknGIhr7j3eARoBXAJNH-Ac","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"}'
@@ -644,7 +644,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"BIb3L3LEkxmxSXnbuuPpSjQq4hJvmxUw6ftpodSClU4","items":[{"etag":"i82gzm6-G_780u56xFybUknGIhr7j3eARoBXAJNH-Ac","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"},{"etag":"tMGQllBjAbH6z6-KpBdwP79fIUhh78dgCF3imUUlnQs","key":"Color","label":"v1.0.0","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:05+00:00"}]}'
@@ -683,7 +683,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/revisions?api-version=2023-11-01&key=Color&label=%2A
+    uri: https://kvtest000002.azconfig.io/revisions?api-version=2023-11-01&key=Color&label=%2A
   response:
     body:
       string: '{"etag":"kvCxJ8BlhVtByPfyaqJfEURW3mpVyVUX-JiAeI501AY","items":[{"etag":"i82gzm6-G_780u56xFybUknGIhr7j3eARoBXAJNH-Ac","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"},{"etag":"tMGQllBjAbH6z6-KpBdwP79fIUhh78dgCF3imUUlnQs","key":"Color","label":"v1.0.0","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:05+00:00"},{"etag":"pJTyCF_bDjOUts05WueCvbx7NOh7Ia9x7KeRcBCkbFE","key":"Color","label":"v1.0.0","content_type":"","value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:03+00:00"}]}'
@@ -724,7 +724,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
   response:
     body:
       string: '{"etag":"7ciPwUednhmF5D4ngmkg_Z4sx1m19ukxhmws_vI017o","items":[{"etag":"i82gzm6-G_780u56xFybUknGIhr7j3eARoBXAJNH-Ac","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"}]}'
@@ -769,7 +769,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"i82gzm6-G_780u56xFybUknGIhr7j3eARoBXAJNH-Ac","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"}'
@@ -810,7 +810,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: ''
@@ -853,7 +853,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"zI5YKfNsUrz2mDvP9RudMKJmhAO1AlpHrlQboOl3nN4","key":"Color","label":"newlabel","content_type":"text","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"}'
@@ -896,7 +896,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
   response:
     body:
       string: '{"etag":"7ciPwUednhmF5D4ngmkg_Z4sx1m19ukxhmws_vI017o","items":[{"etag":"i82gzm6-G_780u56xFybUknGIhr7j3eARoBXAJNH-Ac","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:07+00:00"}]}'
@@ -941,7 +941,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
   response:
     body:
       string: '{"etag":"NmLeW1c1mdumE3uYyosjxP32EA6XM0z3ETT3huplLQA","items":[{"etag":"zI5YKfNsUrz2mDvP9RudMKJmhAO1AlpHrlQboOl3nN4","key":"Color","label":"newlabel","content_type":"text","value":"Red","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:13+00:00"}]}'
@@ -987,7 +987,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"ax9Flhl6SdWbjlnQjhFZwQqnPBqutTgedmgrYByJcR0","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"}'
@@ -1028,7 +1028,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
   response:
     body:
       string: '{"etag":"0bpbfjtvN0_dX1ZPSnGZNHoXwpxJcfhRQ0vSyIj-Ux4","items":[{"etag":"ax9Flhl6SdWbjlnQjhFZwQqnPBqutTgedmgrYByJcR0","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"}]}'
@@ -1067,7 +1067,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://kvtest000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1111,7 +1111,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/HostSecrets?api-version=2023-11-01
+    uri: https://kvtest000002.azconfig.io/kv/HostSecrets?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"y2tN0N8Av0ap5WXrC9DiRVe2sWK3uduIA80ultLKpVE","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1153,7 +1153,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"ax9Flhl6SdWbjlnQjhFZwQqnPBqutTgedmgrYByJcR0","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:16+00:00"}'
@@ -1204,7 +1204,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"1z6tcX4YMbowRQZ2ESNkfyOJRpjaovpUQwSjO-uQ6yM","key":"Color","label":"newlabel","content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1246,7 +1246,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=Color&label=newlabel
   response:
     body:
       string: '{"etag":"FjnRtQ6coUIAnhkhobE6ZcUIbXOW9DRhHKbzIHvysjA","items":[{"etag":"1z6tcX4YMbowRQZ2ESNkfyOJRpjaovpUQwSjO-uQ6yM","key":"Color","label":"newlabel","content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1292,7 +1292,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://kvtest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvtest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"1z6tcX4YMbowRQZ2ESNkfyOJRpjaovpUQwSjO-uQ6yM","key":"Color","label":"newlabel","content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1334,7 +1334,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/KvWithNullLabel?api-version=2023-11-01
+    uri: https://kvtest000002.azconfig.io/kv/KvWithNullLabel?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1377,7 +1377,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/KvWithNullLabel?api-version=2023-11-01
+    uri: https://kvtest000002.azconfig.io/kv/KvWithNullLabel?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_AzFa41sVQH5-ksUX2ZDAcBiWp3cjcbHLsEIfJ9PPIM","key":"KvWithNullLabel","label":null,"content_type":"","value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:23+00:00"}'
@@ -1418,7 +1418,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"T8-H9JGWcNdYSBXC8FYEDVqmP2EO5x6H43IJ0_SvloM","items":[{"etag":"y2tN0N8Av0ap5WXrC9DiRVe2sWK3uduIA80ultLKpVE","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1458,7 +1458,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=v1.0.0%2C%00
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=v1.0.0%2C%00
   response:
     body:
       string: '{"etag":"hd06_qclAnnzVF4R9ASXfwnTRNdPBGwhbXnad4VsF84","items":[{"etag":"tMGQllBjAbH6z6-KpBdwP79fIUhh78dgCF3imUUlnQs","key":"Color","label":"v1.0.0","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:58:05+00:00"},{"etag":"y2tN0N8Av0ap5WXrC9DiRVe2sWK3uduIA80ultLKpVE","key":"HostSecrets","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -1498,7 +1498,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: ''
@@ -1543,7 +1543,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"djyA8Nu7DF14DmsVAPcaj4cxk_3HXmpQErKv8BS0tfQ","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"}'
@@ -1584,7 +1584,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2&tags=tag3%3Dvalue3&tags=tag4%3Dvalue4&tags=tag5%3Dvalue5
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2&tags=tag3%3Dvalue3&tags=tag4%3Dvalue4&tags=tag5%3Dvalue5
   response:
     body:
       string: '{"etag":"-ko04QF5SA4Qm5ZFzFbZ6wfRhe9-H4WajFpGp6bxfA8","items":[{"etag":"djyA8Nu7DF14DmsVAPcaj4cxk_3HXmpQErKv8BS0tfQ","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"}]}'
@@ -1623,7 +1623,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: ''
@@ -1667,7 +1667,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: '{"etag":"88bNYEjj3wQSX-Kyha2xYqoNZkv1TSHpq1IZ7MsYkHI","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"}'
@@ -1708,7 +1708,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1
   response:
     body:
       string: '{"etag":"xGqtOrqot43C-zPtZ_o3dHhsUdjZT_Fz-MEr5HLterg","items":[{"etag":"88bNYEjj3wQSX-Kyha2xYqoNZkv1TSHpq1IZ7MsYkHI","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"},{"etag":"djyA8Nu7DF14DmsVAPcaj4cxk_3HXmpQErKv8BS0tfQ","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"}]}'
@@ -1747,7 +1747,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
   response:
     body:
       string: ''
@@ -1791,7 +1791,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithEmptyTagValue
   response:
     body:
       string: '{"etag":"qupkIzh60W7HOkd_G3_6NtDXxKruz9P-ecDHbVlidCI","key":"KeyWithTags","label":"labelWithEmptyTagValue","content_type":"","value":"","tags":{"tag1":""},"locked":false,"last_modified":"2026-07-02T21:58:31+00:00"}'
@@ -1832,7 +1832,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3D
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3D
   response:
     body:
       string: '{"etag":"Iorz2s4ZA80EV5sPNkoFGIUNJN_fsWnajwkgk-AzEPc","items":[{"etag":"qupkIzh60W7HOkd_G3_6NtDXxKruz9P-ecDHbVlidCI","key":"KeyWithTags","label":"labelWithEmptyTagValue","content_type":"","value":"","tags":{"tag1":""},"locked":false,"last_modified":"2026-07-02T21:58:31+00:00"}]}'
@@ -1871,7 +1871,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A
   response:
     body:
       string: '{"etag":"7ezYLh55oHMbqSNl3RqzLicVnl2UPuucM_ndk8wncZU","items":[{"etag":"qupkIzh60W7HOkd_G3_6NtDXxKruz9P-ecDHbVlidCI","key":"KeyWithTags","label":"labelWithEmptyTagValue","content_type":"","value":"","tags":{"tag1":""},"locked":false,"last_modified":"2026-07-02T21:58:31+00:00"},{"etag":"88bNYEjj3wQSX-Kyha2xYqoNZkv1TSHpq1IZ7MsYkHI","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"},{"etag":"djyA8Nu7DF14DmsVAPcaj4cxk_3HXmpQErKv8BS0tfQ","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"}]}'
@@ -1910,7 +1910,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvtest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1
+    uri: https://kvtest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1
   response:
     body:
       string: '{"etag":"xGqtOrqot43C-zPtZ_o3dHhsUdjZT_Fz-MEr5HLterg","items":[{"etag":"88bNYEjj3wQSX-Kyha2xYqoNZkv1TSHpq1IZ7MsYkHI","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"},{"etag":"djyA8Nu7DF14DmsVAPcaj4cxk_3HXmpQErKv8BS0tfQ","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"}]}'
@@ -1955,7 +1955,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: '{"etag":"88bNYEjj3wQSX-Kyha2xYqoNZkv1TSHpq1IZ7MsYkHI","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:58:28+00:00"}'
@@ -2002,7 +2002,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://kvtest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://kvtest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"djyA8Nu7DF14DmsVAPcaj4cxk_3HXmpQErKv8BS0tfQ","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:58:26+00:00"}'

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_list_resolve_snapshot_references.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_list_resolve_snapshot_references.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001",
         "name": "snapreflist000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:45:10+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001",
+        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001",
         "name": "snapreflist000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_list_resolve_snapshot_references.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_list_resolve_snapshot_references.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001",
-        "name": "snapreflist000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000002",
+        "name": "snapreflist000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.PneCXOqoRBeN1Gu_wj7ggfnZLfYc7kW_MnZOI6WdoeE?api-version=2025-08-01-preview&t=639197343108500421&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=F2h7Kb4oaoM5a6JOTfAQVoNgOUGnNXkPhtdulXFDKAtJRLcoY_-bTt4IBZTwaVxM29lFP8PEEWvPccEBw2OqB0TyjncLuAptTgq5R7wJV5Rh91kpJcWsrkBmnqap50NhLkvg9TdmJ_q5iYYQhieABJTj0yeObopxcgZno2m7NZ0hNFTWE7Jdc_jPOldStBvsqrJjPfdX_Y75RZcrM3PtxPQ3yQC13cakCWzOCQ9pCXycqFu1BhGta8Gw2x2iFd4RJ-kFlzn4asvAFgywNx6b9SArBvoLq5Z3axw6cEW-wl0dRvh9qWMnycb-_S7PyUxklW11BAp8EjFY84BRzlNjmw&h=zT9l_e8xRCXOLwphklWnNj4cvGeBukDXdBkGE3q1Nbk
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:45:10+00:00", "endpoint": "https://snapreflist000001.azconfig.io",
+        "2026-07-15T17:45:10+00:00", "endpoint": "https://snapreflist000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:45:10+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000001",
-        "name": "snapreflist000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:45:10+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreflist000002",
+        "name": "snapreflist000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -387,7 +387,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"}'
@@ -428,7 +428,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/Size?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Size?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -471,7 +471,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/Size?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Size?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}'
@@ -516,7 +516,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/snapshots/production-config-v1?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/snapshots/production-config-v1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"n3o6zcxtLyl_0TFCqpad7a6NFxc2L8gqhcwvS0MjZWA","name":"production-config-v1","status":"provisioning","filters":[{"key":"*","label":null,"tags":[]}],"composition_type":"key","created":"2026-07-15T17:45:52.2970294+00:00","size":0,"items_count":0,"tags":{},"retention_period":86400}'
@@ -536,7 +536,7 @@ interactions:
       link:
       - </kv?snapshot=production-config-v1&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapreflist000001.azconfig.io/operations?snapshot=production-config-v1&api-version=2023-11-01
+      - https://snapreflist000002.azconfig.io/operations?snapshot=production-config-v1&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -563,7 +563,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/operations?api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/operations?api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"id": "s7aN403YDY86i5PqJccpaKUEn6Pmxf7Wa3QXrCbx2JA", "status": "Running",
@@ -603,7 +603,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/operations?api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/operations?api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"id": "s7aN403YDY86i5PqJccpaKUEn6Pmxf7Wa3QXrCbx2JA", "status": "Running",
@@ -643,7 +643,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/operations?api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/operations?api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"id": "s7aN403YDY86i5PqJccpaKUEn6Pmxf7Wa3QXrCbx2JA", "status": "Succeeded",
@@ -683,7 +683,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/snapshots/production-config-v1?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/snapshots/production-config-v1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"n3o6zcxtLyl_0TFCqpad7a6NFxc2L8gqhcwvS0MjZWA","name":"production-config-v1","status":"ready","filters":[{"key":"*","label":null,"tags":[]}],"composition_type":"key","created":"2026-07-15T17:45:52+00:00","size":1000,"items_count":2,"tags":{},"retention_period":86400}'
@@ -726,7 +726,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/ProductionConfigRef?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/ProductionConfigRef?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -771,7 +771,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/ProductionConfigRef?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/ProductionConfigRef?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"tlYBF7XOaasTiBf6x9FDnnFROZBNs6jP4gNIsGPv5os","key":"ProductionConfigRef","label":null,"content_type":"application/json;
@@ -814,7 +814,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=ProductionConfigRef&label=%2A
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=ProductionConfigRef&label=%2A
   response:
     body:
       string: '{"etag":"o9M4D2KZNiVR6TqOv0ZrklayTN4l6mFVUBB7OXsYl1o","items":[{"etag":"tlYBF7XOaasTiBf6x9FDnnFROZBNs6jP4gNIsGPv5os","key":"ProductionConfigRef","label":null,"content_type":"application/json;
@@ -855,7 +855,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=ProductionConfigRef&label=%2A
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=ProductionConfigRef&label=%2A
   response:
     body:
       string: '{"etag":"o9M4D2KZNiVR6TqOv0ZrklayTN4l6mFVUBB7OXsYl1o","items":[{"etag":"tlYBF7XOaasTiBf6x9FDnnFROZBNs6jP4gNIsGPv5os","key":"ProductionConfigRef","label":null,"content_type":"application/json;
@@ -898,7 +898,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -937,7 +937,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/Shape?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Shape?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -980,7 +980,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/Shape?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Shape?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"vyOCn_kXMORu4wjNZX_77unHB2iGDTX27z0G-E7pZaM","key":"Shape","label":null,"content_type":"","value":"circle","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:20+00:00"}'
@@ -1021,7 +1021,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"qYZKKxEsG3XO-FLWwtdENML_0OBHVs7bYDRojTa-q5w","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"tlYBF7XOaasTiBf6x9FDnnFROZBNs6jP4gNIsGPv5os","key":"ProductionConfigRef","label":null,"content_type":"application/json;
@@ -1064,7 +1064,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -1103,7 +1103,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"}'
@@ -1153,7 +1153,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/Color?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/Color?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"GffSPlzUzRZuuigCciGfmVnryuKvxE8568ooT84xBJY","key":"Color","label":null,"content_type":"","value":"green","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:23+00:00"}'
@@ -1194,7 +1194,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"wkAc71b7YZOOpZOcJ72gnw_o8eC3fwRw2Yo4mkTiiuY","items":[{"etag":"GffSPlzUzRZuuigCciGfmVnryuKvxE8568ooT84xBJY","key":"Color","label":null,"content_type":"","value":"green","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:23+00:00"},{"etag":"tlYBF7XOaasTiBf6x9FDnnFROZBNs6jP4gNIsGPv5os","key":"ProductionConfigRef","label":null,"content_type":"application/json;
@@ -1237,7 +1237,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -1276,7 +1276,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/ProductionConfigRefAlias?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/ProductionConfigRefAlias?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1321,7 +1321,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/ProductionConfigRefAlias?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/ProductionConfigRefAlias?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"0CD4OF7QXy0ygtcpL0g_Vs1katZhGVbLG9iJmwINzGk","key":"ProductionConfigRefAlias","label":null,"content_type":"application/json;
@@ -1364,7 +1364,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"5dSveUNx2fiSss7VO4uREA_hMQLRdvvJZjfKqMRfXTM","items":[{"etag":"GffSPlzUzRZuuigCciGfmVnryuKvxE8568ooT84xBJY","key":"Color","label":null,"content_type":"","value":"green","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:23+00:00"},{"etag":"tlYBF7XOaasTiBf6x9FDnnFROZBNs6jP4gNIsGPv5os","key":"ProductionConfigRef","label":null,"content_type":"application/json;
@@ -1409,7 +1409,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -1450,7 +1450,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -1489,7 +1489,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/Color?api-version=2023-11-01&label=staging
+    uri: https://snapreflist000002.azconfig.io/kv/Color?api-version=2023-11-01&label=staging
   response:
     body:
       string: ''
@@ -1532,7 +1532,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/Color?api-version=2023-11-01&label=staging
+    uri: https://snapreflist000002.azconfig.io/kv/Color?api-version=2023-11-01&label=staging
   response:
     body:
       string: '{"etag":"yntg1jQKPYy4ShtPYZV5-uuz2OBsi-B1MWp6ch2_OgE","key":"Color","label":"staging","content_type":"","value":"blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:30+00:00"}'
@@ -1578,7 +1578,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/snapshots/staging-override-v1?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/snapshots/staging-override-v1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_0gICVWBUokesATGggsKde8sokJx-tZm1o2OrZcq_IA","name":"staging-override-v1","status":"provisioning","filters":[{"key":"Color","label":"staging","tags":[]}],"composition_type":"key","created":"2026-07-15T17:46:30.9480844+00:00","size":0,"items_count":0,"tags":{},"retention_period":86400}'
@@ -1598,7 +1598,7 @@ interactions:
       link:
       - </kv?snapshot=staging-override-v1&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapreflist000001.azconfig.io/operations?snapshot=staging-override-v1&api-version=2023-11-01
+      - https://snapreflist000002.azconfig.io/operations?snapshot=staging-override-v1&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -1625,7 +1625,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/operations?api-version=2023-11-01&snapshot=staging-override-v1
+    uri: https://snapreflist000002.azconfig.io/operations?api-version=2023-11-01&snapshot=staging-override-v1
   response:
     body:
       string: '{"id": "Rs4X24xMIGDTIai430__q3So9xLKMw6J59MGDO66ik0", "status": "Running",
@@ -1665,7 +1665,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/operations?api-version=2023-11-01&snapshot=staging-override-v1
+    uri: https://snapreflist000002.azconfig.io/operations?api-version=2023-11-01&snapshot=staging-override-v1
   response:
     body:
       string: '{"id": "Rs4X24xMIGDTIai430__q3So9xLKMw6J59MGDO66ik0", "status": "Succeeded",
@@ -1705,7 +1705,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/snapshots/staging-override-v1?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/snapshots/staging-override-v1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"_0gICVWBUokesATGggsKde8sokJx-tZm1o2OrZcq_IA","name":"staging-override-v1","status":"ready","filters":[{"key":"Color","label":"staging","tags":[]}],"composition_type":"key","created":"2026-07-15T17:46:30+00:00","size":1000,"items_count":1,"tags":{},"retention_period":86400}'
@@ -1748,7 +1748,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/StagingOverrideRef?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/StagingOverrideRef?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1793,7 +1793,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/StagingOverrideRef?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/StagingOverrideRef?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"YmMuzGVkKTwMmItG2Mvefdy1ON4uwvXFqLFmekFLRbo","key":"StagingOverrideRef","label":null,"content_type":"application/json;
@@ -1836,7 +1836,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"oGcVmk72W71jdQ-RG-PwsN2j0Y6lFUd9RV_O3CCN2xw","items":[{"etag":"GffSPlzUzRZuuigCciGfmVnryuKvxE8568ooT84xBJY","key":"Color","label":null,"content_type":"","value":"green","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:23+00:00"},{"etag":"yntg1jQKPYy4ShtPYZV5-uuz2OBsi-B1MWp6ch2_OgE","key":"Color","label":"staging","content_type":"","value":"blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:30+00:00"},{"etag":"tlYBF7XOaasTiBf6x9FDnnFROZBNs6jP4gNIsGPv5os","key":"ProductionConfigRef","label":null,"content_type":"application/json;
@@ -1883,7 +1883,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -1924,7 +1924,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -1965,7 +1965,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=staging-override-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=staging-override-v1
   response:
     body:
       string: '{"etag":"qehi4wnspZ9YLgGqOJnTBMZPE6bYJHJZsBywylI64Ko","items":[{"etag":"yntg1jQKPYy4ShtPYZV5-uuz2OBsi-B1MWp6ch2_OgE","key":"Color","label":"staging","content_type":"","value":"blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:30+00:00"}]}'
@@ -2004,7 +2004,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv/ArchivedConfigRef?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/ArchivedConfigRef?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -2049,7 +2049,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreflist000001.azconfig.io/kv/ArchivedConfigRef?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/kv/ArchivedConfigRef?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"cpYSsOXemUXHtqeY8P4MLcvuMDEmB786kxA2pyUqr5c","key":"ArchivedConfigRef","label":null,"content_type":"application/json;
@@ -2092,7 +2092,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"v46VVxlyQOEbYtEbWK2x5JyVZbgbITCXh5-XcVYCnak","items":[{"etag":"cpYSsOXemUXHtqeY8P4MLcvuMDEmB786kxA2pyUqr5c","key":"ArchivedConfigRef","label":null,"content_type":"application/json;
@@ -2141,7 +2141,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=nonexistent-snapshot
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=nonexistent-snapshot
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -2182,7 +2182,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/snapshots/nonexistent-snapshot?api-version=2023-11-01
+    uri: https://snapreflist000002.azconfig.io/snapshots/nonexistent-snapshot?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -2219,7 +2219,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -2260,7 +2260,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=production-config-v1
   response:
     body:
       string: '{"etag":"TRTrFpnWxS9jr5IhXicLZIWHeihAUbGCC2GzTnzk2uE","items":[{"etag":"kYyDjfBVqxcc0SFKbmYR_mmPt0fMDS2gH6Ac-koNxz4","key":"Color","label":null,"content_type":"","value":"red","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:49+00:00"},{"etag":"_9qT7y5bRN8EIxhJdCdkitVYfrYJt2jOEXmCrhWNBz0","key":"Size","label":null,"content_type":"","value":"large","tags":{},"locked":false,"last_modified":"2026-07-15T17:45:51+00:00"}]}'
@@ -2301,7 +2301,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreflist000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=staging-override-v1
+    uri: https://snapreflist000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=staging-override-v1
   response:
     body:
       string: '{"etag":"qehi4wnspZ9YLgGqOJnTBMZPE6bYJHJZsBywylI64Ko","items":[{"etag":"yntg1jQKPYy4ShtPYZV5-uuz2OBsi-B1MWp6ch2_OgE","key":"Color","label":"staging","content_type":"","value":"blue","tags":{},"locked":false,"last_modified":"2026-07-15T17:46:30+00:00"}]}'

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_revision_list.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_revision_list.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001",
         "name": "kvrevisiontest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001",
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001",
         "name": "kvrevisiontest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_revision_list.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_revision_list.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001",
-        "name": "kvrevisiontest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000002",
+        "name": "kvrevisiontest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.LaMKoWYYS9R4_YMAwqd0e03RXaM-gkcjo0Wwj7ymq40?api-version=2025-08-01-preview&t=639186261999665435&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=kGjhwuocBftp8wu_e_WHxa8HPRH-YZ-pi330JIid8oysVjJ7KppqINDRXUvPap4ilQOJaXAoAZEqJXFalL8BV7u9IfR6WtSHPnbeNmneOw6rI5SmP2gEIXhx3lrICWWKX8T-0BJK45K-T6sXGxC8uG84_uzuOZvnK5OxnT47ma1yH2ufAvRplg4sU23fTB1qzynN_tMKdGtbLMUwVvoG7S71TTX7BTs6o8e39sEIkxLYqtBmh3_ZGNBVs-TYrypDSK4G5uYFnpBX2yTmikKGuDS0mGWLNZPhtonKYlNupYzDPYhRLZ7pIVCr6SoUgybBHCedlkh7Eqfr_AUenuSxMw&h=c6OcpkXG72O0-fFpV-C_OLR0VNyUPN2ilPyp23JRbZE
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-02T21:56:39+00:00", "endpoint": "https://kvrevisiontest000001.azconfig.io",
+        "2026-07-02T21:56:39+00:00", "endpoint": "https://kvrevisiontest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-02T21:56:39+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000001",
-        "name": "kvrevisiontest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-02T21:56:39+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/kvrevisiontest000002",
+        "name": "kvrevisiontest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvrevisiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: ''
@@ -387,7 +387,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvrevisiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvrevisiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: '{"etag":"ceeNNtZK_esMCK9zYO5pCG4splvYI48PGK-F8emH8BE","key":"Color","label":"v1.0.0","content_type":"","value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:19+00:00"}'
@@ -428,7 +428,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvrevisiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: '{"etag":"ceeNNtZK_esMCK9zYO5pCG4splvYI48PGK-F8emH8BE","key":"Color","label":"v1.0.0","content_type":"","value":"","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:19+00:00"}'
@@ -478,7 +478,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvrevisiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
+    uri: https://kvrevisiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=v1.0.0
   response:
     body:
       string: '{"etag":"3_ehKAZpDK9Pq_M8lZgQvqVcvLnmzpdRImVQx6Fj1s4","key":"Color","label":"v1.0.0","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:21+00:00"}'
@@ -519,7 +519,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvrevisiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: ''
@@ -563,7 +563,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvrevisiontest000001.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
+    uri: https://kvrevisiontest000002.azconfig.io/kv/Color?api-version=2023-11-01&label=newlabel
   response:
     body:
       string: '{"etag":"EdzZOxvZhklKgzjf4vxrArRwo0Y5YMxnSChwjdm95u8","key":"Color","label":"newlabel","content_type":"text","value":"Green","tags":{},"locked":false,"last_modified":"2026-07-02T21:57:22+00:00"}'
@@ -604,7 +604,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/revisions?%24select=content_type%2Cetag%2Clabel%2Clast_modified%2Cvalue&api-version=2023-11-01&key=Color&label=%2A
+    uri: https://kvrevisiontest000002.azconfig.io/revisions?%24select=content_type%2Cetag%2Clabel%2Clast_modified%2Cvalue&api-version=2023-11-01&key=Color&label=%2A
   response:
     body:
       string: '{"etag":"536wfayYsGmdO2KdGAOIggTp9N-M1NxJQVetcDyNpYs","items":[{"etag":"EdzZOxvZhklKgzjf4vxrArRwo0Y5YMxnSChwjdm95u8","label":"newlabel","content_type":"text","value":"Green","last_modified":"2026-07-02T21:57:22+00:00"},{"etag":"3_ehKAZpDK9Pq_M8lZgQvqVcvLnmzpdRImVQx6Fj1s4","label":"v1.0.0","content_type":"text","value":"Green","last_modified":"2026-07-02T21:57:21+00:00"},{"etag":"ceeNNtZK_esMCK9zYO5pCG4splvYI48PGK-F8emH8BE","label":"v1.0.0","content_type":"","value":"","last_modified":"2026-07-02T21:57:19+00:00"}]}'
@@ -645,7 +645,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://kvrevisiontest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: ''
@@ -690,7 +690,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvrevisiontest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
+    uri: https://kvrevisiontest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"DHXjls75KyaQoWDcb6yALpf2KlYib_RZdBaZMBZTtUI","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:57:25+00:00"}'
@@ -731,7 +731,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2&tags=tag3%3Dvalue3&tags=tag4%3Dvalue4&tags=tag5%3Dvalue5
+    uri: https://kvrevisiontest000002.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1&tags=tag2%3Dvalue2&tags=tag3%3Dvalue3&tags=tag4%3Dvalue4&tags=tag5%3Dvalue5
   response:
     body:
       string: '{"etag":"ZVuB7nxj30wMswiL7_3r4Vkip8261dggfCKrPELJRS4","items":[{"etag":"DHXjls75KyaQoWDcb6yALpf2KlYib_RZdBaZMBZTtUI","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:57:25+00:00"}]}'
@@ -772,7 +772,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://kvrevisiontest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: ''
@@ -816,7 +816,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvrevisiontest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://kvrevisiontest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: '{"etag":"3q9q3-Aj0AYroxfaY2ceHk93d344qnGYLFGiNK6C94o","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:57:27+00:00"}'
@@ -857,7 +857,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1
+    uri: https://kvrevisiontest000002.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3Dvalue1
   response:
     body:
       string: '{"etag":"18kxUYMEwZMj8Ctv3xiUd35gQqtbEpalvTkIkYl_dTY","items":[{"etag":"3q9q3-Aj0AYroxfaY2ceHk93d344qnGYLFGiNK6C94o","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:57:27+00:00"},{"etag":"DHXjls75KyaQoWDcb6yALpf2KlYib_RZdBaZMBZTtUI","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:57:25+00:00"}]}'
@@ -898,7 +898,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://kvrevisiontest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: '{"etag":"3q9q3-Aj0AYroxfaY2ceHk93d344qnGYLFGiNK6C94o","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:57:27+00:00"}'
@@ -948,7 +948,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://kvrevisiontest000001.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
+    uri: https://kvrevisiontest000002.azconfig.io/kv/KeyWithTags?api-version=2023-11-01&label=labelWithTag1
   response:
     body:
       string: '{"etag":"nyMOqX0o73Bj8K3mI1cakw0f-M4l-hil1Sl_HPUe39U","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":""},"locked":false,"last_modified":"2026-07-02T21:57:30+00:00"}'
@@ -989,7 +989,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3D
+    uri: https://kvrevisiontest000002.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A&tags=tag1%3D
   response:
     body:
       string: '{"etag":"bT44_Hba7QC8Dr2t6OriOOzH2p2D-o_VZYQ91SjTcaQ","items":[{"etag":"nyMOqX0o73Bj8K3mI1cakw0f-M4l-hil1Sl_HPUe39U","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":""},"locked":false,"last_modified":"2026-07-02T21:57:30+00:00"}]}'
@@ -1030,7 +1030,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://kvrevisiontest000001.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A
+    uri: https://kvrevisiontest000002.azconfig.io/revisions?api-version=2023-11-01&key=KeyWithTags&label=%2A
   response:
     body:
       string: '{"etag":"JQUV7hhuftdyalDKq1vun8Gb1Ox46KaJjla7yP1fHh8","items":[{"etag":"nyMOqX0o73Bj8K3mI1cakw0f-M4l-hil1Sl_HPUe39U","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":""},"locked":false,"last_modified":"2026-07-02T21:57:30+00:00"},{"etag":"3q9q3-Aj0AYroxfaY2ceHk93d344qnGYLFGiNK6C94o","key":"KeyWithTags","label":"labelWithTag1","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-02T21:57:27+00:00"},{"etag":"DHXjls75KyaQoWDcb6yALpf2KlYib_RZdBaZMBZTtUI","key":"KeyWithTags","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-02T21:57:25+00:00"}]}'

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_set_snapshot_reference.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_set_snapshot_reference.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001",
-        "name": "snapreftest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000002",
+        "name": "snapreftest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.mqvduZV1ivXbEdwUEhBKVW1Y19sFV8ka8fLbxR_BsgA?api-version=2025-08-01-preview&t=639197344157211763&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=EGU-ec30oCdmVAssef-huhdIrHsNpu0DaHvtwKtGly8yvqqHEb_SVGsGYOkcBSFtwBOVrkcvZ4foT0d_AQxfjXdgYgz-XoutEBc3nYwRpVcRB3Cyo7Yd2mubGntYVmIG4EwH86w3QcMAYFwE_MwUNcTwBlicvQx3CHs9KgQR5chgh1K_b5r0vUtCYx9tOp501AaEBt-9KCuVTjONP7ObjrkDwSkIICbwixSxFnHOMc39tGBw30E0BNQEjcNwBfWdtbxnsVLLMZi_x1oDwq1sFiXMLhX0uG70qWlf6Pe09I_lpBQ-uso__WH0sP-GyURfm7u-7TOuCy1OMfyOlyIZ-w&h=ARHl2ylaHGuUfjKdvPZeT6dXTF7FtM1EmxA1NGgD4k0
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:46:55+00:00", "endpoint": "https://snapreftest000001.azconfig.io",
+        "2026-07-15T17:46:55+00:00", "endpoint": "https://snapreftest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:46:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001",
-        "name": "snapreftest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000002",
+        "name": "snapreftest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreftest000001.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
+    uri: https://snapreftest000002.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
   response:
     body:
       string: ''
@@ -389,7 +389,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreftest000001.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
+    uri: https://snapreftest000002.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
   response:
     body:
       string: '{"etag":"b_4BbyncCZf_Io48hERMVTLLpcxQBDG1Z_xKCysJ1lA","key":"MySnapshotRef","label":"MyLabel","content_type":"application/json;
@@ -432,7 +432,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreftest000001.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
+    uri: https://snapreftest000002.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
   response:
     body:
       string: '{"etag":"b_4BbyncCZf_Io48hERMVTLLpcxQBDG1Z_xKCysJ1lA","key":"MySnapshotRef","label":"MyLabel","content_type":"application/json;
@@ -475,7 +475,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreftest000001.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
+    uri: https://snapreftest000002.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
   response:
     body:
       string: '{"etag":"b_4BbyncCZf_Io48hERMVTLLpcxQBDG1Z_xKCysJ1lA","key":"MySnapshotRef","label":"MyLabel","content_type":"application/json;
@@ -528,7 +528,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreftest000001.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
+    uri: https://snapreftest000002.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
   response:
     body:
       string: '{"etag":"ciQUj5eQ-otkpqkQRgHHkgsMiB2BbooSIbBX_oeI2EU","key":"MySnapshotRef","label":"MyLabel","content_type":"application/json;
@@ -571,7 +571,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreftest000001.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
+    uri: https://snapreftest000002.azconfig.io/kv/MySnapshotRef?api-version=2023-11-01&label=MyLabel
   response:
     body:
       string: '{"etag":"ciQUj5eQ-otkpqkQRgHHkgsMiB2BbooSIbBX_oeI2EU","key":"MySnapshotRef","label":"MyLabel","content_type":"application/json;
@@ -614,7 +614,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapreftest000001.azconfig.io/kv/TaggedRef?api-version=2023-11-01
+    uri: https://snapreftest000002.azconfig.io/kv/TaggedRef?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -659,7 +659,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapreftest000001.azconfig.io/kv/TaggedRef?api-version=2023-11-01
+    uri: https://snapreftest000002.azconfig.io/kv/TaggedRef?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"S-9vuc3nzh19Gn0Xm0k3K3pX958uu6AuXXGajZmG0eU","key":"TaggedRef","label":null,"content_type":"application/json;

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_set_snapshot_reference.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_kv_set_snapshot_reference.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001",
         "name": "snapreftest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:46:55+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:46:55+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapreftest000001",
         "name": "snapreftest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_filtering.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_filtering.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001",
         "name": "snapshotfilters000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-17T18:32:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001",
+        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001",
         "name": "snapshotfilters000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_filtering.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_filtering.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001",
-        "name": "snapshotfilters000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000002",
+        "name": "snapshotfilters000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/francecentral/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.E3VAq0fXDzdroh66FWB1S-ivzJNHnPPw1evFWtZAfU0?api-version=2025-08-01-preview&t=639199099461470536&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=MPxRH83ZcoSxnY-wMv0W3bxkc7dO4E8ROm30woyh0jjYqMJ6aQLZJbyumum_mtzQYnuSL-qvMwqW3LqIMfGle61y4l_jsKEhrClr8nqFI03KpaZi8IRS1yTcKydwZfa5Uduj9nLh9eGtGEfhZRf19ObXfpn55n3ZU91zk0HN_dzHEcUDZvpfMRnai0zVQKx9zCyxHzBCO8W-LJX4aKqYypZlOqtk45kTwZtM12Ky-zk7BhpgI9ZNi-mnk2gHv8B9pocg0sCd-DXKK4t5-wieig7NNsd5TCn4fxqTq7Lpl2Ldj_p59Xq_vLCjCOJqAxewn0-mghhci7GUBV6TBI9OnQ&h=13E6nKk1pr3_vnB-oxhTW23PdI0rWAJEOq3Dmh6VR_U
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "francecentral", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-17T18:32:25+00:00", "endpoint": "https://snapshotfilters000001.azconfig.io",
+        "2026-07-17T18:32:25+00:00", "endpoint": "https://snapshotfilters000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-17T18:32:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000001",
-        "name": "snapshotfilters000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotfilters000002",
+        "name": "snapshotfilters000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/kv/KeyWithTags1?api-version=2023-11-01&label=labelWithTags
+    uri: https://snapshotfilters000002.azconfig.io/kv/KeyWithTags1?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: ''
@@ -389,7 +389,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/kv/KeyWithTags1?api-version=2023-11-01&label=labelWithTags
+    uri: https://snapshotfilters000002.azconfig.io/kv/KeyWithTags1?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"bOh3KDkzl7prT9vbAzTO1n2UCRG1Sq7jzmbDkdXbt7c","key":"KeyWithTags1","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5"},"locked":false,"last_modified":"2026-07-17T18:33:06+00:00"}'
@@ -436,7 +436,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWith5Tags?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWith5Tags?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"n3FtxOdF4AsjYTMPiQob7IFP-6q_oZY4DSkdBqYuiQg","name":"TestSnapshotWith5Tags","status":"provisioning","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":["tag1=value1","tag2=value2","tag3=value3","tag4=value4","tag5=value5"]}],"composition_type":"key_label","created":"2026-07-17T18:33:07.6870272+00:00","size":0,"items_count":0,"tags":{},"retention_period":3600}'
@@ -456,7 +456,7 @@ interactions:
       link:
       - </kv?snapshot=TestSnapshotWith5Tags&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapshotfilters000001.azconfig.io/operations?snapshot=TestSnapshotWith5Tags&api-version=2023-11-01
+      - https://snapshotfilters000002.azconfig.io/operations?snapshot=TestSnapshotWith5Tags&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -483,7 +483,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith5Tags
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith5Tags
   response:
     body:
       string: '{"id": "0NqVh6pO7aVl9LNq0gqP4ZK5mVK-67N5cv6vTIxNIfM", "status": "Running",
@@ -523,7 +523,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith5Tags
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith5Tags
   response:
     body:
       string: '{"id": "0NqVh6pO7aVl9LNq0gqP4ZK5mVK-67N5cv6vTIxNIfM", "status": "Succeeded",
@@ -563,7 +563,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWith5Tags?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWith5Tags?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"n3FtxOdF4AsjYTMPiQob7IFP-6q_oZY4DSkdBqYuiQg","name":"TestSnapshotWith5Tags","status":"ready","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":["tag1=value1","tag2=value2","tag3=value3","tag4=value4","tag5=value5"]}],"composition_type":"key_label","created":"2026-07-17T18:33:07+00:00","size":1000,"items_count":1,"tags":{},"retention_period":3600}'
@@ -606,7 +606,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/kv/KeyWithTags2?api-version=2023-11-01&label=labelWithTags
+    uri: https://snapshotfilters000002.azconfig.io/kv/KeyWithTags2?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: ''
@@ -650,7 +650,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/kv/KeyWithTags2?api-version=2023-11-01&label=labelWithTags
+    uri: https://snapshotfilters000002.azconfig.io/kv/KeyWithTags2?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"A_1IB2OP7ZeQpSpsVkKVfG1W8M_xGCvHE8eWlAHpimQ","key":"KeyWithTags2","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":"value1"},"locked":false,"last_modified":"2026-07-17T18:33:23+00:00"}'
@@ -696,7 +696,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWith1Tag?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWith1Tag?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"KvAIzOixlWDfQAdzPdra04IqNLFBP0pJiQklb3mVTsE","name":"TestSnapshotWith1Tag","status":"provisioning","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":["tag1=value1"]}],"composition_type":"key_label","created":"2026-07-17T18:33:24.0267782+00:00","size":0,"items_count":0,"tags":{},"retention_period":3600}'
@@ -716,7 +716,7 @@ interactions:
       link:
       - </kv?snapshot=TestSnapshotWith1Tag&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapshotfilters000001.azconfig.io/operations?snapshot=TestSnapshotWith1Tag&api-version=2023-11-01
+      - https://snapshotfilters000002.azconfig.io/operations?snapshot=TestSnapshotWith1Tag&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -743,7 +743,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith1Tag
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith1Tag
   response:
     body:
       string: '{"id": "mtxbOeJkvNutbC0PHTuF0Q7JfEqRJ5332EO7U4mZxZQ", "status": "Running",
@@ -783,7 +783,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith1Tag
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWith1Tag
   response:
     body:
       string: '{"id": "mtxbOeJkvNutbC0PHTuF0Q7JfEqRJ5332EO7U4mZxZQ", "status": "Succeeded",
@@ -823,7 +823,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWith1Tag?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWith1Tag?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"KvAIzOixlWDfQAdzPdra04IqNLFBP0pJiQklb3mVTsE","name":"TestSnapshotWith1Tag","status":"ready","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":["tag1=value1"]}],"composition_type":"key_label","created":"2026-07-17T18:33:24+00:00","size":2000,"items_count":2,"tags":{},"retention_period":3600}'
@@ -866,7 +866,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/kv/KeyWithTags3?api-version=2023-11-01&label=labelWithTags
+    uri: https://snapshotfilters000002.azconfig.io/kv/KeyWithTags3?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: ''
@@ -910,7 +910,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/kv/KeyWithTags3?api-version=2023-11-01&label=labelWithTags
+    uri: https://snapshotfilters000002.azconfig.io/kv/KeyWithTags3?api-version=2023-11-01&label=labelWithTags
   response:
     body:
       string: '{"etag":"cLhZN_bb76Gasorl7iuA8W3gfU2PGb5PVTwgM2VPmjM","key":"KeyWithTags3","label":"labelWithTags","content_type":"","value":"","tags":{"tag1":""},"locked":false,"last_modified":"2026-07-17T18:33:38+00:00"}'
@@ -956,7 +956,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWithEmptyTagValue?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWithEmptyTagValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"UvXiYdlYOBIapj-MgBy1AkMizNNPS-nKdl7lPNqwBSk","name":"TestSnapshotWithEmptyTagValue","status":"provisioning","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":["tag1="]}],"composition_type":"key_label","created":"2026-07-17T18:33:39.7467268+00:00","size":0,"items_count":0,"tags":{},"retention_period":3600}'
@@ -976,7 +976,7 @@ interactions:
       link:
       - </kv?snapshot=TestSnapshotWithEmptyTagValue&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapshotfilters000001.azconfig.io/operations?snapshot=TestSnapshotWithEmptyTagValue&api-version=2023-11-01
+      - https://snapshotfilters000002.azconfig.io/operations?snapshot=TestSnapshotWithEmptyTagValue&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -1003,7 +1003,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithEmptyTagValue
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithEmptyTagValue
   response:
     body:
       string: '{"id": "FH4gsBinX9hQt_pn8HOojLMzKRf51S3GdNK2yDYq0bM", "status": "Running",
@@ -1043,7 +1043,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithEmptyTagValue
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithEmptyTagValue
   response:
     body:
       string: '{"id": "FH4gsBinX9hQt_pn8HOojLMzKRf51S3GdNK2yDYq0bM", "status": "Running",
@@ -1083,7 +1083,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithEmptyTagValue
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithEmptyTagValue
   response:
     body:
       string: '{"id": "FH4gsBinX9hQt_pn8HOojLMzKRf51S3GdNK2yDYq0bM", "status": "Succeeded",
@@ -1123,7 +1123,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWithEmptyTagValue?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWithEmptyTagValue?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"UvXiYdlYOBIapj-MgBy1AkMizNNPS-nKdl7lPNqwBSk","name":"TestSnapshotWithEmptyTagValue","status":"ready","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":["tag1="]}],"composition_type":"key_label","created":"2026-07-17T18:33:39+00:00","size":1000,"items_count":1,"tags":{},"retention_period":3600}'
@@ -1171,7 +1171,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWithAllKVs?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWithAllKVs?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"xKgLt6qR8ixOYkWBnW1-RGDdKw19-SpJT_kjOX9-9oI","name":"TestSnapshotWithAllKVs","status":"provisioning","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:34:04.6325987+00:00","size":0,"items_count":0,"tags":{},"retention_period":3600}'
@@ -1191,7 +1191,7 @@ interactions:
       link:
       - </kv?snapshot=TestSnapshotWithAllKVs&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapshotfilters000001.azconfig.io/operations?snapshot=TestSnapshotWithAllKVs&api-version=2023-11-01
+      - https://snapshotfilters000002.azconfig.io/operations?snapshot=TestSnapshotWithAllKVs&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -1218,7 +1218,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithAllKVs
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithAllKVs
   response:
     body:
       string: '{"id": "jUH1kKY3iP_6Ky1JUR8vcTLergFOcEcLj3KJ0CI_JFU", "status": "Running",
@@ -1258,7 +1258,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithAllKVs
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithAllKVs
   response:
     body:
       string: '{"id": "jUH1kKY3iP_6Ky1JUR8vcTLergFOcEcLj3KJ0CI_JFU", "status": "Succeeded",
@@ -1298,7 +1298,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWithAllKVs?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWithAllKVs?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"xKgLt6qR8ixOYkWBnW1-RGDdKw19-SpJT_kjOX9-9oI","name":"TestSnapshotWithAllKVs","status":"ready","filters":[{"key":"KeyWithTags*","label":"labelWithTags","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:34:04+00:00","size":2000,"items_count":3,"tags":{},"retention_period":3600}'
@@ -1341,7 +1341,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
+    uri: https://snapshotfilters000002.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
   response:
     body:
       string: ''
@@ -1385,7 +1385,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
+    uri: https://snapshotfilters000002.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
   response:
     body:
       string: '{"etag":"UcIF4qppPzlLI5jOn9TTluL-djbcXSA0zOt-IjlHQgc","key":"TestKey1","label":"dev","content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:19+00:00"}'
@@ -1426,7 +1426,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
+    uri: https://snapshotfilters000002.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
   response:
     body:
       string: ''
@@ -1470,7 +1470,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
+    uri: https://snapshotfilters000002.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
   response:
     body:
       string: '{"etag":"k6Baiyjr3tDBUVLNDZpMH0EEAUdifxb1JQzvv9JEh2M","key":"TestKey2","label":"dev","content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:21+00:00"}'
@@ -1511,7 +1511,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
+    uri: https://snapshotfilters000002.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
   response:
     body:
       string: ''
@@ -1555,7 +1555,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
+    uri: https://snapshotfilters000002.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
   response:
     body:
       string: '{"etag":"hzfJd2H3H-1aKuoM5FB1dE-FZoNiQvO8qc1NvxkFwKY","key":"LastTestKey","label":"dev","content_type":"","value":"LastTestValue","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:23+00:00"}'
@@ -1601,7 +1601,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWithPrefix?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWithPrefix?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"DxVf_hONUxquGGeYiozYLo369Q4j1G6JJVIAj2SxEjE","name":"TestSnapshotWithPrefix","status":"provisioning","filters":[{"key":"Test*","label":"dev","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:34:24.2283491+00:00","size":0,"items_count":0,"tags":{"tag1":"value1"},"retention_period":3600}'
@@ -1621,7 +1621,7 @@ interactions:
       link:
       - </kv?snapshot=TestSnapshotWithPrefix&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapshotfilters000001.azconfig.io/operations?snapshot=TestSnapshotWithPrefix&api-version=2023-11-01
+      - https://snapshotfilters000002.azconfig.io/operations?snapshot=TestSnapshotWithPrefix&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -1648,7 +1648,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithPrefix
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithPrefix
   response:
     body:
       string: '{"id": "Ku5w9yRA5o_wE_gLcsc9zaRruYJUx_Zhiu4awoKu-ZM", "status": "Running",
@@ -1688,7 +1688,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithPrefix
+    uri: https://snapshotfilters000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshotWithPrefix
   response:
     body:
       string: '{"id": "Ku5w9yRA5o_wE_gLcsc9zaRruYJUx_Zhiu4awoKu-ZM", "status": "Succeeded",
@@ -1728,7 +1728,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotfilters000001.azconfig.io/snapshots/TestSnapshotWithPrefix?api-version=2023-11-01
+    uri: https://snapshotfilters000002.azconfig.io/snapshots/TestSnapshotWithPrefix?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"DxVf_hONUxquGGeYiozYLo369Q4j1G6JJVIAj2SxEjE","name":"TestSnapshotWithPrefix","status":"ready","filters":[{"key":"Test*","label":"dev","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:34:24+00:00","size":1000,"items_count":2,"tags":{"tag1":"value1"},"retention_period":3600}'

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_mgmt.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,7 +30,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001",
         "name": "snapshotstore000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -288,7 +288,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -301,7 +301,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-17T18:32:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001",
+        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001",
         "name": "snapshotstore000001", "tags": {}}'
     headers:
       cache-control:
@@ -1186,7 +1186,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -1195,7 +1195,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
         "name": "snapshotstore000002", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -1453,7 +1453,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -1466,7 +1466,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-17T18:33:45+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-17T18:33:45+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
+        "User", "lastModifiedAt": "2026-07-17T18:33:45+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
         "name": "snapshotstore000002", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_snapshot_mgmt.yaml
@@ -21,7 +21,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -30,8 +30,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001",
-        "name": "snapshotstore000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
+        "name": "snapshotstore000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/francecentral/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.9u8ItINsMljXdfrsTYazY-YpFXns_sRWb7qk1wbBiuk?api-version=2025-08-01-preview&t=639199099461922133&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=jzpRnWAeS3Ll97Mrlu2PqpImOrX5sgxza2zVNJo9ssSisSw7xzAA2TDX28beKjYGwTifh9ddbr8Ttcpg3gjfcldO8Fnvne5j102ofDLY22EqxGCy82BlEXPUOUSoLhAl7wckgontf8GbAlIbtjT0yv9LrYWeTGOULS-9MsQePyq3n9ZOiEucWzSSiDHGO5LMTuyXdSJLjYQPWLEeSdyvdaTnG5KLMS5E4xIi5R_o6hBWKXDupbF4e3RxdAJ_7F5e6QnGJYYLW_o64b5KvGNPiJzu2CVRFAb3_zJHc1PbQPz66mAz9cf7jL4jAayuir45fbXn9iQCVfI3zInKEBG-Lg&h=iDhQSLsVUxcJ6dC9jG9YsgWJj9B8MvBcVx4nmcUre3Q
@@ -288,12 +288,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "francecentral", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-17T18:32:25+00:00", "endpoint": "https://snapshotstore000001.azconfig.io",
+        "2026-07-17T18:32:25+00:00", "endpoint": "https://snapshotstore000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -301,8 +301,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-17T18:32:25+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000001",
-        "name": "snapshotstore000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-17T18:32:25+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
+        "name": "snapshotstore000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
+    uri: https://snapshotstore000002.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
   response:
     body:
       string: ''
@@ -388,7 +388,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000001.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
+    uri: https://snapshotstore000002.azconfig.io/kv/TestKey1?api-version=2023-11-01&label=dev
   response:
     body:
       string: '{"etag":"W_bYqCEnS-sEll-4BHB7sBKj18OBLm29QgFsJXCTwzQ","key":"TestKey1","label":"dev","content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:06+00:00"}'
@@ -429,7 +429,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
+    uri: https://snapshotstore000002.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
   response:
     body:
       string: ''
@@ -473,7 +473,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000001.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
+    uri: https://snapshotstore000002.azconfig.io/kv/TestKey2?api-version=2023-11-01&label=dev
   response:
     body:
       string: '{"etag":"KzUI5bMFP7qVHGsfpXfdb27ADA8pxAPnWycs64XF6y8","key":"TestKey2","label":"dev","content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:08+00:00"}'
@@ -514,7 +514,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
+    uri: https://snapshotstore000002.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
   response:
     body:
       string: ''
@@ -558,7 +558,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000001.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
+    uri: https://snapshotstore000002.azconfig.io/kv/LastTestKey?api-version=2023-11-01&label=dev
   response:
     body:
       string: '{"etag":"aLyNh3obgvbn_zxiXw0NLRyQzW15YGg7au8or5BWL7E","key":"LastTestKey","label":"dev","content_type":"","value":"LastTestValue","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:10+00:00"}'
@@ -604,7 +604,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000001.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
+    uri: https://snapshotstore000002.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HVC4olRTOnU1uG9SJAWp4vH5v7rB-dvjwxh-WrX9dpA","name":"TestSnapshot","status":"provisioning","filters":[{"key":"Test*","label":"dev","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:33:11.8127697+00:00","size":0,"items_count":0,"tags":{"tag1":"value1"},"retention_period":3600}'
@@ -624,7 +624,7 @@ interactions:
       link:
       - </kv?snapshot=TestSnapshot&api-version=2023-11-01>; rel="items"
       operation-location:
-      - https://snapshotstore000001.azconfig.io/operations?snapshot=TestSnapshot&api-version=2023-11-01
+      - https://snapshotstore000002.azconfig.io/operations?snapshot=TestSnapshot&api-version=2023-11-01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       sync-token:
@@ -651,7 +651,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshot
+    uri: https://snapshotstore000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshot
   response:
     body:
       string: '{"id": "q7wYTFRvCMHmch6lzgTPUbdvwE7RPkM4ouZIUKU6i6I", "status": "Running",
@@ -691,7 +691,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshot
+    uri: https://snapshotstore000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshot
   response:
     body:
       string: '{"id": "q7wYTFRvCMHmch6lzgTPUbdvwE7RPkM4ouZIUKU6i6I", "status": "Running",
@@ -731,7 +731,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshot
+    uri: https://snapshotstore000002.azconfig.io/operations?api-version=2023-11-01&snapshot=TestSnapshot
   response:
     body:
       string: '{"id": "q7wYTFRvCMHmch6lzgTPUbdvwE7RPkM4ouZIUKU6i6I", "status": "Succeeded",
@@ -771,7 +771,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
+    uri: https://snapshotstore000002.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"HVC4olRTOnU1uG9SJAWp4vH5v7rB-dvjwxh-WrX9dpA","name":"TestSnapshot","status":"ready","filters":[{"key":"Test*","label":"dev","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:33:11+00:00","size":1000,"items_count":2,"tags":{"tag1":"value1"},"retention_period":3600}'
@@ -814,7 +814,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/snapshots/TestSnapshot?%24select=name%2Cstatus%2Citems_count%2Cfilters&api-version=2023-11-01
+    uri: https://snapshotstore000002.azconfig.io/snapshots/TestSnapshot?%24select=name%2Cstatus%2Citems_count%2Cfilters&api-version=2023-11-01
   response:
     body:
       string: '{"name":"TestSnapshot","status":"ready","filters":[{"key":"Test*","label":"dev","tags":[]}],"items_count":2}'
@@ -857,7 +857,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/snapshots?%24select=name%2Cstatus%2Citems_count%2Cfilters&api-version=2023-11-01&name=TestSnapshot
+    uri: https://snapshotstore000002.azconfig.io/snapshots?%24select=name%2Cstatus%2Citems_count%2Cfilters&api-version=2023-11-01&name=TestSnapshot
   response:
     body:
       string: '{"items":[{"name":"TestSnapshot","status":"ready","filters":[{"key":"Test*","label":"dev","tags":[]}],"items_count":2}]}'
@@ -898,7 +898,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PATCH
-    uri: https://snapshotstore000001.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
+    uri: https://snapshotstore000002.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"hQsa1huI1EaYxNjuq0WJr_fcZqOPyc6uiUuBboEAOCg","name":"TestSnapshot","status":"archived","filters":[{"key":"Test*","label":"dev","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:33:11+00:00","expires":"2026-07-17T19:33:38.5238238+00:00","size":1000,"items_count":2,"tags":{"tag1":"value1"},"retention_period":3600}'
@@ -941,7 +941,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/snapshots?%24select=&api-version=2023-11-01&name=%2A&status=ready
+    uri: https://snapshotstore000002.azconfig.io/snapshots?%24select=&api-version=2023-11-01&name=%2A&status=ready
   response:
     body:
       string: '{"items":[]}'
@@ -982,7 +982,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PATCH
-    uri: https://snapshotstore000001.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
+    uri: https://snapshotstore000002.azconfig.io/snapshots/TestSnapshot?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"QjNyoHu9M82da2hDD97vI5DDtqxoXqAxTp5ikCutnWU","name":"TestSnapshot","status":"ready","filters":[{"key":"Test*","label":"dev","tags":[]}],"composition_type":"key_label","created":"2026-07-17T18:33:11+00:00","size":1000,"items_count":2,"tags":{"tag1":"value1"},"retention_period":3600}'
@@ -1025,7 +1025,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/snapshots?%24select=&api-version=2023-11-01&name=%2A&status=archived
+    uri: https://snapshotstore000002.azconfig.io/snapshots?%24select=&api-version=2023-11-01&name=%2A&status=archived
   response:
     body:
       string: '{"items":[]}'
@@ -1062,7 +1062,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=TestSnapshot
+    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=TestSnapshot
   response:
     body:
       string: '{"etag":"m1fn8LWFrWj5nO6AeoKJBmVw4NQHSpd5fINyBYiK_Ag","items":[{"etag":"W_bYqCEnS-sEll-4BHB7sBKj18OBLm29QgFsJXCTwzQ","key":"TestKey1","label":"dev","content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:06+00:00"},{"etag":"KzUI5bMFP7qVHGsfpXfdb27ADA8pxAPnWycs64XF6y8","key":"TestKey2","label":"dev","content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:08+00:00"}]}'
@@ -1101,7 +1101,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=non_existent_snapshot
+    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=non_existent_snapshot
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1142,7 +1142,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/snapshots/non_existent_snapshot?api-version=2023-11-01
+    uri: https://snapshotstore000002.azconfig.io/snapshots/non_existent_snapshot?api-version=2023-11-01
   response:
     body:
       string: ''
@@ -1186,7 +1186,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000003?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -1195,8 +1195,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
-        "name": "snapshotstore000002", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000003",
+        "name": "snapshotstore000003", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/francecentral/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.OpiCniRHfrI2kLzQ8Rngf93bNLDEeKzf1D8EBCbzLuI?api-version=2025-08-01-preview&t=639199100256808387&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=lRo44_J8ICAp7zSAxs9_VQeHDAV2PnQkgdeN1itC-4H87EBPekFiobysoj7m2wVLqRgNHnMPJJlcb9KyauMCS1Tcscxs_qJIzOsEzdaUdF__L5Nc8ET_BSYvdMnpVPOx8STRCKK-_ZE-qTXIfNBaUnbK949CqFvVrDQbSg3vCk8NCcSrMnBgs1QkydByoSgpDOJR4cRYCXdvBo3b7Q7zWT0FpG-YllH63wpqLTiWUjqfbNlYVGOYHlIm5OuclYXKW_sB8YRCXAEUwkor5BI7tckvYBxIQXR4dFQPzdhRmo2gq2u32trNLwDWBlhvPvKifzPTFwWubvRkMw5ImtWS3g&h=TkP4Z1f1bn62022YTdULsnXfYJdVThgGmP3zj2Lof2w
@@ -1453,12 +1453,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000003?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "francecentral", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-17T18:33:45+00:00", "endpoint": "https://snapshotstore000002.azconfig.io",
+        "2026-07-17T18:33:45+00:00", "endpoint": "https://snapshotstore000003.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -1466,8 +1466,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-17T18:33:45+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-17T18:33:45+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000002",
-        "name": "snapshotstore000002", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-17T18:33:45+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/snapshotstore000003",
+        "name": "snapshotstore000003", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -1509,7 +1509,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=TestSnapshot
+    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=TestSnapshot
   response:
     body:
       string: '{"etag":"m1fn8LWFrWj5nO6AeoKJBmVw4NQHSpd5fINyBYiK_Ag","items":[{"etag":"W_bYqCEnS-sEll-4BHB7sBKj18OBLm29QgFsJXCTwzQ","key":"TestKey1","label":"dev","content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:06+00:00"},{"etag":"KzUI5bMFP7qVHGsfpXfdb27ADA8pxAPnWycs64XF6y8","key":"TestKey2","label":"dev","content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:08+00:00"}]}'
@@ -1548,7 +1548,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://snapshotstore000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1587,7 +1587,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
+    uri: https://snapshotstore000003.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1633,7 +1633,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000002.azconfig.io/kv/TestKey1?api-version=2023-11-01
+    uri: https://snapshotstore000003.azconfig.io/kv/TestKey1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"uzLv7xf7Wx8Iegb0FVu4XDHuaR_UdKKV30cQ7cZH5uQ","key":"TestKey1","label":null,"content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:26+00:00"}'
@@ -1681,7 +1681,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000002.azconfig.io/kv/TestKey2?api-version=2023-11-01
+    uri: https://snapshotstore000003.azconfig.io/kv/TestKey2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"JC_QT8DC0SwGY7TQ6HxfsS1rFVNz7qvDyWNFL2U3ohs","key":"TestKey2","label":null,"content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:27+00:00"}'
@@ -1722,7 +1722,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapshotstore000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"-kQJ5YoR2Q4te2SJxUr7Nkhv9zQ8dOAMRLuSMYITaGQ","items":[{"etag":"uzLv7xf7Wx8Iegb0FVu4XDHuaR_UdKKV30cQ7cZH5uQ","key":"TestKey1","label":null,"content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:26+00:00"},{"etag":"JC_QT8DC0SwGY7TQ6HxfsS1rFVNz7qvDyWNFL2U3ohs","key":"TestKey2","label":null,"content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:27+00:00"}]}'
@@ -1761,7 +1761,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapshotstore000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"-kQJ5YoR2Q4te2SJxUr7Nkhv9zQ8dOAMRLuSMYITaGQ","items":[{"etag":"uzLv7xf7Wx8Iegb0FVu4XDHuaR_UdKKV30cQ7cZH5uQ","key":"TestKey1","label":null,"content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:26+00:00"},{"etag":"JC_QT8DC0SwGY7TQ6HxfsS1rFVNz7qvDyWNFL2U3ohs","key":"TestKey2","label":null,"content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:27+00:00"}]}'
@@ -1806,7 +1806,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://snapshotstore000002.azconfig.io/kv/TestKey1?api-version=2023-11-01
+    uri: https://snapshotstore000003.azconfig.io/kv/TestKey1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"uzLv7xf7Wx8Iegb0FVu4XDHuaR_UdKKV30cQ7cZH5uQ","key":"TestKey1","label":null,"content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:26+00:00"}'
@@ -1853,7 +1853,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://snapshotstore000002.azconfig.io/kv/TestKey2?api-version=2023-11-01
+    uri: https://snapshotstore000003.azconfig.io/kv/TestKey2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"JC_QT8DC0SwGY7TQ6HxfsS1rFVNz7qvDyWNFL2U3ohs","key":"TestKey2","label":null,"content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:27+00:00"}'
@@ -1894,7 +1894,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000001.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=TestSnapshot
+    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&snapshot=TestSnapshot
   response:
     body:
       string: '{"etag":"m1fn8LWFrWj5nO6AeoKJBmVw4NQHSpd5fINyBYiK_Ag","items":[{"etag":"W_bYqCEnS-sEll-4BHB7sBKj18OBLm29QgFsJXCTwzQ","key":"TestKey1","label":"dev","content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:06+00:00"},{"etag":"KzUI5bMFP7qVHGsfpXfdb27ADA8pxAPnWycs64XF6y8","key":"TestKey2","label":"dev","content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:33:08+00:00"}]}'
@@ -1933,7 +1933,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
+    uri: https://snapshotstore000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%00
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -1979,7 +1979,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000002.azconfig.io/kv/TestKey1?api-version=2023-11-01
+    uri: https://snapshotstore000003.azconfig.io/kv/TestKey1?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"UwZ_SpUbp3mKAfq6BhVuhsr-Cc7vBGxtlhCNTw6h_U4","key":"TestKey1","label":null,"content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:35+00:00"}'
@@ -2027,7 +2027,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://snapshotstore000002.azconfig.io/kv/TestKey2?api-version=2023-11-01
+    uri: https://snapshotstore000003.azconfig.io/kv/TestKey2?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"GViFBn8xE077dAsSNt5Di-Sfj9O9CndjhABvE6mhhy8","key":"TestKey2","label":null,"content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:36+00:00"}'
@@ -2068,7 +2068,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.0 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://snapshotstore000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://snapshotstore000003.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"YYiC343DEqqcZt5ps3Cna3vYhi1r7TgqJe5VVWQ8tzA","items":[{"etag":"UwZ_SpUbp3mKAfq6BhVuhsr-Cc7vBGxtlhCNTw6h_U4","key":"TestKey1","label":null,"content_type":"","value":"TestValue1","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:35+00:00"},{"etag":"GViFBn8xE077dAsSNt5Di-Sfj9O9CndjhABvE6mhhy8","key":"TestKey2","label":null,"content_type":"","value":"TestValue2","tags":{},"locked":false,"last_modified":"2026-07-17T18:34:36+00:00"}]}'

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_strict_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_strict_import.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,7 +29,7 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001",
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001",
         "name": "strictimporttest000001", "tags": {}}'
     headers:
       azure-asyncoperation:
@@ -287,7 +287,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -300,7 +300,7 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:55:15+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:55:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mametcal-python/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001",
+        "User", "lastModifiedAt": "2026-07-15T17:55:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001",
         "name": "strictimporttest000001", "tags": {}}'
     headers:
       cache-control:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_strict_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/recordings/test_azconfig_strict_import.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
@@ -29,8 +29,8 @@ interactions:
         "privateEndpointConnections": null, "disableLocalAuth": null, "softDeleteRetentionInDays":
         null, "defaultKeyValueRevisionRetentionPeriodInSeconds": null, "enablePurgeProtection":
         null, "dataPlaneProxy": null, "telemetry": null, "azureFrontDoor": null},
-        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001",
-        "name": "strictimporttest000001", "tags": {}}'
+        "sku": {"name": "Standard"}, "systemData": null, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000002",
+        "name": "strictimporttest000002", "tags": {}}'
     headers:
       azure-asyncoperation:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AppConfiguration/locations/eastus/operationsStatus/Y29uZmlndXJhdGlvblN0b3Jlcw.jNaqjZAz1HxkjoN3CWDWidJneujr9yMLNFPhX9eL3p8?api-version=2025-08-01-preview&t=639197349155158472&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=O2HK-Mf2azXFqP4ZGmoXYDYRK2hMYpeSiXZLwen496bDx5g7h4pz71PXmvlge34D68svpQTaz85FUQvNo5rVPvxczodVN6YRehR_LXaGJdlZTZLfiSOeoBMPEtiwTE-wdyQVdfoysag9wlMZMUjyuL8q1kilkgzj_8FgjsiAgeS7AZGGVY_76ZT8ky59g3QhIMRdOEO7qkNQaip3FpYinHatI9A2huGIQeUtlTo-jUllLUsUIlOjT0Z8IW-8Yy-sdRvhmz1HgoNEaGnX5Ccs4e0muOfG6H2dkdKGzZkB1l5X75HL858Z4DSMYP5rJ1BzgMVElRe2Nf9RyzT_D0602Q&h=z7FWgtOfJIV-ElZGgGJfHlI3QONdnCs16GDOGA8MYBw
@@ -287,12 +287,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.88.0 azsdk-python-core/1.39.0 Python/3.14.3 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001?api-version=2025-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000002?api-version=2025-08-01-preview
   response:
     body:
       string: '{"type": "Microsoft.AppConfiguration/configurationStores", "location":
         "eastus", "properties": {"provisioningState": "Succeeded", "creationDate":
-        "2026-07-15T17:55:15+00:00", "endpoint": "https://strictimporttest000001.azconfig.io",
+        "2026-07-15T17:55:15+00:00", "endpoint": "https://strictimporttest000002.azconfig.io",
         "encryption": {"keyVaultProperties": null}, "privateEndpointConnections":
         null, "disableLocalAuth": true, "softDeleteRetentionInDays": 1, "defaultKeyValueRevisionRetentionPeriodInSeconds":
         2592000, "enablePurgeProtection": false, "dataPlaneProxy": {"authenticationMode":
@@ -300,8 +300,8 @@ interactions:
         null}, "azureFrontDoor": {"resourceId": null}}, "sku": {"name": "standard"},
         "systemData": {"createdBy": "test@example.com", "createdByType": "User", "createdAt":
         "2026-07-15T17:55:15+00:00", "lastModifiedBy": "test@example.com", "lastModifiedByType":
-        "User", "lastModifiedAt": "2026-07-15T17:55:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000001",
-        "name": "strictimporttest000001", "tags": {}}'
+        "User", "lastModifiedAt": "2026-07-15T17:55:15+00:00"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.AppConfiguration/configurationStores/strictimporttest000002",
+        "name": "strictimporttest000002", "tags": {}}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +343,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://strictimporttest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://strictimporttest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"00wWELzclWef22f82qcUDI7FbJweVOoKWZDA_JoUeD0","items":[]}'
@@ -392,7 +392,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/.appconfig.featureflag%2Fbeta-enabled?api-version=2023-11-01&label=beta-feature
+    uri: https://strictimporttest000002.azconfig.io/kv/.appconfig.featureflag%2Fbeta-enabled?api-version=2023-11-01&label=beta-feature
   response:
     body:
       string: '{"etag":"WyWRH0K3W65Z28A64joGWf9orb7zboq8HxXjXssIty0","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -445,7 +445,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/.appconfig.featureflag%2Fbool-feature?api-version=2023-11-01
+    uri: https://strictimporttest000002.azconfig.io/kv/.appconfig.featureflag%2Fbool-feature?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"flIZhqlDE4zqnslKSN79c1pwUNj4XtpGfMRZShciO9M","key":".appconfig.featureflag/bool-feature","label":null,"content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -500,7 +500,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/.appconfig.featureflag%2Ftheta-enabled?api-version=2023-11-01&label=theta-enabled-label
+    uri: https://strictimporttest000002.azconfig.io/kv/.appconfig.featureflag%2Ftheta-enabled?api-version=2023-11-01&label=theta-enabled-label
   response:
     body:
       string: '{"etag":"LmEfxfMD8P1ZHHiJbk75Sl9Zpb9lp8BGkEoN9u51ehE","key":".appconfig.featureflag/theta-enabled","label":"theta-enabled-label","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -553,7 +553,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/TestApp%3ASettings%3ABackgroundColor?api-version=2023-11-01
+    uri: https://strictimporttest000002.azconfig.io/kv/TestApp%3ASettings%3ABackgroundColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"QI003gOSPVm25NDLl8NObPizmcQatQpD3nNblkAEB-c","key":"TestApp:Settings:BackgroundColor","label":null,"content_type":"","value":"#FBB","tags":{"App":"TesApp"},"locked":false,"last_modified":"2026-07-15T17:55:56+00:00"}'
@@ -601,7 +601,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/TestApp%3ASettings%3AFontColor?api-version=2023-11-01
+    uri: https://strictimporttest000002.azconfig.io/kv/TestApp%3ASettings%3AFontColor?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"6T64vSMwkslmqyxHdQrC7kdveCNK7ZD4xhnpfmYw8Iw","key":"TestApp:Settings:FontColor","label":null,"content_type":"","value":"#999","tags":{"App":"TestApp"},"locked":false,"last_modified":"2026-07-15T17:55:57+00:00"}'
@@ -649,7 +649,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/TestApp%3ASettings%3AFontSize?api-version=2023-11-01
+    uri: https://strictimporttest000002.azconfig.io/kv/TestApp%3ASettings%3AFontSize?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"xVUiAXqOuTaZ9ILEI7UE8p19gGBiCfxBU1ZutJFmsH8","key":"TestApp:Settings:FontSize","label":null,"content_type":"","value":"30","tags":{"App":"TestApp"},"locked":false,"last_modified":"2026-07-15T17:55:57+00:00"}'
@@ -697,7 +697,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/TestApp%3ASettings%3AMessage?api-version=2023-11-01
+    uri: https://strictimporttest000002.azconfig.io/kv/TestApp%3ASettings%3AMessage?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"fpJIbFbTuV_aOVsIQgb7bneRfIUyDCCcHXBfQocrjYo","key":"TestApp:Settings:Message","label":null,"content_type":"","value":"Dada
@@ -747,7 +747,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/pratik-top-secret?api-version=2023-11-01
+    uri: https://strictimporttest000002.azconfig.io/kv/pratik-top-secret?api-version=2023-11-01
   response:
     body:
       string: '{"etag":"fIAZ6RQQ8smhJi1lMlXmr42QJS5odI4uWGI2olMxGxY","key":"pratik-top-secret","label":null,"content_type":"application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8","value":"{\"uri\":
@@ -796,7 +796,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-1
+    uri: https://strictimporttest000002.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-1
   response:
     body:
       string: '{"etag":"-6CFCjL27GsZ7_jcC5OCCpVoH-OsVPRNCc9c_popCbo","key":"sample-1-testkey","label":"sample-1","content_type":"text/json","value":"sample-1-testvalue","tags":{"tag1":"sample","tag2":"sample2"},"locked":false,"last_modified":"2026-07-15T17:56:00+00:00"}'
@@ -844,7 +844,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-2
+    uri: https://strictimporttest000002.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-2
   response:
     body:
       string: '{"etag":"bAcFaSyMJEAIL2tTsWKpPahCA0S0qn_r3J_W6G-iABI","key":"sample-1-testkey","label":"sample-2","content_type":"application/json","value":"sample-2-with-label","tags":{},"locked":false,"last_modified":"2026-07-15T17:56:00+00:00"}'
@@ -892,7 +892,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://strictimporttest000001.azconfig.io/kv/sample-2-testkey?api-version=2023-11-01&label=sample-3
+    uri: https://strictimporttest000002.azconfig.io/kv/sample-2-testkey?api-version=2023-11-01&label=sample-3
   response:
     body:
       string: '{"etag":"tdSqQEyHnOW1Duc74hyHQyDn9eng03Hh1FXLyV2IoAo","key":"sample-2-testkey","label":"sample-3","content_type":"application/json","value":"sample-2-with-label","tags":{},"locked":false,"last_modified":"2026-07-15T17:56:01+00:00"}'
@@ -933,7 +933,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://strictimporttest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://strictimporttest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"xeb11mj9QvH5-g3c3pGyuVEd9TqSHjhKXsEIj71DEWY","items":[{"etag":"WyWRH0K3W65Z28A64joGWf9orb7zboq8HxXjXssIty0","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -988,7 +988,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://strictimporttest000001.azconfig.io/kv/.appconfig.featureflag%2Ftheta-enabled?api-version=2023-11-01&label=theta-enabled-label
+    uri: https://strictimporttest000002.azconfig.io/kv/.appconfig.featureflag%2Ftheta-enabled?api-version=2023-11-01&label=theta-enabled-label
   response:
     body:
       string: '{"etag":"LmEfxfMD8P1ZHHiJbk75Sl9Zpb9lp8BGkEoN9u51ehE","key":".appconfig.featureflag/theta-enabled","label":"theta-enabled-label","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1038,7 +1038,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://strictimporttest000001.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-2
+    uri: https://strictimporttest000002.azconfig.io/kv/sample-1-testkey?api-version=2023-11-01&label=sample-2
   response:
     body:
       string: '{"etag":"bAcFaSyMJEAIL2tTsWKpPahCA0S0qn_r3J_W6G-iABI","key":"sample-1-testkey","label":"sample-2","content_type":"application/json","value":"sample-2-with-label","tags":{},"locked":false,"last_modified":"2026-07-15T17:56:00+00:00"}'
@@ -1083,7 +1083,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://strictimporttest000001.azconfig.io/kv/sample-2-testkey?api-version=2023-11-01&label=sample-3
+    uri: https://strictimporttest000002.azconfig.io/kv/sample-2-testkey?api-version=2023-11-01&label=sample-3
   response:
     body:
       string: '{"etag":"tdSqQEyHnOW1Duc74hyHQyDn9eng03Hh1FXLyV2IoAo","key":"sample-2-testkey","label":"sample-3","content_type":"application/json","value":"sample-2-with-label","tags":{},"locked":false,"last_modified":"2026-07-15T17:56:01+00:00"}'
@@ -1124,7 +1124,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://strictimporttest000001.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
+    uri: https://strictimporttest000002.azconfig.io/kv?%24select=&api-version=2023-11-01&key=%2A&label=%2A
   response:
     body:
       string: '{"etag":"-qW7AyOFiaJ-ay5OvQZ0S2xjfQGLskwtUJZJQfh7qfs","items":[{"etag":"WyWRH0K3W65Z28A64joGWf9orb7zboq8HxXjXssIty0","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":
@@ -1170,7 +1170,7 @@ interactions:
       - AZURECLI.APPCONFIG/2.88.0 azsdk-python-appconfiguration/1.8.1 Python/3.14.3
         (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://strictimporttest000001.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
+    uri: https://strictimporttest000002.azconfig.io/kv?api-version=2023-11-01&key=.appconfig.featureflag%2F%2A&label=%2A
   response:
     body:
       string: '{"etag":"HWrJ7issPozgg27nM1bSBZdUY0tyBJNhWMNvcv33E1Y","items":[{"etag":"WyWRH0K3W65Z28A64joGWf9orb7zboq8HxXjXssIty0","key":".appconfig.featureflag/beta-enabled","label":"beta-feature","content_type":"application/vnd.microsoft.appconfig.ff+json;charset=utf-8","value":"{\"id\":

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py
@@ -12,7 +12,7 @@ from azure.cli.testsdk.checkers import NoneCheck
 from azure.cli.command_modules.appconfig._constants import FeatureFlagConstants
 from azure.cli.core.azclierror import InvalidArgumentValueError
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -22,6 +22,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
         register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
 
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
@@ -658,6 +659,8 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
     def __init__(self, *args, **kwargs):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
+        register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
 
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_feature_commands.py
@@ -12,7 +12,7 @@ from azure.cli.testsdk.checkers import NoneCheck
 from azure.cli.command_modules.appconfig._constants import FeatureFlagConstants
 from azure.cli.core.azclierror import InvalidArgumentValueError
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import AppConfigResourceGroupPreparer, create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -24,10 +24,11 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_feature(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_feature(self, resource_group, location):
         feature_test_store_prefix = get_resource_name_prefix('featuretest')
         config_store_name = self.create_random_name(prefix=feature_test_store_prefix, length=24)
 
@@ -36,7 +37,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })
@@ -466,10 +467,11 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         list_features = self.cmd('appconfig feature list --endpoint {endpoint} --auth-mode login --feature {feature} --label {label}').get_output_in_json()
         assert len(list_features) == 4
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_feature_namespacing(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_feature_namespacing(self, resource_group, location):
         feature_namespace_store_prefix = get_resource_name_prefix('featurenamespacetest')
         config_store_name = self.create_random_name(prefix=feature_namespace_store_prefix, length=24)
 
@@ -478,7 +480,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })
@@ -568,10 +570,11 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         with self.assertRaisesRegex(CLIError, "Feature name cannot contain the following characters: '%', ':'"):
             self.cmd('appconfig feature set --endpoint {endpoint} --auth-mode login --feature {feature}')
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_feature_telemetry(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_feature_telemetry(self, resource_group, location):
         """Test feature flag telemetry functionality."""
         feature_telemetry_store_prefix = get_resource_name_prefix('featuretelemetrytest')
         config_store_name = self.create_random_name(prefix=feature_telemetry_store_prefix, length=24)
@@ -581,7 +584,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })
@@ -662,10 +665,11 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_feature_filter(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_feature_filter(self, resource_group, location):
         feature_filter_store_prefix = get_resource_name_prefix('featurefiltertest')
         config_store_name = self.create_random_name(prefix=feature_filter_store_prefix, length=24)
 
@@ -674,7 +678,7 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_json_content_type.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_json_content_type.py
@@ -14,7 +14,7 @@ import yaml
 from knack.util import CLIError
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import AppConfigResourceGroupPreparer, create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, register_appconfig_query_matcher, register_appconfig_recording_processors
 from azure.cli.command_modules.appconfig._constants import AIConfigConstants, FeatureFlagConstants, KeyVaultConstants
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
@@ -27,10 +27,11 @@ class AppConfigJsonContentTypeScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_json_content_type(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_json_content_type(self, resource_group, location):
         src_config_store_prefix = get_resource_name_prefix('source')
         dest_config_store_prefix = get_resource_name_prefix('destination')
         src_config_store_name = self.create_random_name(prefix=src_config_store_prefix, length=24)
@@ -42,7 +43,7 @@ class AppConfigJsonContentTypeScenarioTest(ScenarioTest):
             'config_store_name': src_config_store_name,
             'src_endpoint': 'https://' + src_config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku
         })
         create_config_store(self, self.kwargs, disable_local_auth=True)

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_json_content_type.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_json_content_type.py
@@ -14,7 +14,7 @@ import yaml
 from knack.util import CLIError
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
 from azure.cli.command_modules.appconfig._constants import AIConfigConstants, FeatureFlagConstants, KeyVaultConstants
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
@@ -25,6 +25,7 @@ class AppConfigJsonContentTypeScenarioTest(ScenarioTest):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
         register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
 
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_key_validation.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_key_validation.py
@@ -11,7 +11,7 @@ import os
 from knack.util import CLIError
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import AppConfigResourceGroupPreparer, create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -23,10 +23,11 @@ class AppConfigKeyValidationScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
     
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_key_validation(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_key_validation(self, resource_group, location):
         config_store_prefix = get_resource_name_prefix('kvtest')
         config_store_name = self.create_random_name(prefix=config_store_prefix, length=24)
 
@@ -35,7 +36,7 @@ class AppConfigKeyValidationScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_key_validation.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_key_validation.py
@@ -11,7 +11,7 @@ import os
 from knack.util import CLIError
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -21,6 +21,7 @@ class AppConfigKeyValidationScenarioTest(ScenarioTest):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
         register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
     
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py
@@ -13,7 +13,7 @@ from azure.cli.testsdk import (ResourceGroupPreparer, ScenarioTest, KeyVaultPrep
 from azure.cli.command_modules.appconfig._constants import KeyVaultConstants
 from azure.cli.core.azclierror import RequiredArgumentMissingError, InvalidArgumentValueError, MutuallyExclusiveArgumentError
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -23,6 +23,7 @@ class AppConfigKVScenarioTest(ScenarioTest):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
         register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
 
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
@@ -366,8 +367,9 @@ class AppConfigKVScenarioTest(ScenarioTest):
         os.remove(exported_file_path)
 
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
+    # Uses Entra ID auth (store created with local auth disabled). For live runs set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a resource group where the recording principal holds
+    # "App Configuration Data Owner"; ResourceGroupNameReplacer scrubs that name out of recordings.
     def test_azconfig_kv_revision_list(self):
         # Use an all-lowercase store name prefix. The data-plane endpoint is '<name>.azconfig.io'
         # and HTTP lowercases the host, so a mixed-case name would not match the (case-sensitive)

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_commands.py
@@ -13,7 +13,7 @@ from azure.cli.testsdk import (ResourceGroupPreparer, ScenarioTest, KeyVaultPrep
 from azure.cli.command_modules.appconfig._constants import KeyVaultConstants
 from azure.cli.core.azclierror import RequiredArgumentMissingError, InvalidArgumentValueError, MutuallyExclusiveArgumentError
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import AppConfigResourceGroupPreparer, create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -25,10 +25,11 @@ class AppConfigKVScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_kv(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_kv(self, resource_group, location):
         # Lowercase store-name prefix so the HTTP-lowercased '<name>.azconfig.io' host matches the
         # name registered with the recording name-replacer, keeping cassettes scrubbed for playback.
         config_store_prefix = get_resource_name_prefix('kvtest')
@@ -39,7 +40,7 @@ class AppConfigKVScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })
@@ -366,11 +367,12 @@ class AppConfigKVScenarioTest(ScenarioTest):
         assert exported_kvs[secret_name] == secret_value
         os.remove(exported_file_path)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled). For live runs set
     # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a resource group where the recording principal holds
     # "App Configuration Data Owner"; ResourceGroupNameReplacer scrubs that name out of recordings.
-    def test_azconfig_kv_revision_list(self):
+    def test_azconfig_kv_revision_list(self, resource_group, location):
         # Use an all-lowercase store name prefix. The data-plane endpoint is '<name>.azconfig.io'
         # and HTTP lowercases the host, so a mixed-case name would not match the (case-sensitive)
         # name registered with the recording name-replacer, leaving the live host unscrubbed in the
@@ -383,7 +385,7 @@ class AppConfigKVScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py
@@ -1005,7 +1005,7 @@ class AppConfigToAppConfigImportExportScenarioTest(ScenarioTest):
 
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
+    # recording principal holds "App Configuration Data Owner". For live runs set AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME.
     def test_appconfig_to_appconfig_import_export(self):
         src_config_store_prefix = get_resource_name_prefix('source')
         dest_config_store_prefix = get_resource_name_prefix('destination')

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py
@@ -15,7 +15,7 @@ from azure.cli.testsdk import (ResourceGroupPreparer, ScenarioTest, LiveScenario
 from azure.cli.command_modules.appconfig._constants import FeatureFlagConstants, KeyVaultConstants, ImportExportProfiles, AppServiceConstants
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.core.azclierror import AzureInternalError, MutuallyExclusiveArgumentError
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import AppConfigResourceGroupPreparer, create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -27,10 +27,11 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_import_export(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_import_export(self, resource_group, location):
         store_name_prefix = get_resource_name_prefix('importtest')
         config_store_name = self.create_random_name(prefix=store_name_prefix, length=24)
 
@@ -40,7 +41,7 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
             'config_store_name': config_store_name,
             'endpoint': 'https://' + config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku
         })
         create_config_store(self, self.kwargs, disable_local_auth=True)
@@ -289,10 +290,11 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
         with self.assertRaisesRegex(MutuallyExclusiveArgumentError, "The '--dry-run' and '--yes' options cannot be specified together."):
             self.cmd('appconfig kv export --endpoint {endpoint} --auth-mode login -d {import_source} --path "{exported_file_path}" --format {imported_format} --label {label} --dry-run -y')
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_import_export_new_fm_schema(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_import_export_new_fm_schema(self, resource_group, location):
         # Feature flags test with new ms fm schema
         os.environ['AZURE_APPCONFIG_FM_COMPATIBLE'] = 'False'
 
@@ -305,7 +307,7 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
             'config_store_name': config_store_name,
             'endpoint': 'https://' + config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'import_source': 'file',
             'imported_format': 'json',
@@ -399,10 +401,11 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
         os.remove(exported_prop_file_path)
 
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_import_export_kvset(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_import_export_kvset(self, resource_group, location):
         kvset_store_prefix = get_resource_name_prefix('kvsetimporttest')
         config_store_name = self.create_random_name(prefix=kvset_store_prefix, length=24)
 
@@ -412,7 +415,7 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
             'config_store_name': config_store_name,
             'endpoint': 'https://' + config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku
         })
         create_config_store(self, self.kwargs, disable_local_auth=True)
@@ -454,10 +457,11 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
         assert exported_kvs == expected_kvs
         os.remove(exported_file_path)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_strict_import(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_strict_import(self, resource_group, location):
         strict_store_prefix = get_resource_name_prefix('strictimporttest')
         config_store_name = self.create_random_name(prefix=strict_store_prefix, length=24)
 
@@ -467,7 +471,7 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
             'config_store_name': config_store_name,
             'endpoint': 'https://' + config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku
         })
         create_config_store(self, self.kwargs, disable_local_auth=True)
@@ -760,10 +764,11 @@ class AppConfigImportExportNamingConventionScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_import_export_naming_conventions(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_import_export_naming_conventions(self, resource_group, location):
         naming_convention_store_prefix = get_resource_name_prefix('namingconventiontest')
         config_store_name = self.create_random_name(prefix=naming_convention_store_prefix, length=24)
 
@@ -773,7 +778,7 @@ class AppConfigImportExportNamingConventionScenarioTest(ScenarioTest):
             'config_store_name': config_store_name,
             'endpoint': 'https://' + config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku
         })
         create_config_store(self, self.kwargs, disable_local_auth=True)
@@ -845,10 +850,11 @@ class AppConfigImportExportNamingConventionScenarioTest(ScenarioTest):
         assert exported_yaml_file == exported_hyphen_yaml_file
         os.remove(exported_yaml_file_path)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_import_export_respect_both_schemas_naming_conventions(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_import_export_respect_both_schemas_naming_conventions(self, resource_group, location):
         # Respect both fm schemas in file
         both_schema_test_prefix = get_resource_name_prefix('bothschematest')
         config_store_name = self.create_random_name(prefix=both_schema_test_prefix, length=24)
@@ -859,7 +865,7 @@ class AppConfigImportExportNamingConventionScenarioTest(ScenarioTest):
             'config_store_name': config_store_name,
             'endpoint': 'https://' + config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'import_source': 'file'
         })
@@ -1003,10 +1009,11 @@ class AppConfigToAppConfigImportExportScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_appconfig_to_appconfig_import_export(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_appconfig_to_appconfig_import_export(self, resource_group, location):
         src_config_store_prefix = get_resource_name_prefix('source')
         dest_config_store_prefix = get_resource_name_prefix('destination')
         src_config_store_name = self.create_random_name(prefix=src_config_store_prefix, length=24)
@@ -1019,7 +1026,7 @@ class AppConfigToAppConfigImportExportScenarioTest(ScenarioTest):
             'src_endpoint': 'https://' + src_config_store_name + '.azconfig.io',
             'dest_endpoint': 'https://' + dest_config_store_name + '.azconfig.io',
             'rg_loc': location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku
         })
         create_config_store(self, self.kwargs, disable_local_auth=True)

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_import_export_commands.py
@@ -15,7 +15,7 @@ from azure.cli.testsdk import (ResourceGroupPreparer, ScenarioTest, LiveScenario
 from azure.cli.command_modules.appconfig._constants import FeatureFlagConstants, KeyVaultConstants, ImportExportProfiles, AppServiceConstants
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.core.azclierror import AzureInternalError, MutuallyExclusiveArgumentError
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -25,6 +25,7 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
         register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
 
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
@@ -757,6 +758,7 @@ class AppConfigImportExportNamingConventionScenarioTest(ScenarioTest):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
         register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
 
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
@@ -998,7 +1000,9 @@ class AppConfigToAppConfigImportExportScenarioTest(ScenarioTest):
     def __init__(self, *args, **kwargs):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super().__init__(*args, **kwargs)
-    
+        register_appconfig_query_matcher(self)
+        register_appconfig_recording_processors(self)
+
     @AllowLargeResponse()
     # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
     # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_snapshot_reference_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_kv_snapshot_reference_commands.py
@@ -10,7 +10,7 @@ import json
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.command_modules.appconfig._constants import SnapshotReferenceConstants
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import AppConfigResourceGroupPreparer, create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 
 class AppConfigSnapshotRefScenarioTest(ScenarioTest):
@@ -21,10 +21,11 @@ class AppConfigSnapshotRefScenarioTest(ScenarioTest):
         register_appconfig_query_matcher(self)
         register_appconfig_recording_processors(self)
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_kv_set_snapshot_reference(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_kv_set_snapshot_reference(self, resource_group, location):
         store_name_prefix = get_resource_name_prefix('snapreftest')
         config_store_name = self.create_random_name(prefix=store_name_prefix, length=24)
         store_location = 'eastus'
@@ -33,7 +34,7 @@ class AppConfigSnapshotRefScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': store_location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })
@@ -86,10 +87,11 @@ class AppConfigSnapshotRefScenarioTest(ScenarioTest):
                          self.check('tags.env', 'prod'),
                          self.check('tags.team', 'config')])
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_kv_list_resolve_snapshot_references(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_kv_list_resolve_snapshot_references(self, resource_group, location):
         store_name_prefix = get_resource_name_prefix('snapreflist')
         config_store_name = self.create_random_name(prefix=store_name_prefix, length=24)
         store_location = 'eastus'
@@ -98,7 +100,7 @@ class AppConfigSnapshotRefScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': store_location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'endpoint': 'https://' + config_store_name + '.azconfig.io'
         })

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_snapshot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_snapshot_commands.py
@@ -10,7 +10,7 @@ import json
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.core.azclierror import ResourceNotFoundError as CliResourceNotFoundError, MutuallyExclusiveArgumentError
-from azure.cli.command_modules.appconfig.tests.latest._test_utils import create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, get_test_resource_group, register_appconfig_query_matcher, register_appconfig_recording_processors
+from azure.cli.command_modules.appconfig.tests.latest._test_utils import AppConfigResourceGroupPreparer, create_config_store, CredentialResponseSanitizer, get_resource_name_prefix, register_appconfig_query_matcher, register_appconfig_recording_processors
 
 class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
 
@@ -21,10 +21,11 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
         register_appconfig_recording_processors(self)
 
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_snapshot_mgmt(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_snapshot_mgmt(self, resource_group, location):
         store_name_prefix = get_resource_name_prefix('snapshotstore') 
         config_store_name = self.create_random_name(prefix=store_name_prefix, length=24)
         snapshot_name = "TestSnapshot"
@@ -35,7 +36,7 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
             'config_store_name': config_store_name,
             'snapshot_name': snapshot_name,
             'rg_loc': store_location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'retention_days': 1,
             'enable_purge_protection': False,
@@ -181,10 +182,11 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
         self.assertEqual(len(current_kvs), 2)
 
 
+    @AppConfigResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
-    # Uses Entra ID auth (store created with local auth disabled); target a resource group where the
-    # recording principal holds "App Configuration Data Owner". Override via AZURE_CLI_APPCONFIG_TEST_RG.
-    def test_azconfig_snapshot_filtering(self):
+    # Uses Entra ID auth (store created with local auth disabled). For live recording, set
+    # AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME to a group where you hold "App Configuration Data Owner".
+    def test_azconfig_snapshot_filtering(self, resource_group, location):
         store_name_prefix = get_resource_name_prefix('snapshotfilters') 
         config_store_name = self.create_random_name(prefix=store_name_prefix, length=36)
         store_location = 'francecentral'
@@ -193,7 +195,7 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
         self.kwargs.update({
             'config_store_name': config_store_name,
             'rg_loc': store_location,
-            'rg': get_test_resource_group(),
+            'rg': resource_group,
             'sku': sku,
             'retention_days': 1,
             'enable_purge_protection': False,


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Description
App Configuration data-plane tests use Microsoft Entra ID (`--auth-mode login`) against stores created with local authentication disabled, which requires the recording principal to hold *App Configuration Data Owner* on a resource group. Recording against such a group caused the environment-specific resource group name to be baked into the checked-in cassettes.

This change:
- Adds a recording processor (`ResourceGroupNameReplacer`) that rewrites the reused live resource group (from the standard `AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME`) to a neutral stub in the recordings, and registers it on the data-plane test classes.
- Defaults `get_test_resource_group()` to that same stub during playback so requests match the sanitized cassettes, and fails fast (only in live mode) when no resource group is provided.
- Sanitizes the resource group name out of the existing data-plane recordings.

Management-plane test recordings are intentionally left untouched.

### Testing Guide
Data-plane suite: 20 passed / 3 skipped (live-only). Management suite: 10 passed / 5 skipped. No regressions.

### History Notes
[Component Name] `az appconfig`: Keep environment-specific resource group names out of data-plane test recordings (test-only change).