### PR TITLE
{Packaging} Build wheels with `python -m build` instead of `python setup.py`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -577,7 +577,7 @@ jobs:
     displayName: 'Use Python $(python.version)'
     inputs:
       versionSpec: '$(python.version)'
-  - bash: pip install --upgrade pip wheel "setuptools<81"
+  - bash: pip install --upgrade pip wheel build "setuptools<81"
     displayName: 'Install pip and wheel'
   - bash: ./scripts/ci/test_profile_integration.sh
     displayName: 'Run Integration Test against Profiles'
@@ -598,7 +598,7 @@ jobs:
     displayName: 'Use Python $(python.version)'
     inputs:
       versionSpec: '$(python.version)'
-  - bash: pip install --upgrade pip wheel "setuptools<81"
+  - bash: pip install --upgrade pip wheel build "setuptools<81"
     displayName: 'Install pip and wheel setuptools'
   - bash: ./scripts/ci/test_extensions.sh
     displayName: 'Load extensions'

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -52,8 +52,11 @@ title 'Build Azure CLI and its command modules'
 for setup_file in $(find src -name 'setup.py'); do
     pushd $(dirname ${setup_file}) >/dev/null
     echo "Building module at $(pwd) ..."
-    python setup.py -q bdist_wheel -d $output_dir
-    python setup.py -q sdist -d $sdist_dir
+    # --no-isolation builds against the environment prepared by the caller rather than
+    # provisioning a fresh one, which keeps the caller's setuptools pin in force and
+    # avoids requiring outbound network access inside the packaging test containers.
+    python -m build --wheel --no-isolation --outdir $output_dir
+    python -m build --sdist --no-isolation --outdir $sdist_dir
     popd >/dev/null
 done
 
@@ -187,8 +190,8 @@ Azure CLI Test Cases
 EOL
 
 pushd $testsrc_dir >/dev/null
-python setup.py -q bdist_wheel -d $output_dir
-python setup.py -q sdist -d $sdist_dir
+python -m build --wheel --no-isolation --outdir $output_dir
+python -m build --sdist --no-isolation --outdir $sdist_dir
 popd >/dev/null
 
 ##############################################

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -49,6 +49,13 @@ title 'Determine version'
 ##############################################
 # build product packages
 title 'Build Azure CLI and its command modules'
+
+# This script builds through the PEP 517 frontend. It is invoked both directly and by
+# being sourced via scripts/ci/artifacts.sh, so the set of callers responsible for
+# provisioning the frontend is easy to miss. Install it here if it is absent rather
+# than failing partway through the build.
+python -c 'import build' 2>/dev/null || python -m pip install --disable-pip-version-check -q build
+
 for setup_file in $(find src -name 'setup.py'); do
     pushd $(dirname ${setup_file}) >/dev/null
     echo "Building module at $(pwd) ..."

--- a/scripts/release/debian/test_deb_in_docker.sh
+++ b/scripts/release/debian/test_deb_in_docker.sh
@@ -14,7 +14,8 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-/opt/az/bin/python3 -m pip install wheel
+# `build` is the PEP 517 frontend used by scripts/ci/build.sh.
+/opt/az/bin/python3 -m pip install wheel build
 ln -sf /opt/az/bin/python3 /usr/bin/python
 ./scripts/ci/build.sh
 

--- a/scripts/release/homebrew/test_homebrew_package.sh
+++ b/scripts/release/homebrew/test_homebrew_package.sh
@@ -20,7 +20,8 @@ AZ_BASE=/usr/local/Cellar/azure-cli/$CLI_VERSION/libexec
 export PATH=$AZ_BASE/bin:$PATH
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 echo $PATH
-pip install wheel
+# `build` is the PEP 517 frontend used by scripts/ci/build.sh.
+pip install wheel build
 ./scripts/ci/build.sh
 pip install pytest --prefix $AZ_BASE
 pip install pytest-xdist --prefix $AZ_BASE

--- a/scripts/release/rpm/test_azurelinux_in_docker.sh
+++ b/scripts/release/rpm/test_azurelinux_in_docker.sh
@@ -14,8 +14,10 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources); build.sh relies on setup.py.
-python -m pip install --upgrade "setuptools<81"
+# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources).
+# scripts/ci/build.sh builds with `python -m build --no-isolation`, so this pin is the setuptools the build uses.
+# `build` is the PEP 517 frontend that script invokes.
+python -m pip install --upgrade "setuptools<81" build
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -15,8 +15,10 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources); build.sh relies on setup.py.
-python -m pip install --upgrade pip "setuptools<81"
+# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources).
+# scripts/ci/build.sh builds with `python -m build --no-isolation`, so this pin is the setuptools the build uses.
+# `build` is the PEP 517 frontend that script invokes.
+python -m pip install --upgrade pip "setuptools<81" build
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->


`scripts/ci/build.sh` invoked `python setup.py bdist_wheel` / `sdist` directly. Setuptools 80+ deprecates running setup.py as a CLI and warns that these calls must be removed "to avoid build errors in the future", so drive the builds through the standard PEP 517 frontend instead.

Verified: wheels produced via `python -m build --wheel --no-isolation` are identical to the previous `setup.py bdist_wheel` output for all four distributions; same archive member list and same METADATA.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
