### PR TITLE
{Core} Add url normalization in client-side pagination

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
@@ -767,7 +767,9 @@ class AAZPaginationTokenArgFormat(AAZBaseArgFormat):
             # `next_link` is a URL that the next page request is sent to with an Azure access token.
             # Validate it shares the same origin as a trusted endpoint of the active cloud to prevent
             # the token from being sent to an attacker-controlled host such as
-            # `https://management.azure.com.attacker`.
+            # `https://management.azure.com.attacker`. URLs that are not normalized, such as
+            # `https://management.azure.com//attacker.example/leak`, are rejected as well, since they
+            # may be resolved to a different host by a downstream parser, proxy or server.
             if next_link is not None:
                 from azure.cli.core.util import is_trusted_cloud_endpoint
                 if not is_trusted_cloud_endpoint(next_link, ctx.cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -440,6 +440,51 @@ class TestUtils(unittest.TestCase):
         self.assertFalse(is_same_origin('', endpoint))
         self.assertFalse(is_same_origin('https://management.azure.com/path', 'not a url'))
 
+    def test_normalize_url(self):
+        from azure.cli.core.util import normalize_url
+
+        # Already normalized URLs are unchanged
+        for url in ['https://management.azure.com/',
+                    'https://management.azure.com/subscriptions/01/resourceGroups/rg?api-version=2021-04-01']:
+            self.assertEqual(normalize_url(url), url)
+
+        # Empty path is normalized to '/'
+        self.assertEqual(normalize_url('https://management.azure.com'), 'https://management.azure.com/')
+        # Scheme and host are lowercased
+        self.assertEqual(normalize_url('HTTPS://Management.Azure.COM/Path'), 'https://management.azure.com/Path')
+        # Empty segments are collapsed, so the path can't be read as a protocol-relative URL
+        self.assertEqual(normalize_url('https://management.azure.com//attacker.example/leak'),
+                         'https://management.azure.com/attacker.example/leak')
+        # Dot segments are removed
+        self.assertEqual(normalize_url('https://management.azure.com/a/b/../c'),
+                         'https://management.azure.com/a/c')
+        self.assertEqual(normalize_url('https://management.azure.com/../..//attacker.example/leak'),
+                         'https://management.azure.com/attacker.example/leak')
+        # Backslashes in the authority belong to the path, like in WHATWG URL parsers
+        self.assertEqual(normalize_url('https://management.azure.com\\@attacker.example/leak'),
+                         'https://management.azure.com/@attacker.example/leak')
+        # Control characters are stripped
+        self.assertEqual(normalize_url('https://management.azure.com\t\r\n/path'),
+                         'https://management.azure.com/path')
+        # Query and fragment are preserved
+        self.assertEqual(normalize_url('https://management.azure.com/a//b?x=1//2#f//g'),
+                         'https://management.azure.com/a/b?x=1//2#f//g')
+
+    def test_is_trusted_cloud_endpoint(self):
+        from azure.cli.core.util import is_trusted_cloud_endpoint
+        from azure.cli.core.mock import DummyCli
+
+        cli_ctx = DummyCli()
+
+        self.assertTrue(is_trusted_cloud_endpoint(
+            'https://management.azure.com/subscriptions/01?api-version=2025-09-01', cli_ctx))
+        # Not a trusted host
+        self.assertFalse(is_trusted_cloud_endpoint('https://management.azure.com.attacker/path', cli_ctx))
+        # Not normalized: the path may be re-interpreted as an authority downstream
+        self.assertFalse(is_trusted_cloud_endpoint('https://management.azure.com//attacker.example/leak', cli_ctx))
+        self.assertFalse(is_trusted_cloud_endpoint('https://management.azure.com/../..//attacker.example', cli_ctx))
+        self.assertFalse(is_trusted_cloud_endpoint(None, cli_ctx))
+
     @mock.patch("psutil.Process")
     def test_get_parent_proc_name(self, mock_process_type):
         process = mock_process_type.return_value

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1086,7 +1086,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     if 'Authorization' in prepped.headers and not is_same_origin(prepped.url, url):
         from .azclierror import InvalidArgumentValueError
         raise InvalidArgumentValueError(
-            "The request URL '{}' doesn't match the validated URL '{}'.".format(prepped.url, url))
+            "The prepared request URL '{}' does not share the same origin as the validated URL '{}'.".format(prepped.url, url))
 
     # Merge environment settings into session
     settings = s.merge_environment_settings(prepped.url, {}, None, not should_disable_connection_verify(), None)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1257,8 +1257,8 @@ def normalize_url(url):
       ``https://management.azure.com/attacker.example/leak``.
 
     :param url: The URL to normalize.
