### PR TITLE
{Profile} az login: Support automatic OIDC federated token refresh

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -33,6 +33,10 @@ AZURE_TENANT_ID = "AZURE_TENANT_ID"
 AZURE_CLIENT_ID = "AZURE_CLIENT_ID"
 AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET"
 
+# Sentinel value persisted as the client_assertion of a service principal entry to indicate that the OIDC
+# ID token should be fetched (and refreshed) on demand from the CI/CD provider instead of being a static token.
+FEDERATED_IDENTITY = "FEDERATED_IDENTITY"
+
 WAM_PROMPT = (
     "Select the account you want to log in with. "
     "For more information on login with Azure CLI, see https://go.microsoft.com/fwlink/?linkid=2271136")
@@ -347,7 +351,9 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
         #     "client_assertion": "...a JWT with claims aud, exp, iss, jti, nbf, and sub..."
         # }
         if self.client_assertion:
-            client_credential = {'client_assertion': self.client_assertion}
+            client_credential = {
+                'client_assertion': get_federated_id_token if self.client_assertion == FEDERATED_IDENTITY
+                else self.client_assertion}
 
         return client_credential
 
@@ -456,3 +462,55 @@ def get_environment_credential():
         getenv(AZURE_TENANT_ID))
     credentials = ServicePrincipalCredential(sp_auth, authority=authority)
     return credentials
+
+
+def get_federated_id_token():
+    """Acquire a fresh OIDC ID token from the current CI/CD provider.
+
+    This is the dispatcher registered as MSAL's ``client_assertion`` callback. MSAL invokes it lazily every
+    time it needs a client assertion, so an expired ID token is transparently replaced with a fresh one for
+    as long as the underlying provider request token is valid. The provider is auto-detected from the
+    environment so that ``--federated-identity`` stays a single, provider-agnostic flag.
+    """
+    if 'ACTIONS_ID_TOKEN_REQUEST_URL' in os.environ:
+        return _get_id_token_github()
+    raise CLIError(
+        "--federated-identity: no supported CI/CD OIDC provider was detected in the environment. "
+        "Only GitHub Actions is currently supported. Provide a token with --federated-token instead. "
+        "See https://github.com/Azure/azure-cli/issues/28708 for provider support progress.")
+
+
+def _get_id_token_github():
+    """Fetch a fresh OIDC ID token from the GitHub Actions token service.
+
+    Valid for the lifetime of the GitHub Actions request token (currently ~6 hours after the job starts).
+    https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
+    """
+    from urllib.parse import quote
+    import requests
+
+    try:
+        request_token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
+        request_url = os.environ['ACTIONS_ID_TOKEN_REQUEST_URL']
+    except KeyError as ex:
+        raise CLIError(
+            'Environment variable {} is not set. --federated-identity requires GitHub Actions with '
+            '"id-token: write" permission granted to the workflow.'.format(ex))
+
+    audience = quote('api://AzureADTokenExchange')
+    url = '{}&audience={}'.format(request_url, audience)
+    headers = {
+        'Authorization': 'bearer {}'.format(request_token),
+        'Accept': 'application/json; api-version=2.0',
+        'Content-Type': 'application/json'
+    }
+    response = requests.get(url, headers=headers)
+    if not response.ok:
+        raise CLIError('Failed to retrieve an ID token from GitHub Actions: {} {}'.format(
+            response.status_code, response.reason))
+    id_token = response.json().get('value')
+    if not id_token:
+        raise CLIError('GitHub Actions OIDC endpoint did not return an ID token.')
+    # Never log the token value itself.
+    logger.debug('Retrieved a fresh ID token from the GitHub Actions OIDC endpoint.')
+    return id_token

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+import threading
 
 from azure.cli.core._environment import get_config_dir
 from knack.log import get_logger
@@ -481,6 +482,10 @@ def get_environment_credential():
     return credentials
 
 
+# MSAL may invoke a client_assertion callback concurrently; this lock keeps the dispatcher fetch thread-safe.
+_federated_id_token_lock = threading.Lock()
+
+
 def get_federated_id_token():
     """Acquire a fresh OIDC ID token from the current CI/CD provider.
 
@@ -488,15 +493,19 @@ def get_federated_id_token():
     time it needs a client assertion, so an expired ID token is transparently replaced with a fresh one for
     as long as the underlying provider request token is valid. The provider is auto-detected from the
     environment so that ``--federated-identity`` stays a single, provider-agnostic flag.
+
+    MSAL may invoke the client_assertion callback from concurrent token requests, so this is serialized with
+    a lock to avoid duplicate token fetches racing against each other.
     """
-    if 'ACTIONS_ID_TOKEN_REQUEST_URL' in os.environ:
-        return _get_id_token_github()
-    if 'SYSTEM_OIDCREQUESTURI' in os.environ or 'ARM_OIDC_REQUEST_URL' in os.environ:
-        return _get_id_token_azure_devops()
-    raise CLIError(
-        "--federated-identity: no supported CI/CD OIDC provider was detected in the environment. "
-        "Only GitHub Actions and Azure DevOps are currently supported. Provide a token with "
-        "--federated-token instead. See https://github.com/Azure/azure-cli/issues/28708 for details.")
+    with _federated_id_token_lock:
+        if 'ACTIONS_ID_TOKEN_REQUEST_URL' in os.environ:
+            return _get_id_token_github()
+        if 'SYSTEM_OIDCREQUESTURI' in os.environ or 'ARM_OIDC_REQUEST_URL' in os.environ:
+            return _get_id_token_azure_devops()
+        raise CLIError(
+            "--federated-identity: no supported CI/CD OIDC provider was detected in the environment. "
+            "Only GitHub Actions and Azure DevOps are currently supported. Provide a token with "
+            "--federated-token instead. See https://github.com/Azure/azure-cli/issues/28708 for details.")
 
 
 def _get_id_token_github():
@@ -608,16 +617,21 @@ def _build_command_assertion_callback(command):
     if not args:
         raise CLIError('--federated-token-callback: the command is empty.')
 
+    # MSAL may invoke the client_assertion callback from concurrent token requests; serialize the command
+    # execution so two requests don't run the callback command at the same time.
+    lock = threading.Lock()
+
     def get_id_token():
         import subprocess
