### PR TITLE
[Core] Test: reproduce Red Hat RPM package build failure (from fork)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -251,6 +251,7 @@ def logout(cmd, username=None):
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)
 
+    # test
     profile = Profile(cli_ctx=cmd.cli_ctx)
     if not username:
         username = profile.get_current_account_user()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Same trivial comment-only change as #33993, but raised **from a fork** instead of from a branch on Azure/azure-cli.

Purpose: determine whether the Red Hat RPM package test failures depend on where the pull request originates, since fork pull requests run with different pipeline permissions and agent access.

Observed on #33849, in all four `Test Rpm Package` jobs (UBI 8/9, AMD64/ARM64):

```
ImportError: /usr/lib64/python3.12/lib-dynload/pyexpat.cpython-312-aarch64-linux-gnu.so:
undefined symbol: XML_SetBillionLaughsAttackProtectionMaximumAmplification
```

`pip` itself cannot import, which points at an expat ABI mismatch in the UBI base image.

Compare with #33993, which carries an identical change from an upstream branch.

Do not merge.