### PR TITLE
{Packaging} Update UBI packages before RPM tests

### DIFF
--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -5,7 +5,8 @@ set -exv
 
 export USERNAME=azureuser
 
-dnf update -y
+# Pinned UBI 8/9 images contain an older Expat incompatible with current Python 3.12 pyexpat.
+dnf update -y expat
 dnf --nogpgcheck install /mnt/rpm/$RPM_NAME -y
 
 dnf install git findutils $PYTHON_PACKAGE-pip -y

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -5,6 +5,7 @@ set -exv
 
 export USERNAME=azureuser
 
+dnf update -y
 dnf --nogpgcheck install /mnt/rpm/$RPM_NAME -y
 
 dnf install git findutils $PYTHON_PACKAGE-pip -y


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

N/A (RPM packaging CI)

**Description**

Update UBI packages before installing and testing the Azure CLI RPM.

Red Hat published Python 3.12.14 packages for UBI 8 and UBI 9 that require a newer Expat symbol. The pinned base images still contain older Expat packages, causing every AMD64 and ARM64 RPM test leg for UBI 8/9 to fail when pip imports `pyexpat`:

```
undefined symbol: XML_SetBillionLaughsAttackProtectionMaximumAmplification
```

Running `dnf update -y` first upgrades Expat to a compatible version before the Azure CLI RPM and test dependencies are installed.

**Testing Guide**

Reproduced the failure on fresh images without an update:

- UBI 8.4: Python `3.12.14-1.el8_10` + Expat `2.2.5-4.el8`
- UBI 9.0: Python `3.12.14-1.el9_8` + Expat `2.2.10-12.el9_0.3`

Validated the fix on fresh images after `dnf update -y`:

- UBI 8.4: Expat `2.5.0-2.el8_10`, `import pyexpat` succeeds
- UBI 9.0: Expat `2.5.0-6.el9_8.1`, `import pyexpat` succeeds
- `bash -n scripts/release/rpm/test_rpm_in_docker.sh`

**History Notes**

N/A

---

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).