### PR TITLE
[Core] Fix #33996: `az network vnet create`: Eagerly import requests during CLI startup to avoid Python 3.14 module-lock deadlock

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -13,8 +13,8 @@ import sys
 # before any background thread can trigger a lazy import.  Python 3.14
 # detects import-lock ordering cycles and raises _DeadlockError when two
 # threads race to initialise the same module; pre-loading avoids the race.
-import msal  # noqa: F401
-import requests  # noqa: F401
+import msal  # noqa: F401  # pylint: disable=unused-import
+import requests  # noqa: F401  # pylint: disable=unused-import
 
 from azure.cli.core._environment import get_config_dir
 from knack.log import get_logger

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -8,6 +8,14 @@ import os
 import re
 import sys
 
+# Eagerly import requests and msal here, on the main thread, so that their
+# submodules (e.g. requests.structures) are fully initialised in sys.modules
+# before any background thread can trigger a lazy import.  Python 3.14
+# detects import-lock ordering cycles and raises _DeadlockError when two
+# threads race to initialise the same module; pre-loading avoids the race.
+import msal  # noqa: F401
+import requests  # noqa: F401
+
 from azure.cli.core._environment import get_config_dir
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli-core/azure/cli/core/tests/test_auth_eager_import.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_auth_eager_import.py
@@ -1,0 +1,80 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+"""Regression test: azure.cli.core.auth.identity must eagerly import requests and msal.
+
+Python 3.14 raises _DeadlockError when two threads race to initialise a module
+whose import-lock ordering creates a cycle (e.g. requests.structures).  The fix
+is to pre-load requests (and msal) on the main thread before any background
+thread can trigger the same import lazily.  This test guards against the eager
+import being removed in the future.
+"""
+
+import sys
+import unittest
+
+# Modules that azure.cli.core.auth.identity must eagerly pre-load.
+_EAGER_MODULES = ('requests', 'requests.structures', 'msal')
+
+# All modules that must be evicted from sys.modules to make the test
+# independent of import order within the test session.
+_EVICT_PREFIXES = (
+    'azure.cli.core.auth',
+    'requests',
+    'msal',
+)
+
+
+def _evict_modules():
+    """Remove all cached copies of identity and the packages it should eagerly load."""
+    for key in list(sys.modules):
+        for prefix in _EVICT_PREFIXES:
+            if key == prefix or key.startswith(prefix + '.'):
+                del sys.modules[key]
+                break
+
+
+class TestEagerImport(unittest.TestCase):
+
+    def setUp(self):
+        # Evict modules so the import inside each test re-executes the module
+        # body, which is the only way to reliably detect a missing eager import.
+        _evict_modules()
+
+    def tearDown(self):
+        # Leave sys.modules clean so other tests are not affected.
+        _evict_modules()
+
+    def test_requests_in_sys_modules_after_identity_import(self):
+        """After importing azure.cli.core.auth.identity, requests must already be
+        present in sys.modules so that no background thread can trigger a lazy
+        import that would race with Python 3.14 per-module import locks."""
+        import azure.cli.core.auth.identity  # noqa: F401
+
+        self.assertIn(
+            'requests',
+            sys.modules,
+            "requests must be eagerly imported by azure.cli.core.auth.identity "
+            "to prevent Python 3.14 module-lock deadlocks in background threads.",
+        )
+        self.assertIn(
+            'requests.structures',
+            sys.modules,
+            "requests.structures must be present in sys.modules after importing "
+            "azure.cli.core.auth.identity.",
+        )
+
+    def test_msal_in_sys_modules_after_identity_import(self):
+        """msal must be eagerly imported by azure.cli.core.auth.identity."""
+        import azure.cli.core.auth.identity  # noqa: F401
+
+        self.assertIn(
+            'msal',
+            sys.modules,
+            "msal must be eagerly imported by azure.cli.core.auth.identity.",
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description
Fixes https://github.com/Azure/azure-cli/issues/33996.

**Related command**
`az network vnet create` (and any command that constructs an MSAL credential)

**Description**

Python 3.14 detects import-lock ordering cycles and raises `_DeadlockError` instead of blocking forever. When `msal` lazily imports `requests` from a background/worker thread while the main thread is mid-import of a transitively-imported submodule (e.g. `requests.structures`), the per-module lock ordering creates a detectable cycle, causing intermittent failures like:

```
ERROR: deadlock detected by _ModuleLock('requests.structures')
```

**Fix:** eagerly `import msal` and `import requests` at module-load time in `azure/cli/core/auth/identity.py`. This guarantees both packages and all their submodules are fully initialised in `sys.modules` on the main thread before any credential-creation code runs on a worker thread, eliminating the race entirely.

**Regression test** added in `tests/test_auth_eager_import.py`: evicts `requests`, `msal`, and `azure.cli.core.auth` from `sys.modules` in `setUp`/`tearDown`, then re-imports `identity` and asserts `requests`, `requests.structures`, and `msal` are all present — ensuring the eager imports cannot be silently removed.

**Testing Guide**

```bash
cd src/azure-cli-core
python -m unittest azure.cli.core.tests.test_auth_eager_import -v
```

**History Notes**

[Core] `az network vnet create`: Fix intermittent Python 3.14 `_DeadlockError` on `requests.structures` by eagerly importing `requests` and `msal` at CLI startup

<!-- azure-client-tools-agent:revision YXp1cmVjbGlib3QuYXp1cmVjci5pby9hZ2VudC1hc3Npc3Q6MC4wLjAtMzQyNTYz -->