-    :return: The normalized URL, or the input unchanged if it is not a parsable string.
-    :rtype: str
+    :return: The normalized URL. If ``url`` is not a string, it is returned unchanged. If parsing fails, the cleaned (control/whitespace-stripped) input is returned.
+    :rtype: str or object
     """
     from urllib.parse import urlsplit, urlunsplit
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1028,7 +1028,13 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     # default to Azure Resource Manager.
     # https://management.azure.com + /subscriptions/xxx/resourcegroups/xxx?api-version=2019-07-01
     if '://' not in url:
-        url = endpoints.resource_manager.rstrip('/') + url
+        # lstrip('/') prevents a protocol-relative path like '//attacker.example/leak' from
+        # producing 'https://management.azure.com//attacker.example/leak'.
+        url = endpoints.resource_manager.rstrip('/') + '/' + url.lstrip('/')
+
+    # Normalize before validating and before sending, so that the URL whose origin is validated is
+    # exactly the URL the request is sent to.
+    url = normalize_url(url)
 
     # Replace common tokens with real values. It is for smooth experience if users copy and paste the url from
     # Azure Rest API doc
@@ -1074,6 +1080,13 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     s = Session()
     req = Request(method=method, url=url, headers=headers, params=uri_parameters, data=body)
     prepped = s.prepare_request(req)
+
+    # Final defense: make sure requests didn't resolve the URL to a different origin than the one
+    # whose origin was validated above before an access token was attached.
+    if 'Authorization' in prepped.headers and not is_same_origin(prepped.url, url):
+        from .azclierror import InvalidArgumentValueError
+        raise InvalidArgumentValueError(
+            "The request URL '{}' doesn't match the validated URL '{}'.".format(prepped.url, url))
 
     # Merge environment settings into session
     settings = s.merge_environment_settings(prepped.url, {}, None, not should_disable_connection_verify(), None)
@@ -1202,6 +1215,88 @@ def urlretrieve(url):
     return req.read()
 
 
+def _remove_dot_segments(path):
+    """Remove ``.`` and ``..`` segments from a URL path (RFC 3986 section 5.2.4) and collapse
+    empty segments, so that ``/a/b/../c`` becomes ``/a/c`` and ``//attacker.example/leak``
+    becomes ``/attacker.example/leak``.
+    """
+    leading_slash = path.startswith('/')
+    trailing_slash = path.endswith('/')
+    segments = []
+    for segment in path.split('/'):
+        # Empty segments are dropped so that a path can never be re-interpreted as an authority
+        # (protocol-relative URL) by a downstream parser, proxy or gateway.
+        if segment in ('', '.'):
+            continue
+        if segment == '..':
+            if segments:
+                segments.pop()
+            continue
+        segments.append(segment)
+    new_path = '/'.join(segments)
+    if leading_slash:
+        new_path = '/' + new_path
+    if trailing_slash and not new_path.endswith('/'):
+        new_path += '/'
+    return new_path
+
+
+def normalize_url(url):
+    """Normalize a URL so that it is parsed the same way by the CLI and by any downstream
+    consumer (requests/urllib3, proxies, gateways, servers).
+
+    Validating a URL that is not normalized is unsafe, because the validator and the consumer
+    may disagree on which host the request is actually sent to. This function:
+
+    - removes whitespace and control characters, which are silently stripped by many URL parsers;
+    - lowercases the scheme and the host;
+    - converts backslashes in the authority to ``/`` (WHATWG URL parsers treat ``\\`` as ``/``),
+      moving anything after them into the path;
+    - removes ``.``/``..`` segments and collapses empty segments in the path, so that
+      ``https://management.azure.com//attacker.example/leak`` is normalized to
+      ``https://management.azure.com/attacker.example/leak``.
+
+    :param url: The URL to normalize.
+    :return: The normalized URL, or the input unchanged if it is not a parsable string.
+    :rtype: str
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    if not isinstance(url, str):
+        return url
+
+    # Strip whitespace and C0/DEL control characters. Browsers and urllib strip some of them
+    # (\t, \r, \n), so a validator must not consider them part of the host.
+    cleaned = ''.join(c for c in url if ord(c) > 0x20 and ord(c) != 0x7f).strip()
+
+    try:
+        parts = urlsplit(cleaned)
+    except ValueError:
+        return cleaned
+
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc
+    path = parts.path
+
+    if netloc:
+        # `urlsplit` doesn't treat '\' as a delimiter, but WHATWG parsers do. Anything after it
+        # belongs to the path, not to the authority.
+        netloc = netloc.replace('\\', '/')
+        if '/' in netloc:
+            netloc, _, rest = netloc.partition('/')
+            path = '/' + rest + path
+        # The host is case-insensitive, but userinfo isn't, so only lowercase the host part.
+        userinfo, sep, hostport = netloc.rpartition('@')
+        netloc = userinfo + sep + hostport.lower()
+
+    if path:
+        path = _remove_dot_segments(path)
+    elif netloc:
+        path = '/'
+
+    return urlunsplit((scheme, netloc, path, parts.query, parts.fragment))
+
+
 def is_same_origin(url, endpoint):
     """Check whether ``url`` and ``endpoint`` share the same origin (scheme + host + port).
 
@@ -1210,6 +1305,9 @@ def is_same_origin(url, endpoint):
     the trusted endpoint ``https://management.azure.com``. It is intended for validating that a
     URL points to a trusted endpoint before sensitive data (e.g., an Azure access token) is sent
     to it.
+
+    The URLs are normalized with :func:`normalize_url` first, so that tricks relying on control
+    characters or backslashes in the authority can't hide the real host.
 
     :param url: The URL to validate, e.g., ``https://management.azure.com/subscriptions/...``.
     :param endpoint: The trusted endpoint to validate against, e.g., ``https://management.azure.com/``.
@@ -1222,8 +1320,8 @@ def is_same_origin(url, endpoint):
         return False
 
     try:
-        url_parts = urlparse(url)
-        endpoint_parts = urlparse(endpoint)
+        url_parts = urlparse(normalize_url(url))
+        endpoint_parts = urlparse(normalize_url(endpoint))
 
     except (TypeError, ValueError):
         return False
@@ -1280,11 +1378,19 @@ def match_cloud_endpoint(url, cli_ctx):
 def is_trusted_cloud_endpoint(url, cli_ctx):
     """Check whether ``url`` shares the same origin as any endpoint of the active cloud.
 
+    The URL must already be in normalized form (see :func:`normalize_url`). A URL that is not
+    normalized is rejected, because the CLI and the downstream consumer (requests, a proxy or the
+    server) may not resolve it to the same host, e.g.
+    ``https://management.azure.com//attacker.example/leak``, whose path can be re-interpreted as
+    a protocol-relative URL.
+
     :param url: The URL to validate, e.g., ``https://management.azure.com/subscriptions/...``.
     :param cli_ctx: The CLI context whose active cloud's endpoints are treated as trusted.
     :return: ``True`` if ``url`` shares the same origin as any cloud endpoint, otherwise ``False``.
     :rtype: bool
     """
+    if not isinstance(url, str) or normalize_url(url) != url:
+        return False
     return match_cloud_endpoint(url, cli_ctx) is not None
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`is_same_origin` — normalizes both inputs before parsing.
Added test_normalize_url and test_is_trusted_cloud_endpoint in tests/test_util.py.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
