### PR TITLE
[Consumption] Fix #33907: `az consumption usage list`: Preserve `meterDetails.totalIncludedQuantity`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/consumption/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/consumption/custom.py
@@ -103,7 +103,7 @@ def transform_usage_output(result):
     result['billableQuantity'] = str(result.get('billableQuantity', None))
     result['pretaxCost'] = str(result.get('pretaxCost', None))
     if 'meterDetails' in result:
-        result['meterDetails']['totalIncludedQuantity'] = str(result['meterDetails'].get('pretaxStandardRate', None))
+        result['meterDetails']['totalIncludedQuantity'] = str(result['meterDetails'].get('totalIncludedQuantity', None))
         result['meterDetails']['pretaxStandardRate'] = str(result['meterDetails'].get('pretaxStandardRate', None))
     else:
         result['meterDetails'] = None
@@ -246,7 +246,7 @@ def pricesheet_show_properties(result):
     result['includedQuantity'] = str(result['includedQuantity'])
     result['unitPrice'] = str(result['unitPrice'])
     if 'meterDetails' in result:
-        result['meterDetails']['totalIncludedQuantity'] = str(result['meterDetails'].get('pretaxStandardRate', None))
+        result['meterDetails']['totalIncludedQuantity'] = str(result['meterDetails'].get('totalIncludedQuantity', None))
         result['meterDetails']['pretaxStandardRate'] = str(result['meterDetails'].get('pretaxStandardRate', None))
     else:
         result['meterDetails'] = None


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
az consumption usage list -m
az consumption usage list -a -m
az consumption pricesheet show --include-meter-details

**Description**
Fixes #33907.

`transform_usage_output` and `pricesheet_show_properties` stringified `meterDetails.totalIncludedQuantity` from `pretaxStandardRate`, so included quantity was replaced with the listing price.

This restores the pre-AAZ mapping from #27152: each field is converted from its own service value.

**Testing Guide**
With `--include-meter-details`, if the service returns `totalIncludedQuantity: 100` and `pretaxStandardRate: 0.05`, CLI output should be:

```json
"meterDetails": {
  "totalIncludedQuantity": "100",
  "pretaxStandardRate": "0.05"
}
```

`--debug` already showed the correct REST payload; only the CLI transform was wrong.

**History Notes**
[Consumption] `az consumption usage list/pricesheet show`: Preserve `meterDetails.totalIncludedQuantity` when including meter details

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

Made with [Cursor](https://cursor.com)