### PR TITLE
{Packaging} bump cryptography

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -100,7 +100,7 @@ certifi==2024.7.4
 cffi==2.0.0
 chardet==5.2.0
 colorama==0.4.6
-cryptography==46.0.7
+cryptography==48.0.1
 fabric==3.2.2
 humanfriendly==10.0
 idna==3.15
@@ -124,7 +124,7 @@ pycomposefile==0.0.34
 PyGithub==1.55
 PyJWT==2.13.0
 PyNaCl==1.6.2
-pyOpenSSL==26.0.0
+pyOpenSSL==26.2.0
 PySocks==1.7.1
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -100,7 +100,7 @@ certifi==2024.7.4
 cffi==2.0.0
 chardet==5.2.0
 colorama==0.4.6
-cryptography==46.0.7
+cryptography==48.0.1
 distro==1.6.0
 fabric==3.2.2
 humanfriendly==10.0
@@ -125,7 +125,7 @@ pycomposefile==0.0.34
 PyGithub==1.55
 PyJWT==2.13.0
 PyNaCl==1.6.2
-pyOpenSSL==26.0.0
+pyOpenSSL==26.2.0
 PySocks==1.7.1
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -100,7 +100,7 @@ certifi==2024.7.4
 cffi==2.0.0
 chardet==5.2.0
 colorama==0.4.6
-cryptography==46.0.7
+cryptography==48.0.1
 fabric==3.2.2
 humanfriendly==10.0
 idna==3.15
@@ -125,7 +125,7 @@ PyGithub==1.55
 PyJWT==2.13.0
 pymsalruntime==0.20.6
 PyNaCl==1.6.2
-pyOpenSSL==26.0.0
+pyOpenSSL==26.2.0
 PySocks==1.7.1
 python-dateutil==2.8.0
 pywin32==311


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

The bundled-build requirements pin cryptography==46.0.7 in all three platform files (src/azure-cli/requirements.py3.{Linux,Darwin,windows}.txt). That version is affected by [GHSA-537c-gmf6-5ccf](https://github.com/advisories/GHSA-537c-gmf6-5ccf) — "Vulnerable OpenSSL included in cryptography wheels" (CVSS 7.5, AV:N/AC:L/PR:N/UI:N/…/A:H). Per OSV the fix is cryptography 48.0.1.

cryptography → ≥ 48.0.1 (fixed), and
pyOpenSSL → a version that permits it — 26.2.0

Expected behavior
Bundled azure-cli ships cryptography ≥ 48.0.1 (with a compatible pyOpenSSL), clearing https://github.com/advisories/GHSA-537c-gmf6-5ccf.