-        try:
-            result = subprocess.run(args, capture_output=True, text=True, check=True)
-        except FileNotFoundError:
-            raise CLIError("--federated-token-callback: command not found: '{}'".format(args[0]))
-        except subprocess.CalledProcessError as ex:
-            raise CLIError('--federated-token-callback command exited with code {}: {}'.format(
-                ex.returncode, (ex.stderr or '').strip()))
-        id_token = result.stdout.strip()
+        with lock:
+            try:
+                result = subprocess.run(args, capture_output=True, text=True, check=True)
+            except FileNotFoundError:
+                raise CLIError("--federated-token-callback: command not found: '{}'".format(args[0]))
+            except subprocess.CalledProcessError as ex:
+                raise CLIError('--federated-token-callback command exited with code {}: {}'.format(
+                    ex.returncode, (ex.stderr or '').strip()))
+            id_token = result.stdout.strip()
         if not id_token:
             raise CLIError('--federated-token-callback command produced no output on stdout.')
         # Never log the token value itself.

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -26,6 +26,7 @@ _CLIENT_SECRET = 'client_secret'
 _CERTIFICATE = 'certificate'
 _USE_CERT_SN_ISSUER = 'use_cert_sn_issuer'
 _CLIENT_ASSERTION = 'client_assertion'
+_CLIENT_ASSERTION_CALLBACK = 'client_assertion_callback'
 
 # For environment credential
 AZURE_AUTHORITY_HOST = "AZURE_AUTHORITY_HOST"
@@ -261,6 +262,8 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
         self.use_cert_sn_issuer = None
         # federated identity credential
         self.client_assertion = None
+        # command that prints a fresh federated token to stdout (provider-agnostic callback)
+        self.client_assertion_callback = None
 
         # Internal attributes for certificate
         # They are computed at runtime and not persisted in the service principal entry.
@@ -298,12 +301,13 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
     @classmethod
     def build_credential(cls, client_secret=None,
                          certificate=None, use_cert_sn_issuer=None,
-                         client_assertion=None):
+                         client_assertion=None, client_assertion_callback=None):
         """Build credential from user input. The credential looks like below, but only one key can exist.
         {
             'client_secret': 'my_secret',
             'certificate': '/path/to/cert.pem',
-            'client_assertion': 'my_federated_token'
+            'client_assertion': 'my_federated_token',
+            'client_assertion_callback': 'my-get-token-command'
         }
         """
         entry = {}
@@ -315,11 +319,14 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
                 entry[_USE_CERT_SN_ISSUER] = use_cert_sn_issuer
         elif client_assertion:
             entry[_CLIENT_ASSERTION] = client_assertion
+        elif client_assertion_callback:
+            entry[_CLIENT_ASSERTION_CALLBACK] = client_assertion_callback
         return entry
 
     def get_entry_to_persist(self):
         """Get a service principal entry that can be persisted by ServicePrincipalStore."""
-        persisted_keys = [_CLIENT_ID, _TENANT, _CLIENT_SECRET, _CERTIFICATE, _USE_CERT_SN_ISSUER, _CLIENT_ASSERTION]
+        persisted_keys = [_CLIENT_ID, _TENANT, _CLIENT_SECRET, _CERTIFICATE, _USE_CERT_SN_ISSUER,
+                          _CLIENT_ASSERTION, _CLIENT_ASSERTION_CALLBACK]
         # Only persist certain attributes whose values are not None
         return {k: v for k, v in self.__dict__.items() if k in persisted_keys and v}
 
@@ -354,6 +361,16 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
             client_credential = {
                 'client_assertion': get_federated_id_token if self.client_assertion == FEDERATED_IDENTITY
                 else self.client_assertion}
+
+        # client_assertion_callback
+        # A user-provided command that prints a fresh federated token to stdout. Wrapped as a callable so
+        # MSAL re-runs it whenever a fresh assertion is needed (provider-agnostic refresh).
+        # {
+        #     "client_assertion": <callable returning a JWT>
+        # }
+        if self.client_assertion_callback:
+            client_credential = {
+                'client_assertion': _build_command_assertion_callback(self.client_assertion_callback)}
 
         return client_credential
 
@@ -568,3 +585,28 @@ def _get_id_token_azure_devops():
     # Never log the token value itself.
     logger.debug('Retrieved a fresh ID token from the Azure DevOps OIDC endpoint.')
     return id_token
