### PR TITLE
[Core] Validate Agent Assist fork-to-upstream PR flow

### DIFF
--- a/.github/agent-assist-fork-flow-test.md
+++ b/.github/agent-assist-fork-flow-test.md
@@ -1,0 +1,3 @@
+# Agent Assist fork flow test
+
+This temporary file validates that Copilot can create work in a user fork before Agent Assist promotes the branch to an upstream draft pull request.


### PR DESCRIPTION
## Disposable Agent Assist validation

This draft pull request validates that Agent Assist can promote a Copilot-created branch from the `a0x1ab/azure-cli` fork into an upstream `Azure/azure-cli` pull request.

- Copilot task: https://github.com/a0x1ab/azure-cli/tasks/840f4240-2adf-4e3c-889d-e7bceae11e5c
- Fork PR: https://github.com/a0x1ab/azure-cli/pull/2
- Expected change: only `.github/agent-assist-fork-flow-test.md`
- Product impact: none; this PR will be closed after topology and CI-routing validation.

No generated files or customer-facing behavior are changed. No release note is required.