### PR TITLE
[Core] Fix #33282: `az`: Support Ubuntu 26.04 LTS (resolute) in deb install script

### DIFF
--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -60,10 +60,21 @@ setup() {
         CLI_REPO=$(lsb_release -cs)
         shopt -s nocasematch
         ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -sL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
-        if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
+        AZURE_CLI_DISTS=$(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/)
+        if [[ ! $AZURE_CLI_DISTS =~ $CLI_REPO ]]; then
             DIST=$(lsb_release -is)
             if [[ $DIST =~ "Ubuntu" ]]; then
-                CLI_REPO="jammy"
+                # Try supported Ubuntu LTS codenames newest-first
+                for lts_codename in noble jammy focal; do
+                    if [[ $AZURE_CLI_DISTS =~ $lts_codename ]]; then
+                        CLI_REPO="$lts_codename"
+                        break
+                    fi
+                done
+                if [[ -z $CLI_REPO ]]; then
+                    echo "$ERROR_MSG"
+                    exit 1
+                fi
             elif [[ $DIST =~ "Debian" ]]; then
                 CLI_REPO="bookworm"
             elif [[ $DIST =~ "LinuxMint" ]]; then

--- a/scripts/release/debian/test_deb_install.sh
+++ b/scripts/release/debian/test_deb_install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-base_images=("ubuntu:xenial" "ubuntu:bionic" "debian:stretch" "debian:jessie" "debian:buster")
+base_images=("ubuntu:xenial" "ubuntu:bionic" "ubuntu:noble" "debian:stretch" "debian:jessie" "debian:buster")
 
 set -e
 


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description
Fixes https://github.com/Azure/azure-cli/issues/33282.

`deb_install.sh` hardcoded `CLI_REPO="jammy"` as the Ubuntu fallback, so Ubuntu 26.04 (resolute) — and any future Ubuntu release without its own package suite — silently installed from a 22.04 repo instead of the most recent supported LTS.

**Changes**

- **`scripts/release/debian/deb_install.sh`**
  - Cache the `curl` response from `packages.microsoft.com/repos/azure-cli/dists/` once into `AZURE_CLI_DISTS` (avoids redundant network calls)
  - Replace hardcoded `CLI_REPO="jammy"` with a loop over `noble jammy focal` (newest-first); picks the first codename present in the repo; exits with the existing error if none match

  ```bash
  # Before
  if [[ $DIST =~ "Ubuntu" ]]; then
      CLI_REPO="jammy"

  # After
  if [[ $DIST =~ "Ubuntu" ]]; then
      for lts_codename in noble jammy focal; do
          if [[ $AZURE_CLI_DISTS =~ $lts_codename ]]; then
              CLI_REPO="$lts_codename"
              break
          fi
      done
      if [[ -z $CLI_REPO ]]; then
          echo "$ERROR_MSG"
          exit 1
      fi
  ```

- **`scripts/release/debian/test_deb_install.sh`**
  - Added `ubuntu:noble` to the `base_images` test array

**Testing Guide**

Run `deb_install.sh` on an Ubuntu 26.04 host (or simulate by setting `lsb_release -cs` to return an unknown codename on an Ubuntu distro). The script should resolve to `noble` (or `jammy`/`focal` if `noble` is absent from the repo) rather than silently using `jammy`.

**History Notes**

[Core] `az`: Support Ubuntu 26.04 LTS (resolute) in deb install script — fall back to newest available LTS instead of hardcoded `jammy`