### PR TITLE
[Network] Fix #33981: `az network application-gateway show`: Bump parent Application Gateway API version to 2025-07-01 so Managed HSM SSL certificate fields are preserved

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_create.py
@@ -16,9 +16,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-10-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2024-10-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -1651,7 +1651,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -3268,6 +3268,7 @@ class Create(AAZCommand):
 
             properties = cls._schema_on_200_201.properties.ssl_certificates.Element.properties
             properties.data = AAZStrType()
+            properties.hsm = AAZObjectType()
             properties.key_vault_secret_id = AAZStrType(
                 serialized_name="keyVaultSecretId",
             )
@@ -3279,6 +3280,14 @@ class Create(AAZCommand):
             properties.public_cert_data = AAZStrType(
                 serialized_name="publicCertData",
                 flags={"read_only": True},
+            )
+
+            hsm = cls._schema_on_200_201.properties.ssl_certificates.Element.properties.hsm
+            hsm.key_id = AAZStrType(
+                serialized_name="keyId",
+            )
+            hsm.public_cert_data = AAZStrType(
+                serialized_name="publicCertData",
             )
 
             ssl_profiles = cls._schema_on_200_201.properties.ssl_profiles

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_show.py
@@ -19,9 +19,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-10-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2024-10-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -117,7 +117,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -1062,6 +1062,7 @@ class Show(AAZCommand):
 
             properties = cls._schema_on_200.properties.ssl_certificates.Element.properties
             properties.data = AAZStrType()
+            properties.hsm = AAZObjectType()
             properties.key_vault_secret_id = AAZStrType(
                 serialized_name="keyVaultSecretId",
             )
@@ -1073,6 +1074,14 @@ class Show(AAZCommand):
             properties.public_cert_data = AAZStrType(
                 serialized_name="publicCertData",
                 flags={"read_only": True},
+            )
+
+            hsm = cls._schema_on_200.properties.ssl_certificates.Element.properties.hsm
+            hsm.key_id = AAZStrType(
+                serialized_name="keyId",
+            )
+            hsm.public_cert_data = AAZStrType(
+                serialized_name="publicCertData",
             )
 
             ssl_profiles = cls._schema_on_200.properties.ssl_profiles

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_update.py
@@ -19,9 +19,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-10-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2024-10-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -452,7 +452,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -551,7 +551,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -1864,6 +1864,7 @@ class _UpdateHelper:
 
         properties = _schema_application_gateway_read.properties.ssl_certificates.Element.properties
         properties.data = AAZStrType()
+        properties.hsm = AAZObjectType()
         properties.key_vault_secret_id = AAZStrType(
             serialized_name="keyVaultSecretId",
         )
@@ -1875,6 +1876,14 @@ class _UpdateHelper:
         properties.public_cert_data = AAZStrType(
             serialized_name="publicCertData",
             flags={"read_only": True},
+        )
+
+        hsm = _schema_application_gateway_read.properties.ssl_certificates.Element.properties.hsm
+        hsm.key_id = AAZStrType(
+            serialized_name="keyId",
+        )
+        hsm.public_cert_data = AAZStrType(
+            serialized_name="publicCertData",
         )
 
         ssl_profiles = _schema_application_gateway_read.properties.ssl_profiles

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
@@ -125,5 +125,51 @@ class TestVpnConnectionCertAuthNoSharedKey(unittest.TestCase):
         self.assertIn('--shared-key is required', str(ctx.exception))
 
 
