### PR TITLE
{Network} `az network vnet create`: Remove unsupported `summarized-gateway-prefixes` with `ipam-pool-prefix-allocations` reference from help text

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_create.py
@@ -30,9 +30,6 @@ class Create(AAZCommand):
 
     :example: For --summarized-gateway-prefixes with address-prefixes
         az network vnet create --resource-group rg1 --name test-vnet --location eastus --address-prefixes 10.0.0.0/16 --summarized-gateway-prefixes address-prefixes="[10.0.0.0/16]"
-
-    :example: For --summarized-gateway-prefixes with ipam-pool-prefix-allocations
-        az network vnet create -g {rg} -n {vnet} --address-prefixes 10.0.0.0/16 --summarized-gateway-prefixes ipam-pool-prefix-allocations="[{id:<pool-resource-id>,number-of-ip-addresses:10}]"
     """
 
     _aaz_info = {

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_update.py
@@ -28,9 +28,6 @@ class Update(AAZCommand):
 
     :example: For --summarized-gateway-prefixes with address-prefixes
         az network vnet update --resource-group rg1 --name test-vnet --summarized-gateway-prefixes address-prefixes="[10.0.0.0/16,10.1.0.0/16]"
-
-    :example: For --summarized-gateway-prefixes with ipam-pool-prefix-allocations
-        az network vnet update --resource-group rg1 --name test-vnet --summarized-gateway-prefixes ipam-pool-prefix-allocations="[{id:<pool-resource-id>,number-of-ip-addresses:10}]"
     """
 
     _aaz_info = {


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
`az network vnet create`
 `az network vnet update`

**Description**
The help for `az network vnet create` and `az network vnet update` included examples combining `--summarized-gateway-prefixes` with `ipam-pool-prefix-allocations`, but this combination is not currently supported for public use.
 
Remove the unsupported examples to avoid directing users to an unavailable scenario. The supported `address-prefixes` examples remain unchanged.

Fixes #33923
aaz https://github.com/Azure/aaz/pull/1068

**Testing Guide**
`az network vnet create --help`
`az network vnet update --help`

**History Notes**


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
