### PR TITLE
{AKS} Specify principal type in live-test role assignment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -8353,10 +8353,16 @@ spec:
 
         # role assignment
         assignee_object_id = _get_test_sp_object_id(sp_name)
-        role_assignment_cmd = (
-            'role assignment create --scope {vnet_id} --role "Network Contributor" ' +
-            ("--assignee-object-id " + assignee_object_id) if assignee_object_id else "--assignee {service_principal}"
-        )
+        if assignee_object_id:
+            role_assignment_cmd = (
+                'role assignment create --scope {vnet_id} --role "Network Contributor" '
+                f"--assignee-object-id {assignee_object_id} --assignee-principal-type ServicePrincipal"
+            )
+        else:
+            role_assignment_cmd = (
+                'role assignment create --scope {vnet_id} --role "Network Contributor" '
+                "--assignee {service_principal}"
+            )
         self.cmd(role_assignment_cmd, checks=[
             self.check('scope', vnet_id)
         ])


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
`az role assignment create` in `test_aks_create_with_outbound_type_udr`

**Description**
PIM Only Mode requires persistent role-assignment requests for service principals and managed identities to include `principalType` explicitly.

When the AKS live-test service principal object ID is available, create the Network Contributor assignment with `--assignee-object-id` and `--assignee-principal-type ServicePrincipal`. This avoids relying on Microsoft Graph to infer the principal type. The explicit conditional also preserves the complete role-assignment command in the fallback path.

This is a test-only compliance hardening change; it does not change customer-facing AKS command behavior.

**Testing Guide**
- `flake8 --append-config=.flake8 src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py`
- `python -m pylint --rcfile=pylintrc src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py`
- `python -m py_compile src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py`

The live scenario was not run because it provisions an AKS cluster, Azure Firewall, networking resources, and RBAC assignments.

**History Notes**
None. This change only updates live-test setup.

---

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