+
+
+def _build_command_assertion_callback(command):
+    """Wrap a user-provided command as a callable that returns a fresh federated token.
+
+    This is the provider-agnostic escape hatch behind `az login --federated-token-callback`. The command
+    is expected to print a single OIDC token to stdout; MSAL invokes the returned callable whenever it
+    needs a fresh assertion, so refresh works with any CI/CD provider. The command is supplied directly by
+    the user on the command line (it is their own command, not untrusted input).
+    """
+    def get_id_token():
+        import subprocess
+        try:
+            # shell=True is required so users can pipe (e.g. `curl ... | jq -r .value`).
+            result = subprocess.run(command, shell=True, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as ex:
+            raise CLIError('--federated-token-callback command exited with code {}: {}'.format(
+                ex.returncode, (ex.stderr or '').strip()))
+        id_token = result.stdout.strip()
+        if not id_token:
+            raise CLIError('--federated-token-callback command produced no output on stdout.')
+        # Never log the token value itself.
+        logger.debug('Retrieved a fresh ID token from the --federated-token-callback command.')
+        return id_token
+    return get_id_token

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -485,6 +485,10 @@ def get_environment_credential():
 # MSAL may invoke a client_assertion callback concurrently; this lock keeps the dispatcher fetch thread-safe.
 _federated_id_token_lock = threading.Lock()
 
+# Connect/read timeouts (seconds) for OIDC ID token requests, so a network stall fails fast on a
+# long-running CI job instead of hanging the whole token acquisition indefinitely.
+_OIDC_HTTP_TIMEOUT = (10, 30)
+
 
 def get_federated_id_token():
     """Acquire a fresh OIDC ID token from the current CI/CD provider.
@@ -506,6 +510,21 @@ def get_federated_id_token():
             "--federated-identity: no supported CI/CD OIDC provider was detected in the environment. "
             "Only GitHub Actions and Azure DevOps are currently supported. Provide a token with "
             "--federated-token instead. See https://github.com/Azure/azure-cli/issues/28708 for details.")
+
+
+def _oidc_http_request(method, url, headers, provider):
+    """Issue an OIDC ID token HTTP request with an explicit timeout.
+
+    A missing timeout would let a stalled connection hang token acquisition forever on a long-running CI
+    job, so we bound it and surface a clear error on timeout or connection failure.
+    """
+    import requests
+    try:
+        return method(url, headers=headers, timeout=_OIDC_HTTP_TIMEOUT)
+    except requests.exceptions.Timeout:
+        raise CLIError('Timed out requesting an ID token from {}. Please retry.'.format(provider))
+    except requests.exceptions.RequestException as ex:
+        raise CLIError('Failed to reach the {} OIDC endpoint: {}'.format(provider, ex))
 
 
 def _get_id_token_github():
@@ -534,7 +553,7 @@ def _get_id_token_github():
         'Accept': 'application/json; api-version=2.0',
         'Content-Type': 'application/json'
     }
-    response = requests.get(url, headers=headers)
+    response = _oidc_http_request(requests.get, url, headers, 'GitHub Actions')
     if not response.ok:
         raise CLIError('Failed to retrieve an ID token from GitHub Actions: {} {}'.format(
             response.status_code, response.reason))
@@ -586,7 +605,7 @@ def _get_id_token_azure_devops():
         # Prevents the service from responding with a redirect HTTP status code.
         'X-TFS-FedAuthRedirect': 'Suppress',
     }
-    response = requests.post(url, headers=headers)
+    response = _oidc_http_request(requests.post, url, headers, 'Azure DevOps')
     if not response.ok:
         raise CLIError('Failed to retrieve an ID token from Azure DevOps: {} {}'.format(
             response.status_code, response.reason))
@@ -605,15 +624,18 @@ def _build_command_assertion_callback(command):
     is expected to print a single OIDC token to stdout; MSAL invokes the returned callable whenever it
     needs a fresh assertion, so refresh works with any CI/CD provider.
 
-    The command is parsed into an argument vector and run WITHOUT a shell (shell=False). Because the command
-    is persisted in the service principal entry and re-executed on every refresh, avoiding a shell prevents a
-    tampered token cache from turning into arbitrary code execution. Users who need shell features such as
-    pipes or redirection should either point to a script file or wrap the pipeline explicitly, e.g.
+    The command is parsed into an argument vector (with POSIX rules on every platform) and run WITHOUT a
+    shell (shell=False). Because the command is persisted in the service principal entry and re-executed on
+    every refresh, avoiding a shell prevents a tampered token cache from turning into arbitrary code
+    execution. Users who need shell features such as pipes or redirection should either point to a script
+    file or wrap the pipeline explicitly, e.g.
     --federated-token-callback "bash -c 'curl ... | jq -r .value'".
+    On Windows, use forward slashes in paths or escape backslashes (POSIX parsing treats '\\' as an escape).
     """
     import shlex
-    # posix=False keeps Windows paths (backslashes) intact; args are still executed without a shell.
-    args = shlex.split(command, posix=not sys.platform.startswith('win'))
+    # POSIX parsing on every platform so quoted arguments containing spaces are handled correctly and
+    # consistently. The trade-off is that backslashes are escape characters (see the Windows note above).
+    args = shlex.split(command, posix=True)
     if not args:
         raise CLIError('--federated-token-callback: the command is empty.')
 

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -474,10 +474,12 @@ def get_federated_id_token():
     """
     if 'ACTIONS_ID_TOKEN_REQUEST_URL' in os.environ:
         return _get_id_token_github()
+    if 'SYSTEM_OIDCREQUESTURI' in os.environ or 'ARM_OIDC_REQUEST_URL' in os.environ:
+        return _get_id_token_azure_devops()
     raise CLIError(
         "--federated-identity: no supported CI/CD OIDC provider was detected in the environment. "
-        "Only GitHub Actions is currently supported. Provide a token with --federated-token instead. "
-        "See https://github.com/Azure/azure-cli/issues/28708 for provider support progress.")
+        "Only GitHub Actions and Azure DevOps are currently supported. Provide a token with "
+        "--federated-token instead. See https://github.com/Azure/azure-cli/issues/28708 for details.")
 
 
 def _get_id_token_github():
@@ -513,4 +515,56 @@ def _get_id_token_github():
         raise CLIError('GitHub Actions OIDC endpoint did not return an ID token.')
     # Never log the token value itself.
     logger.debug('Retrieved a fresh ID token from the GitHub Actions OIDC endpoint.')
+    return id_token
+
+
+def _get_id_token_azure_devops():
+    """Fetch a fresh OIDC ID token from Azure DevOps Pipelines.
+
+    Azure DevOps issues short-lived ID tokens (~5 min) and, unlike GitHub Actions, requires a POST to the
+    oidctoken API authenticated with the pipeline's System.AccessToken and targeting a specific service
+    connection. Because the token refresh runs in a later `az` process, all three inputs are read from the
+    environment following the documented Azure DevOps convention:
+
+    - request URL:   ARM_OIDC_REQUEST_URL, else SYSTEM_OIDCREQUESTURI
+    - access token:  ARM_OIDC_REQUEST_TOKEN, else SYSTEM_ACCESSTOKEN (the pipeline's System.AccessToken)
+    - service conn:  ARM_OIDC_AZURE_SERVICE_CONNECTION_ID
+
+    https://devblogs.microsoft.com/devops/introducing-azure-devops-id-token-refresh-and-terraform-task-version-5/
+    """
+    from urllib.parse import quote
+    import requests
+
+    request_url = os.environ.get('ARM_OIDC_REQUEST_URL') or os.environ.get('SYSTEM_OIDCREQUESTURI')
+    request_token = os.environ.get('ARM_OIDC_REQUEST_TOKEN') or os.environ.get('SYSTEM_ACCESSTOKEN')
+    service_connection_id = os.environ.get('ARM_OIDC_AZURE_SERVICE_CONNECTION_ID')
+
+    missing = [name for name, value in (
+        ('ARM_OIDC_REQUEST_URL (or SYSTEM_OIDCREQUESTURI)', request_url),
+        ('ARM_OIDC_REQUEST_TOKEN (or SYSTEM_ACCESSTOKEN)', request_token),
+        ('ARM_OIDC_AZURE_SERVICE_CONNECTION_ID', service_connection_id)) if not value]
+    if missing:
+        raise CLIError(
+            '--federated-identity on Azure DevOps requires the environment variable(s): {}. '
+            'System.AccessToken is not exposed to scripts by default, so map it explicitly and set the '
+            'service connection ID. See https://github.com/Azure/azure-cli/issues/28708 for guidance.'
+            .format(', '.join(missing)))
+
+    url = '{}?api-version=7.1&serviceConnectionId={}'.format(
+        request_url.rstrip('/'), quote(service_connection_id))
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': 'bearer {}'.format(request_token),
+        # Prevents the service from responding with a redirect HTTP status code.
+        'X-TFS-FedAuthRedirect': 'Suppress',
+    }
+    response = requests.post(url, headers=headers)
+    if not response.ok:
+        raise CLIError('Failed to retrieve an ID token from Azure DevOps: {} {}'.format(
+            response.status_code, response.reason))
+    id_token = response.json().get('oidcToken')
+    if not id_token:
+        raise CLIError('Azure DevOps OIDC endpoint did not return an ID token.')
+    # Never log the token value itself.
+    logger.debug('Retrieved a fresh ID token from the Azure DevOps OIDC endpoint.')
     return id_token

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -517,7 +517,9 @@ def _get_id_token_github():
             '"id-token: write" permission granted to the workflow.'.format(ex))
 
     audience = quote('api://AzureADTokenExchange')
-    url = '{}&audience={}'.format(request_url, audience)
+    # Append the audience with the correct separator in case the request URL already has a query string.
+    separator = '&' if '?' in request_url else '?'
+    url = '{}{}audience={}'.format(request_url, separator, audience)
     headers = {
         'Authorization': 'bearer {}'.format(request_token),
         'Accept': 'application/json; api-version=2.0',
@@ -592,14 +594,26 @@ def _build_command_assertion_callback(command):
 
     This is the provider-agnostic escape hatch behind `az login --federated-token-callback`. The command
     is expected to print a single OIDC token to stdout; MSAL invokes the returned callable whenever it
-    needs a fresh assertion, so refresh works with any CI/CD provider. The command is supplied directly by
-    the user on the command line (it is their own command, not untrusted input).
+    needs a fresh assertion, so refresh works with any CI/CD provider.
+
+    The command is parsed into an argument vector and run WITHOUT a shell (shell=False). Because the command
+    is persisted in the service principal entry and re-executed on every refresh, avoiding a shell prevents a
+    tampered token cache from turning into arbitrary code execution. Users who need shell features such as
+    pipes or redirection should either point to a script file or wrap the pipeline explicitly, e.g.
+    --federated-token-callback "bash -c 'curl ... | jq -r .value'".
     """
+    import shlex
+    # posix=False keeps Windows paths (backslashes) intact; args are still executed without a shell.
+    args = shlex.split(command, posix=not sys.platform.startswith('win'))
+    if not args:
+        raise CLIError('--federated-token-callback: the command is empty.')
+
     def get_id_token():
         import subprocess
         try:
-            # shell=True is required so users can pipe (e.g. `curl ... | jq -r .value`).
-            result = subprocess.run(command, shell=True, capture_output=True, text=True, check=True)
+            result = subprocess.run(args, capture_output=True, text=True, check=True)
+        except FileNotFoundError:
+            raise CLIError("--federated-token-callback: command not found: '{}'".format(args[0]))
         except subprocess.CalledProcessError as ex:
             raise CLIError('--federated-token-callback command exited with code {}: {}'.format(
                 ex.returncode, (ex.stderr or '').strip()))

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -305,12 +305,23 @@ class TestServicePrincipalAuth(unittest.TestCase):
     def test_federated_token_callback_invokes_command(self, run_mock):
         run_mock.return_value = mock.MagicMock(stdout='fresh_token\n', stderr='')
         sp_auth = ServicePrincipalAuth.build_from_credential(
-            'tenant1', 'sp_id1', {'client_assertion_callback': 'get-token'})
+            'tenant1', 'sp_id1', {'client_assertion_callback': 'get-token --audience x'})
         callback = sp_auth.get_msal_client_credential()['client_assertion']
 
         # The callable runs the user command and returns its trimmed stdout each time MSAL calls it.
         assert callback() == 'fresh_token'
-        assert run_mock.call_args.args[0] == 'get-token'
+        # The command is split into an argv list and run WITHOUT a shell (no shell=True kwarg).
+        assert run_mock.call_args.args[0] == ['get-token', '--audience', 'x']
+        assert 'shell' not in run_mock.call_args.kwargs
+
+    def test_federated_token_callback_no_shell_interpretation(self):
+        # Shell metacharacters must be treated as literal argv, never interpreted by a shell.
+        sp_auth = ServicePrincipalAuth.build_from_credential(
+            'tenant1', 'sp_id1', {'client_assertion_callback': "get-token ; rm -rf /"})
+        with mock.patch('subprocess.run') as run_mock:
+            run_mock.return_value = mock.MagicMock(stdout='tok\n', stderr='')
+            sp_auth.get_msal_client_credential()['client_assertion']()
+        assert run_mock.call_args.args[0] == ['get-token', ';', 'rm', '-rf', '/']
 
     @mock.patch('subprocess.run')
     def test_federated_token_callback_empty_output(self, run_mock):
@@ -373,6 +384,21 @@ class TestFederatedIdentity(unittest.TestCase):
         assert called_url.startswith('https://github.example/token?foo=bar&audience=')
         assert 'api%3A//AzureADTokenExchange' in called_url
         assert get_mock.call_args.kwargs['headers']['Authorization'] == 'bearer request_token'
+
+    @mock.patch.dict(os.environ, {
+        'ACTIONS_ID_TOKEN_REQUEST_URL': 'https://github.example/token',
+        'ACTIONS_ID_TOKEN_REQUEST_TOKEN': 'request_token'
+    }, clear=True)
+    @mock.patch('requests.get')
+    def test_get_federated_id_token_github_url_without_query(self, get_mock):
+        # When the request URL has no existing query string, the audience must be appended with '?', not '&'.
+        get_mock.return_value = mock.MagicMock(ok=True, json=lambda: {'value': 'fresh_id_token'})
+
+        get_federated_id_token()
+
+        called_url = get_mock.call_args.args[0]
+        assert called_url.startswith('https://github.example/token?audience=')
+        assert '&audience=' not in called_url
 
     @mock.patch.dict(os.environ, {
         'ACTIONS_ID_TOKEN_REQUEST_URL': 'https://github.example/token',

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -9,6 +9,7 @@ import unittest
 from unittest import mock
 
 from azure.cli.core.auth.identity import (Identity, ServicePrincipalAuth, ServicePrincipalStore,
+                                          FEDERATED_IDENTITY, get_federated_id_token,
                                           _get_authority_url)
 from knack.util import CLIError
 
@@ -263,6 +264,26 @@ class TestServicePrincipalAuth(unittest.TestCase):
         client_credential = sp_auth.get_msal_client_credential()
         assert client_credential == {'client_assertion': 'test_jwt'}
 
+    def test_service_principal_auth_federated_identity(self):
+        # The FEDERATED_IDENTITY sentinel is persisted like a normal client_assertion, ...
+        sp_auth = ServicePrincipalAuth.build_from_credential('tenant1', 'sp_id1',
+                                                             {'client_assertion': FEDERATED_IDENTITY})
+        assert sp_auth.client_assertion == FEDERATED_IDENTITY
+
+        # Verify persist entry keeps the sentinel so later processes can rebuild the callback
+        entry = sp_auth.get_entry_to_persist()
+        assert entry == {
+            'client_id': 'sp_id1',
+            'tenant': 'tenant1',
+            'client_assertion': FEDERATED_IDENTITY
+        }
+
+        # ... but get_msal_client_credential resolves the sentinel to the refreshing callback (not a string),
+        # so MSAL fetches a fresh ID token on every acquisition.
+        client_credential = sp_auth.get_msal_client_credential()
+        assert client_credential == {'client_assertion': get_federated_id_token}
+        assert callable(client_credential['client_assertion'])
+
     def test_build_credential(self):
         # client_secret
         cred = ServicePrincipalAuth.build_credential(client_secret="test_secret")
@@ -290,6 +311,48 @@ class TestServicePrincipalAuth(unittest.TestCase):
         # client_assertion
         cred = ServicePrincipalAuth.build_credential(client_assertion="test_jwt")
         assert cred == {"client_assertion": "test_jwt"}
+
+
+class TestFederatedIdentity(unittest.TestCase):
+    """Tests for the OIDC federated-token dispatcher used by 'az login --federated-identity'."""
+
+    @mock.patch.dict(os.environ, {
+        'ACTIONS_ID_TOKEN_REQUEST_URL': 'https://github.example/token?foo=bar',
+        'ACTIONS_ID_TOKEN_REQUEST_TOKEN': 'request_token'
+    }, clear=True)
+    @mock.patch('requests.get')
+    def test_get_federated_id_token_github(self, get_mock):
+        get_mock.return_value = mock.MagicMock(ok=True, json=lambda: {'value': 'fresh_id_token'})
+
+        token = get_federated_id_token()
+
+        assert token == 'fresh_id_token'
+        # The audience is appended to the GitHub-provided request URL and the request token is used as bearer.
+        called_url = get_mock.call_args.args[0]
+        assert called_url.startswith('https://github.example/token?foo=bar&audience=')
+        assert 'api%3A//AzureADTokenExchange' in called_url
+        assert get_mock.call_args.kwargs['headers']['Authorization'] == 'bearer request_token'
+
+    @mock.patch.dict(os.environ, {
+        'ACTIONS_ID_TOKEN_REQUEST_URL': 'https://github.example/token',
+        'ACTIONS_ID_TOKEN_REQUEST_TOKEN': 'request_token'
+    }, clear=True)
+    @mock.patch('requests.get')
+    def test_get_federated_id_token_github_http_error(self, get_mock):
+        get_mock.return_value = mock.MagicMock(ok=False, status_code=403, reason='Forbidden')
+        with self.assertRaisesRegex(CLIError, 'Failed to retrieve an ID token'):
+            get_federated_id_token()
+
+    @mock.patch.dict(os.environ, {'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI': 'https://dev.azure.com/org'}, clear=True)
+    def test_get_federated_id_token_unsupported_provider(self):
+        # Only GitHub Actions is supported for now; any other environment reports the same clear error.
+        with self.assertRaisesRegex(CLIError, 'no supported CI/CD OIDC provider'):
+            get_federated_id_token()
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_get_federated_id_token_no_provider(self):
+        with self.assertRaisesRegex(CLIError, 'no supported CI/CD OIDC provider'):
+            get_federated_id_token()
 
 
 class TestServicePrincipalStore(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -343,9 +343,35 @@ class TestFederatedIdentity(unittest.TestCase):
         with self.assertRaisesRegex(CLIError, 'Failed to retrieve an ID token'):
             get_federated_id_token()
 
+    @mock.patch.dict(os.environ, {
+        'SYSTEM_OIDCREQUESTURI': 'https://vstoken.dev.azure.com/org/',
+        'SYSTEM_ACCESSTOKEN': 'system_access_token',
+        'ARM_OIDC_AZURE_SERVICE_CONNECTION_ID': 'sc-guid'
+    }, clear=True)
+    @mock.patch('requests.post')
+    def test_get_federated_id_token_azure_devops(self, post_mock):
+        post_mock.return_value = mock.MagicMock(ok=True, json=lambda: {'oidcToken': 'ado_id_token'})
+
+        token = get_federated_id_token()
+
+        assert token == 'ado_id_token'
+        called_url = post_mock.call_args.args[0]
+        # Trailing slash on the request URI is trimmed; api-version and service connection are appended.
+        assert called_url == ('https://vstoken.dev.azure.com/org'
+                              '?api-version=7.1&serviceConnectionId=sc-guid')
+        headers = post_mock.call_args.kwargs['headers']
+        assert headers['Authorization'] == 'bearer system_access_token'
+        assert headers['X-TFS-FedAuthRedirect'] == 'Suppress'
+
+    @mock.patch.dict(os.environ, {'SYSTEM_OIDCREQUESTURI': 'https://vstoken.dev.azure.com/org/'}, clear=True)
+    def test_get_federated_id_token_azure_devops_missing_env(self):
+        # Detected as Azure DevOps, but the access token and service connection ID are missing.
+        with self.assertRaisesRegex(CLIError, 'ARM_OIDC_AZURE_SERVICE_CONNECTION_ID'):
+            get_federated_id_token()
+
     @mock.patch.dict(os.environ, {'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI': 'https://dev.azure.com/org'}, clear=True)
     def test_get_federated_id_token_unsupported_provider(self):
-        # Only GitHub Actions is supported for now; any other environment reports the same clear error.
+        # A DevOps collection URI without the OIDC request URI is not enough to attempt a refresh.
         with self.assertRaisesRegex(CLIError, 'no supported CI/CD OIDC provider'):
             get_federated_id_token()
 

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import time
 import unittest
 from unittest import mock
 
@@ -331,6 +332,36 @@ class TestServicePrincipalAuth(unittest.TestCase):
         callback = sp_auth.get_msal_client_credential()['client_assertion']
         with self.assertRaisesRegex(CLIError, 'produced no output'):
             callback()
+
+    def test_federated_token_callback_is_thread_safe(self):
+        # MSAL may invoke the callback concurrently; the command must not run overlapping.
+        import threading
+        concurrent = []
+        active = [0]
+        state_lock = threading.Lock()
+
+        def fake_run(*args, **kwargs):
+            with state_lock:
+                active[0] += 1
+                concurrent.append(active[0])
+            time.sleep(0.02)
+            with state_lock:
+                active[0] -= 1
+            return mock.MagicMock(stdout='tok\n', stderr='')
+
+        sp_auth = ServicePrincipalAuth.build_from_credential(
+            'tenant1', 'sp_id1', {'client_assertion_callback': 'get-token'})
+        callback = sp_auth.get_msal_client_credential()['client_assertion']
+
+        with mock.patch('subprocess.run', side_effect=fake_run):
+            threads = [threading.Thread(target=callback) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # The lock must serialize invocations, so peak concurrency never exceeds 1.
+        assert max(concurrent) == 1, 'callback ran concurrently: peak={}'.format(max(concurrent))
 
     def test_build_credential(self):
         # client_secret

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -284,6 +284,43 @@ class TestServicePrincipalAuth(unittest.TestCase):
         assert client_credential == {'client_assertion': get_federated_id_token}
         assert callable(client_credential['client_assertion'])
 
+    def test_service_principal_auth_federated_token_callback(self):
+        # The callback command is persisted so later `az` processes can rebuild the callable.
+        sp_auth = ServicePrincipalAuth.build_from_credential(
+            'tenant1', 'sp_id1', {'client_assertion_callback': 'my-get-token-command'})
+        assert sp_auth.client_assertion_callback == 'my-get-token-command'
+
+        entry = sp_auth.get_entry_to_persist()
+        assert entry == {
+            'client_id': 'sp_id1',
+            'tenant': 'tenant1',
+            'client_assertion_callback': 'my-get-token-command'
+        }
+
+        # get_msal_client_credential wraps the command as a refreshing callable (not a static string).
+        client_credential = sp_auth.get_msal_client_credential()
+        assert callable(client_credential['client_assertion'])
+
+    @mock.patch('subprocess.run')
+    def test_federated_token_callback_invokes_command(self, run_mock):
+        run_mock.return_value = mock.MagicMock(stdout='fresh_token\n', stderr='')
+        sp_auth = ServicePrincipalAuth.build_from_credential(
+            'tenant1', 'sp_id1', {'client_assertion_callback': 'get-token'})
+        callback = sp_auth.get_msal_client_credential()['client_assertion']
+
+        # The callable runs the user command and returns its trimmed stdout each time MSAL calls it.
+        assert callback() == 'fresh_token'
+        assert run_mock.call_args.args[0] == 'get-token'
+
+    @mock.patch('subprocess.run')
+    def test_federated_token_callback_empty_output(self, run_mock):
+        run_mock.return_value = mock.MagicMock(stdout='   \n', stderr='')
+        sp_auth = ServicePrincipalAuth.build_from_credential(
+            'tenant1', 'sp_id1', {'client_assertion_callback': 'get-token'})
+        callback = sp_auth.get_msal_client_credential()['client_assertion']
+        with self.assertRaisesRegex(CLIError, 'produced no output'):
+            callback()
+
     def test_build_credential(self):
         # client_secret
         cred = ServicePrincipalAuth.build_credential(client_secret="test_secret")
@@ -311,6 +348,10 @@ class TestServicePrincipalAuth(unittest.TestCase):
         # client_assertion
         cred = ServicePrincipalAuth.build_credential(client_assertion="test_jwt")
         assert cred == {"client_assertion": "test_jwt"}
+
+        # client_assertion_callback
+        cred = ServicePrincipalAuth.build_credential(client_assertion_callback="get-token")
+        assert cred == {"client_assertion_callback": "get-token"}
 
 
 class TestFederatedIdentity(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -324,6 +324,15 @@ class TestServicePrincipalAuth(unittest.TestCase):
             sp_auth.get_msal_client_credential()['client_assertion']()
         assert run_mock.call_args.args[0] == ['get-token', ';', 'rm', '-rf', '/']
 
+    def test_federated_token_callback_quoted_argument(self):
+        # A quoted argument containing spaces must reach the program without the surrounding quotes.
+        sp_auth = ServicePrincipalAuth.build_from_credential(
+            'tenant1', 'sp_id1', {'client_assertion_callback': 'mytool --aud "api://x y"'})
+        with mock.patch('subprocess.run') as run_mock:
+            run_mock.return_value = mock.MagicMock(stdout='tok\n', stderr='')
+            sp_auth.get_msal_client_credential()['client_assertion']()
+        assert run_mock.call_args.args[0] == ['mytool', '--aud', 'api://x y']
+
     @mock.patch('subprocess.run')
     def test_federated_token_callback_empty_output(self, run_mock):
         run_mock.return_value = mock.MagicMock(stdout='   \n', stderr='')
@@ -415,6 +424,19 @@ class TestFederatedIdentity(unittest.TestCase):
         assert called_url.startswith('https://github.example/token?foo=bar&audience=')
         assert 'api%3A//AzureADTokenExchange' in called_url
         assert get_mock.call_args.kwargs['headers']['Authorization'] == 'bearer request_token'
+        # A timeout is always passed so a network stall fails fast instead of hanging the CI job.
+        assert get_mock.call_args.kwargs['timeout'] is not None
+
+    @mock.patch.dict(os.environ, {
+        'ACTIONS_ID_TOKEN_REQUEST_URL': 'https://github.example/token',
+        'ACTIONS_ID_TOKEN_REQUEST_TOKEN': 'request_token'
+    }, clear=True)
+    @mock.patch('requests.get')
+    def test_get_federated_id_token_github_timeout(self, get_mock):
+        import requests
+        get_mock.side_effect = requests.exceptions.Timeout()
+        with self.assertRaisesRegex(CLIError, 'Timed out'):
+            get_federated_id_token()
 
     @mock.patch.dict(os.environ, {
         'ACTIONS_ID_TOKEN_REQUEST_URL': 'https://github.example/token',

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -94,9 +94,10 @@ class ProfileCommandsLoader(AzCommandsLoader):
                        options_list=['--federated-token-callback', '--federated-token-cmd'],
                        help='A command that prints a fresh OIDC federated token to stdout. Azure CLI runs it on '
                             'demand to refresh the token, so it works with any CI/CD provider. The command runs '
-                            'without a shell; to use pipes or redirection, point to a script file or wrap it, '
-                            'e.g. "bash -c \'...\'". Cannot be combined with --federated-token or '
-                            '--federated-identity.')
+                            'without a shell (arguments are parsed with POSIX rules; on Windows use forward '
+                            'slashes or escape backslashes). To use pipes or redirection, point to a script '
+                            'file or wrap it, e.g. "bash -c \'...\'". Cannot be combined with --federated-token '
+                            'or --federated-identity.')
 
             # Managed identity
             c.argument('identity', options_list=('-i', '--identity'), action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -90,6 +90,10 @@ class ProfileCommandsLoader(AzCommandsLoader):
                        help='Acquire and automatically refresh the OIDC federated token from the CI/CD provider '
                             '(GitHub Actions or Azure DevOps). Avoids the AADSTS700024 error on long-running '
                             'tasks. Cannot be combined with --federated-token.')
+            c.argument('federated_token_callback', options_list=['--federated-token-callback'],
+                       help='A command that prints a fresh OIDC federated token to stdout. Azure CLI runs it on '
+                            'demand to refresh the token, so it works with any CI/CD provider. Cannot be combined '
+                            'with --federated-token or --federated-identity.')
 
             # Managed identity
             c.argument('identity', options_list=('-i', '--identity'), action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -5,7 +5,7 @@
 
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import CliCommandType
-from azure.cli.core.commands.parameters import get_enum_type
+from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 
 from azure.cli.command_modules.profile._format import transform_account_list
 import azure.cli.command_modules.profile._help  # pylint: disable=unused-import
@@ -86,6 +86,10 @@ class ProfileCommandsLoader(AzCommandsLoader):
                             'certificate rolls.')
             c.argument('client_assertion', options_list=['--federated-token'],
                        help='Federated token that can be used for OIDC token exchange.')
+            c.argument('federated_identity', options_list=['--federated-identity'], arg_type=get_three_state_flag(),
+                       help='Acquire and automatically refresh the OIDC federated token from the CI/CD provider '
+                            '(currently GitHub Actions). Avoids the AADSTS700024 error on long-running tasks. '
+                            'Cannot be combined with --federated-token.')
 
             # Managed identity
             c.argument('identity', options_list=('-i', '--identity'), action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -90,7 +90,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
                        help='Acquire and automatically refresh the OIDC federated token from the CI/CD provider '
                             '(GitHub Actions or Azure DevOps). Avoids the AADSTS700024 error on long-running '
                             'tasks. Cannot be combined with --federated-token or --federated-token-callback.')
-            c.argument('federated_token_callback', options_list=['--federated-token-callback'],
+            c.argument('federated_token_callback',
+                       options_list=['--federated-token-callback', '--federated-token-cmd'],
                        help='A command that prints a fresh OIDC federated token to stdout. Azure CLI runs it on '
                             'demand to refresh the token, so it works with any CI/CD provider. The command runs '
                             'without a shell; to use pipes or redirection, point to a script file or wrap it, '

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -88,8 +88,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
                        help='Federated token that can be used for OIDC token exchange.')
             c.argument('federated_identity', options_list=['--federated-identity'], arg_type=get_three_state_flag(),
                        help='Acquire and automatically refresh the OIDC federated token from the CI/CD provider '
-                            '(currently GitHub Actions). Avoids the AADSTS700024 error on long-running tasks. '
-                            'Cannot be combined with --federated-token.')
+                            '(GitHub Actions or Azure DevOps). Avoids the AADSTS700024 error on long-running '
+                            'tasks. Cannot be combined with --federated-token.')
 
             # Managed identity
             c.argument('identity', options_list=('-i', '--identity'), action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -89,11 +89,13 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('federated_identity', options_list=['--federated-identity'], arg_type=get_three_state_flag(),
                        help='Acquire and automatically refresh the OIDC federated token from the CI/CD provider '
                             '(GitHub Actions or Azure DevOps). Avoids the AADSTS700024 error on long-running '
-                            'tasks. Cannot be combined with --federated-token.')
+                            'tasks. Cannot be combined with --federated-token or --federated-token-callback.')
             c.argument('federated_token_callback', options_list=['--federated-token-callback'],
                        help='A command that prints a fresh OIDC federated token to stdout. Azure CLI runs it on '
-                            'demand to refresh the token, so it works with any CI/CD provider. Cannot be combined '
-                            'with --federated-token or --federated-identity.')
+                            'demand to refresh the token, so it works with any CI/CD provider. The command runs '
+                            'without a shell; to use pipes or redirection, point to a script file or wrap it, '
+                            'e.g. "bash -c \'...\'". Cannot be combined with --federated-token or '
+                            '--federated-identity.')
 
             # Managed identity
             c.argument('identity', options_list=('-i', '--identity'), action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -139,6 +139,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
           use_device_code=False,
           # Service principal
           service_principal=None, certificate=None, use_cert_sn_issuer=None, client_assertion=None,
+          federated_identity=None,
           # Managed identity
           identity=False, client_id=None, object_id=None, resource_id=None,
           # Subscription discovery and default subscription selection control
@@ -157,6 +158,10 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         raise CLIError("usage error: '--use-sn-issuer' is only applicable with a service principal")
     if service_principal and not username:
         raise CLIError('usage error: --service-principal --username NAME --password SECRET --tenant TENANT')
+    if client_assertion and federated_identity:
+        raise CLIError('usage error: Only one of --federated-token and --federated-identity can be specified')
+    if federated_identity and not service_principal:
+        raise CLIError("usage error: '--federated-identity' is only applicable with a service principal")
     if skip_subscription_discovery and not tenant:
         raise CLIError("usage error: '--skip-subscription-discovery' requires '--tenant'")
     if skip_subscription_discovery and subscription:
@@ -188,7 +193,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 
     if username:
-        if not (password or client_assertion or certificate):
+        if not (password or client_assertion or certificate or federated_identity):
             try:
                 password = prompt_pass('Password: ')
             except NoTTYException:
@@ -197,11 +202,11 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         interactive = True
 
     if service_principal:
-        from azure.cli.core.auth.identity import ServicePrincipalAuth
+        from azure.cli.core.auth.identity import ServicePrincipalAuth, FEDERATED_IDENTITY
         password = ServicePrincipalAuth.build_credential(
             client_secret=password,
             certificate=certificate, use_cert_sn_issuer=use_cert_sn_issuer,
-            client_assertion=client_assertion)
+            client_assertion=FEDERATED_IDENTITY if federated_identity else client_assertion)
 
     login_experience_v2 = cmd.cli_ctx.config.getboolean('core', 'login_experience_v2', fallback=True)
     # Send login_experience_v2 config to telemetry

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -139,7 +139,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
           use_device_code=False,
           # Service principal
           service_principal=None, certificate=None, use_cert_sn_issuer=None, client_assertion=None,
-          federated_identity=None,
+          federated_identity=None, federated_token_callback=None,
           # Managed identity
           identity=False, client_id=None, object_id=None, resource_id=None,
           # Subscription discovery and default subscription selection control
@@ -158,10 +158,13 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         raise CLIError("usage error: '--use-sn-issuer' is only applicable with a service principal")
     if service_principal and not username:
         raise CLIError('usage error: --service-principal --username NAME --password SECRET --tenant TENANT')
-    if client_assertion and federated_identity:
-        raise CLIError('usage error: Only one of --federated-token and --federated-identity can be specified')
+    if sum(map(bool, [client_assertion, federated_identity, federated_token_callback])) > 1:
+        raise CLIError('usage error: Only one of --federated-token, --federated-identity and '
+                       '--federated-token-callback can be specified')
     if federated_identity and not service_principal:
         raise CLIError("usage error: '--federated-identity' is only applicable with a service principal")
+    if federated_token_callback and not service_principal:
+        raise CLIError("usage error: '--federated-token-callback' is only applicable with a service principal")
     if skip_subscription_discovery and not tenant:
         raise CLIError("usage error: '--skip-subscription-discovery' requires '--tenant'")
     if skip_subscription_discovery and subscription:
@@ -193,7 +196,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 
     if username:
-        if not (password or client_assertion or certificate or federated_identity):
+        if not (password or client_assertion or certificate or federated_identity or federated_token_callback):
             try:
                 password = prompt_pass('Password: ')
             except NoTTYException:
@@ -206,7 +209,8 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         password = ServicePrincipalAuth.build_credential(
             client_secret=password,
             certificate=certificate, use_cert_sn_issuer=use_cert_sn_issuer,
-            client_assertion=FEDERATED_IDENTITY if federated_identity else client_assertion)
+            client_assertion=FEDERATED_IDENTITY if federated_identity else client_assertion,
+            client_assertion_callback=federated_token_callback)
 
     login_experience_v2 = cmd.cli_ctx.config.getboolean('core', 'login_experience_v2', fallback=True)
     # Send login_experience_v2 config to telemetry

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -157,10 +157,15 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
     if use_cert_sn_issuer and not service_principal:
         raise CLIError("usage error: '--use-sn-issuer' is only applicable with a service principal")
     if service_principal and not username:
-        raise CLIError('usage error: --service-principal --username NAME --password SECRET --tenant TENANT')
+        raise CLIError('usage error: --service-principal --username NAME --tenant TENANT with one credential '
+                       '(--password, --certificate, --federated-token, --federated-identity or '
+                       '--federated-token-callback)')
     if sum(map(bool, [client_assertion, federated_identity, federated_token_callback])) > 1:
         raise CLIError('usage error: Only one of --federated-token, --federated-identity and '
                        '--federated-token-callback can be specified')
+    if (client_assertion or federated_identity or federated_token_callback) and (password or certificate):
+        raise CLIError('usage error: --federated-token, --federated-identity and --federated-token-callback '
+                       'cannot be combined with --password or --certificate')
     if federated_identity and not service_principal:
         raise CLIError("usage error: '--federated-identity' is only applicable with a service principal")
     if federated_token_callback and not service_principal:


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes | Tests |
| :--: | :--: |
| ⚠️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>⚠️AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>⚠️profile</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|login|cmd `login` added parameter `federated_identity`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|login|cmd `login` added parameter `federated_token_callback`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command
`az login`

### Description
Service-principal login with an OIDC federated token currently accepts only a **static**
token via `--federated-token`. That token expires in ~5–10 minutes and cannot be refreshed,
so long-running CI/CD tasks fail with `AADSTS700024: Client assertion is not within its valid
time range` 

This adds automatic, on-demand refresh by registering a **callable** `client_assertion` with
MSAL (the documented, recommended interface). When the access token expires and a new one is
needed, MSAL invokes the callback to fetch a fresh ID token — including in later `az` processes.

Three ways to supply the assertion (mutually exclusive with each other and with
`--password`/`--certificate`):
- `--federated-token <token>` — static token (existing behavior, unchanged).
- `--federated-identity` — auto-detects the CI/CD provider and refreshes the token itself.
  Supports **GitHub Actions** and **Azure DevOps**.
- `--federated-token-callback <command>` (alias `--federated-token-cmd`) — provider-agnostic:
  runs a user-supplied command that prints a fresh token to stdout. Runs without a shell for safety.

### Testing Guide
- Unit tests in `test_identity.py` cover sentinel→callable resolution, GitHub and Azure DevOps
  token fetch (success + error paths), the no-shell callback behavior, and usage validation.
- Manual: run `az login --service-principal -u <id> -t <tenant> --federated-identity` in a
  GitHub Actions (with `id-token: write`) or Azure DevOps (with `System.AccessToken` mapped)
  job and confirm a >10-minute task no longer fails with AADSTS700024.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
