### PR TITLE
[Resource] Point what-if noise notice to Deployment Stacks What-if with reduced noise

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -110,7 +110,6 @@ def format_what_if_operation_result(
 def _format_noise_notice(builder):
     builder.append_line(
         """Note: The result may contain false positive predictions (noise).
-You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
 NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA"""
     )
     builder.append_line()

--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -110,7 +110,7 @@ def format_what_if_operation_result(
 def _format_noise_notice(builder):
     builder.append_line(
         """Note: The result may contain false positive predictions (noise).
-NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA"""
+NOTICE! - Want to get What-if with reduced noise? Move to Deployment Stacks What-if https://aka.ms/stackswhatifGA"""
     )
     builder.append_line()
 


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command

`az deployment group what-if`, `az deployment sub what-if`, `az deployment mg what-if`, `az deployment tenant what-if` (and the what-if preview shown by `--confirm-with-what-if` / `-c` on `az deployment ... create`).

### Description

Follow-up to #33943, which added a line pointing template deployment what-if users to [Deployment Stacks What-if](https://aka.ms/stackswhatifGA) now that it is generally available.

This PR does two things:

1. Removes the older call to action, so the notice states the caveat and then gives a single next step that actually resolves it.
2. Corrects the new line to say **reduced noise** rather than *without noise*, and uses consistent `What-if` capitalization for both occurrences.

"Reduced noise" is the accurate claim: Stacks What-if filters noise against a baseline recorded when the stack was deployed, which substantially reduces false positives rather than eliminating them outright.

### Before

```
Note: The result may contain false positive predictions (noise).
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

### After

```
Note: The result may contain false positive predictions (noise).
NOTICE! - Want to get What-if with reduced noise? Move to Deployment Stacks What-if https://aka.ms/stackswhatifGA
```

### Scope / risk

- The only change is the string literal in `_format_noise_notice` in `src/azure-cli/azure/cli/command_modules/resource/_formatters.py`, reached solely through `format_what_if_operation_result` for **template deployment** what-if.
- Deployment Stacks what-if output is produced by `DeploymentStacksWhatIfResultFormatter` in `_stacks_formatters.py` and is not touched.
- After this change `https://aka.ms/WhatIfIssues` has no remaining references under `src/`, so nothing is left orphaned.
- No test asserts the notice text. `test_resource_changes_stats` asserts `result.endswith(...)` against the trailing resource-changes stats line, which is unaffected because the notice is emitted at the top of the output.
- The notice line is 116 characters in source, within the 120-character limit configured in both `pylintrc` and `.flake8`.
- The final string is byte-identical to the one used by the corresponding Azure PowerShell change (Azure/azure-powershell#30048).
