### PR TITLE
[Packaging] Fix #28497: Preserve non-ASCII output from Windows launchers in isolated mode

### DIFF
--- a/build_scripts/windows/scripts/az
+++ b/build_scripts/windows/scripts/az
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-AZ_INSTALLER=MSI "$(dirname "${BASH_SOURCE[0]}")/../python.exe" -IBm azure.cli "$@"
+AZ_INSTALLER=MSI "$(dirname "${BASH_SOURCE[0]}")/../python.exe" -X utf8 -IBm azure.cli "$@"

--- a/build_scripts/windows/scripts/az_msi.cmd
+++ b/build_scripts/windows/scripts/az_msi.cmd
@@ -5,7 +5,7 @@
 
 @IF EXIST "%~dp0\..\python.exe" (
   SET AZ_INSTALLER=MSI
-  "%~dp0\..\python.exe" -IBm azure.cli %*
+  "%~dp0\..\python.exe" -X utf8 -IBm azure.cli %*
 ) ELSE (
   echo Failed to load python executable.
   exit /b 1

--- a/build_scripts/windows/scripts/az_zip.cmd
+++ b/build_scripts/windows/scripts/az_zip.cmd
@@ -5,7 +5,7 @@
 
 @IF EXIST "%~dp0\..\python.exe" (
   SET AZ_INSTALLER=ZIP
-  "%~dp0\..\python.exe" -IBm azure.cli %*
+  "%~dp0\..\python.exe" -X utf8 -IBm azure.cli %*
 ) ELSE (
   echo Failed to load python executable.
   exit /b 1

--- a/build_scripts/windows/scripts/azps.ps1
+++ b/build_scripts/windows/scripts/azps.ps1
@@ -1,5 +1,5 @@
 $env:AZ_INSTALLER="MSI"
-& "$PSScriptRoot\..\python.exe" -IBm azure.cli $args
+& "$PSScriptRoot\..\python.exe" -X utf8 -IBm azure.cli $args
 
 # SIG # Begin signature block
 # MIInuQYJKoZIhvcNAQcCoIInqjCCJ6YCAQExDzANBglghkgBZQMEAgEFADB5Bgor


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary
- `az_msi.cmd` / `az_zip.cmd` invoke the bundled Python with `-I` (isolated mode), which drops `-E` behavior and ignores `PYTHONUTF8`/`PYTHONIOENCODING`.
- On Windows, when the legacy ANSI codepage isn't UTF-8 (e.g. Korean/Chinese locales), this causes non-ASCII CLI output to come out as mojibake or get silently discarded (`Unable to encode the output with cp949/cp1252 encoding. Unsupported characters are discarded.`).
- `-X utf8` (PEP 540) is an independent interpreter flag from `-I` — it only forces UTF-8 mode for stdio, and does not restore any of `-I`'s ignored env vars or site-packages behavior. Adding it keeps the isolation guarantees intact while fixing output encoding.

## Change
Two one-line edits:
```
-  "%~dp0\..\python.exe" -IBm azure.cli %*
+  "%~dp0\..\python.exe" -X utf8 -IBm azure.cli %*
```
in both `build_scripts/windows/scripts/az_msi.cmd` and `az_zip.cmd`.

## Verification
Reproduced locally against an installed 2.89.1 MSI build (`C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\az.cmd`):
- Before: `az repos pr show --id <id> --query title -o tsv` on a PR with a Korean title printed mojibake (`?? ??`-style output).
- After patching the launcher with `-X utf8`, the same command prints the title correctly.
- Confirmed isolation is unaffected: setting a bogus `PYTHONPATH` before/after the patch has no effect on CLI behavior in either case (env var still ignored).

Fixes #28497