+    def test_application_gateway_parent_api_version(self):
+        """Parent application-gateway operations must use API version 2025-07-01 so that
+        Managed HSM SSL certificate fields (hsm.keyId / hsm.publicCertData) are preserved."""
+        from azure.cli.command_modules.network.aaz.latest.network.application_gateway import _show, _create, _update
+
+        for module, name in [(_show, "Show"), (_create, "Create"), (_update, "Update")]:
+            cls = getattr(module, name)
+            self.assertEqual(
+                cls._aaz_info["version"],
+                "2025-07-01",
+                msg=f"application-gateway {name}._aaz_info['version'] must be 2025-07-01",
+            )
+            for resource in cls._aaz_info["resources"]:
+                self.assertEqual(
+                    resource[-1],
+                    "2025-07-01",
+                    msg=f"application-gateway {name} resources entry must reference 2025-07-01",
+                )
+
+    def test_application_gateway_show_ssl_cert_hsm_schema(self):
+        """The parent application-gateway show response schema must include the
+        sslCertificates[].properties.hsm object with keyId and publicCertData."""
+        from azure.cli.command_modules.network.aaz.latest.network.application_gateway._show import Show
+
+        inner_cls = Show.ApplicationGatewaysGet
+        inner_cls._build_schema_on_200()
+        ssl_cert_props = inner_cls._schema_on_200.properties.ssl_certificates.Element.properties
+        fields = ssl_cert_props._fields
+        self.assertIn(
+            "hsm",
+            fields,
+            "ssl_certificates.Element.properties must contain 'hsm'",
+        )
+        hsm_fields = fields["hsm"]._fields
+        self.assertIn(
+            "key_id",
+            hsm_fields,
+            "ssl_certificates.Element.properties.hsm must contain 'key_id'",
+        )
+        self.assertIn(
+            "public_cert_data",
+            hsm_fields,
+            "ssl_certificates.Element.properties.hsm must contain 'public_cert_data'",
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ❌ 126/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Failed" summary="126/130" -->
<details>
<summary>❌AzureCLI-FullTest</summary>

><details>
> <summary>️✔️acr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️acs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️advisor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️ams</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️apim</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appconfig</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️aro</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️backup</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batch</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batchai</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️billing</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️botservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cloud</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cognitiveservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️compute_recommender</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️computefleet</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️config</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️configure</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️consumption</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️container</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️containerapp</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️core</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cosmosdb</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️databoxedge</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dls</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventgrid</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventhubs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️feedback</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️find</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️hdinsight</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️identity</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️iot</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️keyvault</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️lab</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️managedservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️maps</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️marketplaceordering</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>❌monitor</summary>
>
>><details>
>> <summary>❌latest</summary>
>>
>>><details>
>>> <summary>❌3.12</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_metric_alert_special_char_scenario|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f0693e62330><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f0695ede240><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-g&nbsp;cli_test_metric_alert_special_char000001&nbsp;-n&nbsp;ag1'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.12/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.12/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_command.py:154:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self._handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:8215:&nbsp;in&nbsp;_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;self._execute_operations()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:8242:&nbsp;in&nbsp;_execute_operations<br>&nbsp;&nbsp;&nbsp;&nbsp;self.ApplicationGatewaysGet(ctx=self.ctx)()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:8262:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self.client.send_request(request=request,&nbsp;stream=False,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_client.py:107:&nbsp;in&nbsp;send_request<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self._pipeline.run(request,&nbsp;stream=stream,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:242:&nbsp;in&nbsp;run<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;first_node.send(pipeline_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/mgmt/core/policies/_base.py:95:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/policies/_redirect.py:205:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/policies/_retry.py:545:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_http_policy.py:112:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:130:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;self._sender.send(request.http_request,&nbsp;**request.context.options),<br>&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/transport/_requests_basic.py:375:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.session.request(&nbsp;&nbsp;#&nbsp;type:&nbsp;ignore<br>env/lib/python3.12/site-packages/requests/sessions.py:592:&nbsp;in&nbsp;request<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;self.send(prep,&nbsp;**send_kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_metric_alert_special_char_scenario.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7f0691e47f80><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_metric_alert_special_char_scenario.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>env/lib/python3.12/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.monitor.tests.latest.test_monitor_metric_alert_scenarios.MonitorTests&nbsp;testMethod=test_metric_alert_special_char_scenario><br>resource_group&nbsp;=&nbsp;'cli_test_metric_alert_special_char000001'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(name_prefix='cli_test_metric_alert_special_char')<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_metric_alert_special_char_scenario(self,&nbsp;resource_group):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'alert':&nbsp;'alert1',<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd('network&nbsp;application-gateway&nbsp;create&nbsp;-g&nbsp;{rg}&nbsp;-n&nbsp;ag1&nbsp;--public-ip-address&nbsp;ip1&nbsp;--priority&nbsp;1001')<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gateway_json&nbsp;=&nbsp;self.cmd('network&nbsp;application-gateway&nbsp;show&nbsp;-g&nbsp;{rg}&nbsp;-n&nbsp;ag1').get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_metric_alert_scenarios.py:122:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f0693e62330><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f0695ede240><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-g&nbsp;cli_test_metric_alert_special_char000001&nbsp;-n&nbsp;ag1'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_metric_alert_special_char_scenario.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/monitor/tests/latest/test_monitor_metric_alert_scenarios.py:115|
>>>
>>></details>
>>><details>
>>> <summary>❌3.14</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_metric_alert_special_char_scenario|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7fc9454c6710><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7fc94903ed50><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-g&nbsp;cli_test_metric_alert_special_char000001&nbsp;-n&nbsp;ag1'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.14/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.14/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_command.py:154:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self._handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:715:&nbsp;in&nbsp;_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;self._execute_operations()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:742:&nbsp;in&nbsp;_execute_operations<br>&nbsp;&nbsp;&nbsp;&nbsp;self.ApplicationGatewaysGet(ctx=self.ctx)()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:762:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self.client.send_request(request=request,&nbsp;stream=False,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_client.py:107:&nbsp;in&nbsp;send_request<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self._pipeline.run(request,&nbsp;stream=stream,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:242:&nbsp;in&nbsp;run<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;first_node.send(pipeline_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/mgmt/core/policies/_base.py:95:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/policies/_redirect.py:205:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/policies/_retry.py:545:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_http_policy.py:112:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:130:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;self._sender.send(request.http_request,&nbsp;**request.context.options),<br>&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/transport/_requests_basic.py:375:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.session.request(&nbsp;&nbsp;#&nbsp;type:&nbsp;ignore<br>env/lib/python3.14/site-packages/requests/sessions.py:592:&nbsp;in&nbsp;request<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;self.send(prep,&nbsp;**send_kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_metric_alert_special_char_scenario.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7fc9453a2f20><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_metric_alert_special_char_scenario.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>env/lib/python3.14/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.monitor.tests.latest.test_monitor_metric_alert_scenarios.MonitorTests&nbsp;testMethod=test_metric_alert_special_char_scenario><br>resource_group&nbsp;=&nbsp;'cli_test_metric_alert_special_char000001'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(name_prefix='cli_test_metric_alert_special_char')<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_metric_alert_special_char_scenario(self,&nbsp;resource_group):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'alert':&nbsp;'alert1',<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd('network&nbsp;application-gateway&nbsp;create&nbsp;-g&nbsp;{rg}&nbsp;-n&nbsp;ag1&nbsp;--public-ip-address&nbsp;ip1&nbsp;--priority&nbsp;1001')<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gateway_json&nbsp;=&nbsp;self.cmd('network&nbsp;application-gateway&nbsp;show&nbsp;-g&nbsp;{rg}&nbsp;-n&nbsp;ag1').get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_metric_alert_scenarios.py:122:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7fc9454c6710><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7fc94903ed50><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-g&nbsp;cli_test_metric_alert_special_char000001&nbsp;-n&nbsp;ag1'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_metric_alert_special_char_scenario.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;1&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_special_char000001/providers/Microsoft.Network/applicationGateways/ag1?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/monitor/tests/latest/test_monitor_metric_alert_scenarios.py:115|
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️mysql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️netappfiles</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>❌network</summary>
>
>><details>
>> <summary>❌latest</summary>
>>
>>><details>
>>> <summary>❌3.12</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_ag_with_non_v2_sku|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f5cc90420f0><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f5ccc191ee0><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-n&nbsp;ag-000002&nbsp;-g&nbsp;cli_test_ag_with_non_v2_sku_000001'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.12/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.12/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_command.py:154:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self._handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:9256:&nbsp;in&nbsp;_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;self._execute_operations()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:9283:&nbsp;in&nbsp;_execute_operations<br>&nbsp;&nbsp;&nbsp;&nbsp;self.ApplicationGatewaysGet(ctx=self.ctx)()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:9303:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self.client.send_request(request=request,&nbsp;stream=False,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_client.py:107:&nbsp;in&nbsp;send_request<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self._pipeline.run(request,&nbsp;stream=stream,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:242:&nbsp;in&nbsp;run<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;first_node.send(pipeline_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/mgmt/core/policies/_base.py:95:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/policies/_redirect.py:205:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/policies/_retry.py:545:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_http_policy.py:112:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/_base.py:130:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;self._sender.send(request.http_request,&nbsp;**request.context.options),<br>&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/azure/core/pipeline/transport/_requests_basic.py:375:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.session.request(&nbsp;&nbsp;#&nbsp;type:&nbsp;ignore<br>env/lib/python3.12/site-packages/requests/sessions.py:592:&nbsp;in&nbsp;request<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;self.send(prep,&nbsp;**send_kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_with_non_v2_sku.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7f5cc6833800><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_with_non_v2_sku.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;7&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;6&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;7&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>env/lib/python3.12/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.network.tests.latest.test_network_commands.NetworkAppGatewayDefaultScenarioTest&nbsp;testMethod=test_ag_with_non_v2_sku><br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(name_prefix="cli_test_ag_with_non_v2_sku_",&nbsp;location="westus")<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_ag_with_non_v2_sku(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"ag_name":&nbsp;self.create_random_name("ag-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"port_name":&nbsp;self.create_random_name("port-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"lisener_name":&nbsp;self.create_random_name("lisener-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"rule_name":&nbsp;self.create_random_name("rule-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd("network&nbsp;application-gateway&nbsp;create&nbsp;-n&nbsp;{ag_name}&nbsp;-g&nbsp;{rg}&nbsp;--sku&nbsp;WAF_Medium")<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs["front_ip"]&nbsp;=&nbsp;self.cmd("network&nbsp;application-gateway&nbsp;show&nbsp;-n&nbsp;{ag_name}&nbsp;-g&nbsp;{rg}").get_output_in_json()["frontendIPConfigurations"][0]["name"]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:837:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f5cc90420f0><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f5ccc191ee0><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-n&nbsp;ag-000002&nbsp;-g&nbsp;cli_test_ag_with_non_v2_sku_000001'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_with_non_v2_sku.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;7&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;6&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;7&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:825|
>>>|Failed|test_network_app_gateway_with_defaults|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:770|
>>>|Failed|test_network_app_gateway_with_waf_v2_sku|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:804|
>>>|Failed|test_network_appgw_creation_with_public_and_private_ip|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:850|
>>>|Failed|test_network_app_gateway_with_ssl_profile|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1046|
>>>|Failed|test_network_ag_zone|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1096|
>>>|Failed|test_network_app_gateway_no_wait|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1253|
>>>|Failed|test_appgw_with_tcp|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1354|
>>>|Failed|test_network_app_gateway_with_private_ip|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1279|
>>>|Failed|test_network_ag_http_listener_with_waf_policy|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1666|
>>>|Failed|test_network_app_gateway_waf_policy_with_application_gateway|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:2624|
>>>|Failed|test_network_application_gateway_http_settings_validate_flags|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:10063|
>>>|Failed|test_ag_rule_create_preserves_http_settings_validate_flags|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:10117|
>>>|Failed|test_application_gateway_parent_api_version|self&nbsp;=&nbsp;<azure.cli.command_modules.network.tests.latest.test_network_unit_tests.TestVpnConnectionCertAuthNoSharedKey&nbsp;testMethod=test_application_gateway_parent_api_version><br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_application_gateway_parent_api_version(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Parent&nbsp;application-gateway&nbsp;operations&nbsp;must&nbsp;use&nbsp;API&nbsp;version&nbsp;2025-07-01&nbsp;so&nbsp;that<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Managed&nbsp;HSM&nbsp;SSL&nbsp;certificate&nbsp;fields&nbsp;(hsm.keyId&nbsp;/&nbsp;hsm.publicCertData)&nbsp;are&nbsp;preserved."""<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;azure.cli.command_modules.network.aaz.latest.network.application_gateway&nbsp;import&nbsp;_show,&nbsp;_create,&nbsp;_update<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ImportError:&nbsp;cannot&nbsp;import&nbsp;name&nbsp;'_show'&nbsp;from&nbsp;'azure.cli.command_modules.network.aaz.latest.network.application_gateway'&nbsp;(/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__init__.py)<br><br>src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:131:&nbsp;ImportError|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:127|
>>>|Failed|test_application_gateway_show_ssl_cert_hsm_schema|self&nbsp;=&nbsp;<azure.cli.command_modules.network.tests.latest.test_network_unit_tests.TestVpnConnectionCertAuthNoSharedKey&nbsp;testMethod=test_application_gateway_show_ssl_cert_hsm_schema><br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_application_gateway_show_ssl_cert_hsm_schema(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""The&nbsp;parent&nbsp;application-gateway&nbsp;show&nbsp;response&nbsp;schema&nbsp;must&nbsp;include&nbsp;the<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sslCertificates[].properties.hsm&nbsp;object&nbsp;with&nbsp;keyId&nbsp;and&nbsp;publicCertData."""<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;azure.cli.command_modules.network.aaz.latest.network.application_gateway._show&nbsp;import&nbsp;Show<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ModuleNotFoundError:&nbsp;No&nbsp;module&nbsp;named&nbsp;'azure.cli.command_modules.network.aaz.latest.network.application_gateway._show'<br><br>src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:150:&nbsp;ModuleNotFoundError|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:146|
>>>|Failed|test_appgw_private_endpoint_with_default|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py:1618|
>>>|Failed|test_appgw_private_endpoint_with_overwrite_default|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py:1705|
>>>
>>></details>
>>><details>
>>> <summary>❌3.14</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_ag_with_non_v2_sku|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7fd0e9f5cb00><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7fd0ee85bed0><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-n&nbsp;ag-000002&nbsp;-g&nbsp;cli_test_ag_with_non_v2_sku_000001'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.14/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.14/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_command.py:154:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self._handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:8620:&nbsp;in&nbsp;_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;self._execute_operations()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:8647:&nbsp;in&nbsp;_execute_operations<br>&nbsp;&nbsp;&nbsp;&nbsp;self.ApplicationGatewaysGet(ctx=self.ctx)()<br>src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__cmds.py:8667:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self.client.send_request(request=request,&nbsp;stream=False,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_client.py:107:&nbsp;in&nbsp;send_request<br>&nbsp;&nbsp;&nbsp;&nbsp;session&nbsp;=&nbsp;self._pipeline.run(request,&nbsp;stream=stream,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:242:&nbsp;in&nbsp;run<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;first_node.send(pipeline_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/mgmt/core/policies/_base.py:95:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/policies/_redirect.py:205:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/policies/_retry.py:545:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/aaz/_http_policy.py:112:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:98:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.next.send(request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/_base.py:130:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;self._sender.send(request.http_request,&nbsp;**request.context.options),<br>&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/azure/core/pipeline/transport/_requests_basic.py:375:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.session.request(&nbsp;&nbsp;#&nbsp;type:&nbsp;ignore<br>env/lib/python3.14/site-packages/requests/sessions.py:592:&nbsp;in&nbsp;request<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;self.send(prep,&nbsp;**send_kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_with_non_v2_sku.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7fd0e8dcb070><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_with_non_v2_sku.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;7&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;6&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;7&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>env/lib/python3.14/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.network.tests.latest.test_network_commands.NetworkAppGatewayDefaultScenarioTest&nbsp;testMethod=test_ag_with_non_v2_sku><br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(name_prefix="cli_test_ag_with_non_v2_sku_",&nbsp;location="westus")<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_ag_with_non_v2_sku(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs.update({<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"ag_name":&nbsp;self.create_random_name("ag-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"port_name":&nbsp;self.create_random_name("port-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"lisener_name":&nbsp;self.create_random_name("lisener-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"rule_name":&nbsp;self.create_random_name("rule-",&nbsp;12),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;})<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd("network&nbsp;application-gateway&nbsp;create&nbsp;-n&nbsp;{ag_name}&nbsp;-g&nbsp;{rg}&nbsp;--sku&nbsp;WAF_Medium")<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.kwargs["front_ip"]&nbsp;=&nbsp;self.cmd("network&nbsp;application-gateway&nbsp;show&nbsp;-n&nbsp;{ag_name}&nbsp;-g&nbsp;{rg}").get_output_in_json()["frontendIPConfigurations"][0]["name"]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:837:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7fd0e9f5cb00><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7fd0ee85bed0><br>command&nbsp;=&nbsp;'network&nbsp;application-gateway&nbsp;show&nbsp;-n&nbsp;ag-000002&nbsp;-g&nbsp;cli_test_ag_with_non_v2_sku_000001'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_ag_with_non_v2_sku.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;7&nbsp;similar&nbsp;requests&nbsp;with&nbsp;1&nbsp;different&nbsp;matcher(s)&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2023-11-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;6&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;7&nbsp;-&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_with_non_v2_sku_000001/providers/Microsoft.Network/applicationGateways/ag-000002?api-version=2024-10-01>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;succeeded&nbsp;:&nbsp;['method',&nbsp;'scheme',&nbsp;'host',&nbsp;'port',&nbsp;'path']<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Matchers&nbsp;failed&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_custom_request_query_matcher&nbsp;-&nbsp;assertion&nbsp;failure&nbsp;:<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:825|
>>>|Failed|test_network_app_gateway_with_defaults|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:770|
>>>|Failed|test_network_app_gateway_with_waf_v2_sku|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:804|
>>>|Failed|test_network_appgw_creation_with_public_and_private_ip|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:850|
>>>|Failed|test_network_app_gateway_with_ssl_profile|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1046|
>>>|Failed|test_network_ag_zone|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1096|
>>>|Failed|test_network_app_gateway_no_wait|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1253|
>>>|Failed|test_appgw_with_tcp|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1354|
>>>|Failed|test_network_app_gateway_with_private_ip|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1279|
>>>|Failed|test_network_ag_http_listener_with_waf_policy|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:1666|
>>>|Failed|test_network_app_gateway_waf_policy_with_application_gateway|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:2624|
>>>|Failed|test_network_application_gateway_http_settings_validate_flags|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:10063|
>>>|Failed|test_ag_rule_create_preserves_http_settings_validate_flags|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py:10117|
>>>|Failed|test_application_gateway_parent_api_version|self&nbsp;=&nbsp;<azure.cli.command_modules.network.tests.latest.test_network_unit_tests.TestVpnConnectionCertAuthNoSharedKey&nbsp;testMethod=test_application_gateway_parent_api_version><br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_application_gateway_parent_api_version(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Parent&nbsp;application-gateway&nbsp;operations&nbsp;must&nbsp;use&nbsp;API&nbsp;version&nbsp;2025-07-01&nbsp;so&nbsp;that<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Managed&nbsp;HSM&nbsp;SSL&nbsp;certificate&nbsp;fields&nbsp;(hsm.keyId&nbsp;/&nbsp;hsm.publicCertData)&nbsp;are&nbsp;preserved."""<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;azure.cli.command_modules.network.aaz.latest.network.application_gateway&nbsp;import&nbsp;_show,&nbsp;_create,&nbsp;_update<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ImportError:&nbsp;cannot&nbsp;import&nbsp;name&nbsp;'_show'&nbsp;from&nbsp;'azure.cli.command_modules.network.aaz.latest.network.application_gateway'&nbsp;(/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/__init__.py)<br><br>src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:131:&nbsp;ImportError|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:127|
>>>|Failed|test_application_gateway_show_ssl_cert_hsm_schema|self&nbsp;=&nbsp;<azure.cli.command_modules.network.tests.latest.test_network_unit_tests.TestVpnConnectionCertAuthNoSharedKey&nbsp;testMethod=test_application_gateway_show_ssl_cert_hsm_schema><br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_application_gateway_show_ssl_cert_hsm_schema(self):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""The&nbsp;parent&nbsp;application-gateway&nbsp;show&nbsp;response&nbsp;schema&nbsp;must&nbsp;include&nbsp;the<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sslCertificates[].properties.hsm&nbsp;object&nbsp;with&nbsp;keyId&nbsp;and&nbsp;publicCertData."""<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;azure.cli.command_modules.network.aaz.latest.network.application_gateway._show&nbsp;import&nbsp;Show<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ModuleNotFoundError:&nbsp;No&nbsp;module&nbsp;named&nbsp;'azure.cli.command_modules.network.aaz.latest.network.application_gateway._show'<br><br>src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:150:&nbsp;ModuleNotFoundError|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py:146|
>>>|Failed|test_appgw_private_endpoint_with_default|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py:1618|
>>>|Failed|test_appgw_private_endpoint_with_overwrite_default|The error message is too long, please check the pipeline log for details.|src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py:1705|
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️policyinsights</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️postgresql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️privatedns</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️profile</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️rdbms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️redis</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️relay</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️resource</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️role</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️search</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️security</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicebus</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️serviceconnector</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicefabric</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️signalr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sqlvm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️storage</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️synapse</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️telemetry</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️util</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️vm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description
Fixes https://github.com/Azure/azure-cli/issues/33981.

**Related command**
`az network application-gateway show` / `az network application-gateway create` / `az network application-gateway update`

**Description**

The parent `application_gateway` AAZ operations (`show`, `create`, `update`) were using API version `2024-10-01`, while the `ssl_cert` sub-group already used `2025-07-01`. This mismatch caused `sslCertificates[].properties.hsm.keyId` and `hsm.publicCertData` (Managed HSM–backed certificate fields, introduced in `2025-07-01`) to be silently dropped on any GET or PUT round-trip through the parent resource.

- **`_show.py` / `_create.py` / `_update.py`**: Bumped `_aaz_info["version"]`, the resources entry, and all `api-version` query parameters from `2024-10-01` → `2025-07-01`.
- **Response schema** (`_show.py`, `_create.py`, `_update.py`): Added `sslCertificates[].properties.hsm` (`AAZObjectType`) with `hsm.key_id` (`keyId`) and `hsm.public_cert_data` (`publicCertData`) to match the schema already present in the `ssl_cert` sub-group.

**Testing Guide**

New unit tests in `test_network_unit_tests.py`:

- `test_application_gateway_parent_api_version` — asserts all three operations declare `2025-07-01` in `_aaz_info` and resources.
- `test_application_gateway_show_ssl_cert_hsm_schema` — introspects the built `ApplicationGatewaysGet` response schema at runtime, asserting `hsm`, `key_id`, and `public_cert_data` are present under `ssl_certificates.Element.properties`.

**History Notes**

[Network] `az network application-gateway show`: Bump API version to 2025-07-01 so Managed HSM SSL certificate fields (`hsm.keyId` / `hsm.publicCertData`) are preserved on show/create/update

## Generation source
https://github.com/Azure/aaz/pull/1071