### PR TITLE
[Core] Remove AzureGermanCloud from built-in cloud list

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -354,7 +354,6 @@ class CloudNameEnum:  # pylint: disable=too-few-public-methods
     AzureCloud = 'AzureCloud'
     AzureChinaCloud = 'AzureChinaCloud'
     AzureUSGovernment = 'AzureUSGovernment'
-    AzureGermanCloud = 'AzureGermanCloud'
     AzureBleuCloud = 'AzureBleuCloud'
 
 
@@ -465,31 +464,6 @@ AZURE_US_GOV_CLOUD = Cloud(
         acr_login_server_endpoint='.azurecr.us',
         synapse_analytics_endpoint='.dev.azuresynapse.usgovcloudapi.net'))
 
-AZURE_GERMAN_CLOUD = Cloud(
-    CloudNameEnum.AzureGermanCloud,
-    endpoints=CloudEndpoints(
-        management='https://management.core.cloudapi.de/',
-        resource_manager='https://management.microsoftazure.de',
-        sql_management='https://management.core.cloudapi.de:8443/',
-        batch_resource_id='https://batch.cloudapi.de/',
-        gallery='https://gallery.cloudapi.de/',
-        active_directory='https://login.microsoftonline.de',
-        active_directory_resource_id='https://management.core.cloudapi.de/',
-        active_directory_graph_resource_id='https://graph.cloudapi.de/',
-        microsoft_graph_resource_id='https://graph.microsoft.de',
-        vm_image_alias_doc='https://azcliprod.blob.core.windows.net/cli/vm/aliases.json',
-        media_resource_id='https://rest.media.cloudapi.de',
-        ossrdbms_resource_id='https://ossrdbms-aad.database.cloudapi.de',
-        portal='https://portal.microsoftazure.de'),
-    suffixes=CloudSuffixes(
-        storage_endpoint='core.cloudapi.de',
-        keyvault_dns='.vault.microsoftazure.de',
-        mhsm_dns='.managedhsm.microsoftazure.de',
-        sql_server_hostname='.database.cloudapi.de',
-        mysql_server_endpoint='.mysql.database.cloudapi.de',
-        postgresql_server_endpoint='.postgres.database.cloudapi.de',
-        mariadb_server_endpoint='.mariadb.database.cloudapi.de'))
-
 AZURE_BLEU_CLOUD = Cloud(
     CloudNameEnum.AzureBleuCloud,
     endpoints=CloudEndpoints(
@@ -519,7 +493,7 @@ AZURE_BLEU_CLOUD = Cloud(
         mariadb_server_endpoint='.mariadb.database.sovcloud-api.fr',
         synapse_analytics_endpoint='.dev.azuresynapse.sovcloud-api.fr'))
 
-HARD_CODED_CLOUD_LIST = [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_GERMAN_CLOUD, AZURE_BLEU_CLOUD]
+HARD_CODED_CLOUD_LIST = [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_BLEU_CLOUD]
 
 
 def retrieve_arm_cloud_metadata():

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -223,8 +223,8 @@ class TestCloud(unittest.TestCase):
     @mock.patch('azure.cli.core.cloud._set_active_subscription', autospec=True)
     def test_switch_active_cloud(self, subscription_setter):
         cli = mock.MagicMock()
-        switch_active_cloud(cli, 'AzureGermanCloud')
-        self.assertEqual(cli.cloud.name, 'AzureGermanCloud')
+        switch_active_cloud(cli, 'AzureUSGovernment')
+        self.assertEqual(cli.cloud.name, 'AzureUSGovernment')
 
         switch_active_cloud(cli, 'AzureChinaCloud')
         self.assertEqual(cli.cloud.name, 'AzureChinaCloud')

--- a/src/azure-cli/azure/cli/command_modules/acr/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_validators.py
@@ -123,7 +123,7 @@ def validate_registry_name(cmd, namespace):
     if registry_login_server_suffix == '' and dnl_hash_index != -1:
         raise InvalidArgumentValueError(BAD_REGISTRY_NAME)
 
-    # Some clouds do not define 'acr_login_server_endpoint' (e.g. AzureGermanCloud)
+    # Some clouds do not define 'acr_login_server_endpoint'
     if hasattr(suffixes, 'acr_login_server_endpoint'):
         acr_suffix = suffixes.acr_login_server_endpoint
         if registry_login_server_suffix.lower() == acr_suffix and registry_login_server_suffix != '':

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -783,7 +783,7 @@ def validate_registry_name(cmd, namespace):
     """Append login server endpoint suffix."""
     registry = namespace.acr
     suffixes = cmd.cli_ctx.cloud.suffixes
-    # Some clouds do not define 'acr_login_server_endpoint' (e.g. AzureGermanCloud)
+    # Some clouds do not define 'acr_login_server_endpoint'
     from azure.cli.core.cloud import CloudSuffixNotSetException
     try:
         acr_suffix = suffixes.acr_login_server_endpoint

--- a/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
@@ -38,11 +38,6 @@ class CloudTests(ScenarioTest):
         self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
 
     @serial_test()
-    def test_cloud_set_AzureGermanCloud(self):
-        self.cmd('az cloud set -n AzureGermanCloud')
-        self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
-
-    @serial_test()
     def test_cloud_set_AzureBleuCloud(self):
         self.cmd('az cloud set -n AzureBleuCloud')
         self.cmd('az cloud show -n AzureBleuCloud', checks=[self.check('isActive', True)])
@@ -61,11 +56,6 @@ class CloudTests(ScenarioTest):
     def test_cloud_set_azureusgovernment(self):
         self.cmd('az cloud set -n azureusgovernment')
         self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
-
-    @serial_test()
-    def test_cloud_set_azuregermancloud(self):
-        self.cmd('az cloud set -n azuregermancloud')
-        self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
 
     @serial_test()
     def test_cloud_set_azurebleucloud(self):

--- a/src/azure-cli/azure/cli/command_modules/postgresql/config.json
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/config.json
@@ -5,8 +5,6 @@
     },
     "AzureUSGovernment": {
     },
-    "AzureGermanCloud": {
-    },
     "Stage": {
     }
 }

--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -5,8 +5,6 @@
     },
     "AzureUSGovernment": {
     },
-    "AzureGermanCloud": {
-    },
     "Stage": {
     }
 }


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Tests |
| :--: |
| ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->



### Description

The Azure German cloud (Microsoft Cloud Germany) was [decommissioned](https://news.microsoft.com/europe/2020/09/30/our-commitment-to-delivering-the-microsoft-cloud-in-germany/). Its built-in `AzureGermanCloud` entry in the Azure CLI is no longer usable and can be confused with other sovereign clouds. This PR removes it.

PS equivalent: https://github.com/Azure/azure-powershell-common/pull/353

Changes:
- Remove the `AzureGermanCloud` enum entry, the `AZURE_GERMAN_CLOUD` definition, and its entry in `HARD_CODED_CLOUD_LIST` in `azure-cli-core`.
- Remove the empty `AzureGermanCloud` stubs from `rdbms` and `postgresql` `config.json`.
- Remove the German-cloud scenario tests and update `test_switch_active_cloud`.
- Update stale comments in `acr`/`acs` validators that referenced `AzureGermanCloud`.

### Testing Guide

- `azure-cli-core` `test_cloud.py`: 14 passed, 1 skipped
- `cloud` module `test_cloud.py`: 12 passed

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description follow the [format](https://github.com/Azure/azure-cli/blob/dev/doc/authoring_command_modules/README.md#format-pr-title).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).