### PR TITLE
{Misc} Clean up AzureGermanCloud references in command modules

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_validators.py
@@ -123,7 +123,7 @@ def validate_registry_name(cmd, namespace):
     if registry_login_server_suffix == '' and dnl_hash_index != -1:
         raise InvalidArgumentValueError(BAD_REGISTRY_NAME)
 
-    # Some clouds do not define 'acr_login_server_endpoint' (e.g. AzureGermanCloud)
+    # Some clouds do not define 'acr_login_server_endpoint'
     if hasattr(suffixes, 'acr_login_server_endpoint'):
         acr_suffix = suffixes.acr_login_server_endpoint
         if registry_login_server_suffix.lower() == acr_suffix and registry_login_server_suffix != '':

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -783,7 +783,7 @@ def validate_registry_name(cmd, namespace):
     """Append login server endpoint suffix."""
     registry = namespace.acr
     suffixes = cmd.cli_ctx.cloud.suffixes
-    # Some clouds do not define 'acr_login_server_endpoint' (e.g. AzureGermanCloud)
+    # Some clouds do not define 'acr_login_server_endpoint'
     from azure.cli.core.cloud import CloudSuffixNotSetException
     try:
         acr_suffix = suffixes.acr_login_server_endpoint

--- a/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
@@ -38,11 +38,6 @@ class CloudTests(ScenarioTest):
         self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
 
     @serial_test()
-    def test_cloud_set_AzureGermanCloud(self):
-        self.cmd('az cloud set -n AzureGermanCloud')
-        self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
-
-    @serial_test()
     def test_cloud_set_AzureBleuCloud(self):
         self.cmd('az cloud set -n AzureBleuCloud')
         self.cmd('az cloud show -n AzureBleuCloud', checks=[self.check('isActive', True)])
@@ -61,11 +56,6 @@ class CloudTests(ScenarioTest):
     def test_cloud_set_azureusgovernment(self):
         self.cmd('az cloud set -n azureusgovernment')
         self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
-
-    @serial_test()
-    def test_cloud_set_azuregermancloud(self):
-        self.cmd('az cloud set -n azuregermancloud')
-        self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
 
     @serial_test()
     def test_cloud_set_azurebleucloud(self):

--- a/src/azure-cli/azure/cli/command_modules/postgresql/config.json
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/config.json
@@ -5,8 +5,6 @@
     },
     "AzureUSGovernment": {
     },
-    "AzureGermanCloud": {
-    },
     "Stage": {
     }
 }

--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -5,8 +5,6 @@
     },
     "AzureUSGovernment": {
     },
-    "AzureGermanCloud": {
-    },
     "Stage": {
     }
 }


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Description

Follow-up to the removal of the decommissioned `AzureGermanCloud` from `azure-cli-core`. This PR removes the corresponding references in command modules.

Changes:
- Remove the empty `AzureGermanCloud` config stubs from `rdbms` and `postgresql` `config.json`. These were empty placeholders; the sole consumer (`get_cloud_cluster`) already falls back gracefully via a caught `KeyError`, and clouds absent from these files (e.g. `AzureBleuCloud`) work via the service-based DNS-suffix lookup.
- Remove the `AzureGermanCloud` scenario tests from the `cloud` module.
- Update stale comments in the `acr`/`acs` validators that referenced `AzureGermanCloud`.

> **Note:** This is one of two PRs splitting the original #33956. The companion PR removes `AzureGermanCloud` from `azure-cli-core`. **That Core PR should merge first.**

### Testing Guide

- `cloud` module `test_cloud.py`: 12 passed

---

- [x] The PR title and description follow the [format](https://github.com/Azure/azure-cli/blob/dev/doc/authoring_command_modules/README.md#format-pr-title).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).