### PR TITLE
{Packaging} Update Expat to be compatible with current Python

### DIFF
--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -4,7 +4,8 @@
 set -exv
 
 export USERNAME=azureuser
-
+# Pinned UBI 8/9 images contain an older Expat incompatible with current Python 3.12 pyexpat.
+dnf update -y expat
 dnf --nogpgcheck install /mnt/rpm/$RPM_NAME -y
 
 dnf install git findutils $PYTHON_PACKAGE-pip -y


### PR DESCRIPTION
**Summary**
Adds a dnf update -y expat step to the RPM Docker test script (scripts/release/rpm/test_rpm_in_docker.sh) before installing the built RPM.
 **Background**
The pinned UBI 8/9 base images ship with an older version of the Expat XML library. This version is incompatible with the pyexpat module in the current Python 3.12 runtime, causing failures when the RPM is exercised inside the container.
 **Changes**
- Update the expat package via dnf prior to installing the Azure CLI RPM and its dependencies.

 **Impact**
- Scope: CI/release test tooling only — no changes to Azure CLI source or shipped artifacts.
- Ensures the RPM smoke test in Docker runs against an Expat version compatible with Python 3.12, preventing spurious pyexpat errors.
 **Testing**
- Runs as part of the existing RPM-in-Docker test flow (set -exv ensures the new step is logged and any failure aborts the run).