### PR TITLE
[Resource] `az deployment what-if`: Point users to Deployment Stacks What-If in the noise notice

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -110,7 +110,8 @@ def format_what_if_operation_result(
 def _format_noise_notice(builder):
     builder.append_line(
         """Note: The result may contain false positive predictions (noise).
-You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues"""
+You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
+NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA"""
     )
     builder.append_line()
 


### PR DESCRIPTION
### Related command

`az deployment group what-if`, `az deployment sub what-if`, `az deployment mg what-if`, `az deployment tenant what-if` (and the what-if preview shown by `--confirm-with-what-if` / `-c` on `az deployment ... create`).

### Description

What-if for Azure Deployment Stacks is now [generally available](https://aka.ms/stackswhatifGA) in all regions. Stacks What-if filters out noise by diffing against a baseline recorded when the stack was deployed, so it does not carry the false-positive caveat that template deployment what-if still has.

Today the very first thing a customer sees when they run template deployment what-if is a notice telling them the result may be wrong, and the only next step it offers is filing an issue. This PR replaces that call to action with the one that actually solves the problem for them: move to Stacks What-if.

### Exact verbiage added

```
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

### Exact verbiage removed

```
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
```

### Before

```
Note: The result may contain false positive predictions (noise).
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
```

### After

```
Note: The result may contain false positive predictions (noise).
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

`https://` is included on the link (the short link itself is `aka.ms/stackswhatifGA`) so terminals render it as a hyperlink.

### Scope / risk

- The only change is the string literal in `_format_noise_notice` in `src/azure-cli/azure/cli/command_modules/resource/_formatters.py`, which is reached solely through `format_what_if_operation_result` for **template deployment** what-if.
- Deployment Stacks what-if output is produced by `DeploymentStacksWhatIfResultFormatter` in `_stacks_formatters.py` and is deliberately **not** touched, so customers who already moved to stacks are not told to move to stacks.
- `https://aka.ms/WhatIfIssues` had no other references in `src/`, so nothing is left orphaned by its removal.
- No test asserts the notice text. `test_resource_changes_stats` asserts `result.endswith(...)` against the trailing resource-changes stats line, which is unaffected because the notice is emitted at the top of the output.
- The new line is 111 characters, within the 120-character limit configured in both `pylintrc` and `.flake8`.
