### PR TITLE
[Core] Test: reproduce Red Hat RPM package build failure

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -251,6 +251,7 @@ def logout(cmd, username=None):
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)
 
+    # test
     profile = Profile(cli_ctx=cmd.cli_ctx)
     if not username:
         username = profile.get_current_account_user()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Trivial comment-only change on a branch off `dev`, opened solely to check whether the Red Hat RPM package test failures reproduce independently of any code change.

Context: on #33849 the four `Test Rpm Package` jobs (UBI 8/9, AMD64/ARM64) fail before reaching any Azure CLI code:

```
ImportError: /usr/lib64/python3.12/lib-dynload/pyexpat.cpython-312-aarch64-linux-gnu.so:
undefined symbol: XML_SetBillionLaughsAttackProtectionMaximumAmplification
```

`pip` itself cannot import, which points at an expat ABI mismatch in the UBI base image rather than at the pull request. This PR isolates that.

Do not merge.