### PR TITLE
{Packaging} Build release wheels with `python -m build`

### DIFF
--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -50,7 +50,8 @@ WORKDIR azure-cli
 USER ContainerUser
 
 RUN python -m pip install --upgrade pip
-RUN pip install wheel
+# `build` is the PEP 517 frontend used to build the wheels below.
+RUN pip install wheel build
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -65,7 +66,7 @@ foreach($f in $folder) \
 { \
     try { \
         Push-Location $f; \
-        & python.exe setup.py bdist_wheel -d $wheels; \
+        & python.exe -m build --wheel --no-isolation --outdir $wheels; \
     } \
     finally { \
         Pop-Location \

--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -17,8 +17,11 @@ echo "Branch $branch"
 echo "Search setup files from `pwd`."
 python --version
 
-# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources); `python setup.py bdist_wheel` below relies on setup.py.
-pip install -U pip "setuptools<81" wheel
+# Cap setuptools<81: setuptools 82 removes pkg_resources, which azure-cli still declares as a
+# runtime dependency. The builds below go through the PEP 517 frontend, but --no-isolation means
+# they use this setuptools too.
+# `build` is that frontend.
+pip install -U pip "setuptools<81" wheel build
 pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`
@@ -29,7 +32,7 @@ fi
 
 for setup_file in $(find src -name 'setup.py' | grep -v azure-cli-testsdk); do
     pushd `dirname $setup_file`
-    python setup.py bdist_wheel -d $BUILD_STAGINGDIRECTORY
-    python setup.py sdist -d $BUILD_STAGINGDIRECTORY
+    python -m build --wheel --no-isolation --outdir $BUILD_STAGINGDIRECTORY
+    python -m build --sdist --no-isolation --outdir $BUILD_STAGINGDIRECTORY
     popd
 done


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Completes the move off `setup.py` started in #33941, covering the last two call sites: `scripts/release/pypi/build.sh` (the `BuildPythonWheel` job) and `Dockerfile.nanoserver`. `build` is added to both, since neither had it.

`--no-isolation` keeps the existing `setuptools<81` pin in force. `--wheel` and `--sdist` are split because a bare `python -m build` builds the wheel from the sdist, which would make `MANIFEST.in` load-bearing.

Also fixes the `setuptools<81` comment: the pin is held by setuptools 82 dropping `pkg_resources`, not by `setup.py`.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
