### PR TITLE
[Resource] Amend what-if noise notice to point to Deployment Stacks

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -109,9 +109,8 @@ def format_what_if_operation_result(
 
 def _format_noise_notice(builder):
     builder.append_line(
-        """Note: The result may contain false positive predictions (noise).
-You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
-NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA"""
+        "Note: The result may contain false positive predictions (noise). "
+        "For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA)"
     )
     builder.append_line()
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -112,6 +112,16 @@ class TestFormatJson(unittest.TestCase):
 
 
 class TestFormatWhatIfOperationResult(unittest.TestCase):
+    def test_noise_notice(self):
+        expected = (
+            "Note: The result may contain false positive predictions (noise). "
+            "For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA)"
+        )
+
+        result = format_what_if_operation_result(WhatIfOperationResult(changes=[]), False)
+
+        self.assertTrue(result.startswith(expected))
+
     def test_change_type_legend(self):
         changes = [
             WhatIfChange(


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command

`az deployment group what-if`, `az deployment sub what-if`, `az deployment mg what-if`, `az deployment tenant what-if` (and the what-if preview shown by `--confirm-with-what-if` / `-c` on `az deployment ... create`).

### Description

Replaces #33952, which is now closed. This PR is branched from current `dev` and implements @alex-frankel's review feedback.

### Review feedback being addressed

@alex-frankel, on Azure/azure-powershell#30048 (`Resources.resx`):

> This reads a bit too much like an ad..
>
> Can we only amend what is there:
>
> > Note: The result may contain false positive predictions (noise). For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA)

That feedback was left on the Azure PowerShell PR, but it applies equally here — the two must stay in sync — so it is implemented identically in both.

**What changed as a result:**

- Dropped the separate `NOTICE! - Want to get What-if without noise? Move to ...` line, which was the part that read like an ad.
- Amended the existing `Note:` sentence in place instead of appending a new line, exactly as requested.
- Removed the `https://aka.ms/WhatIfIssues` issue-filing line, so the notice is a single sentence with one next step.
- Adopted @alex-frankel's proposed wording **verbatim**, including the parenthesized bare URL and lowercase `what-if`.

### Before (current `dev`)

```
Note: The result may contain false positive predictions (noise).
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

### After

```
Note: The result may contain false positive predictions (noise). For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA)
```

### Test coverage

The CI agent on #33952 flagged the absence of regression coverage as the one actionable item before merge. This PR adds `TestFormatWhatIfOperationResult.test_noise_notice` in `tests/latest/test_resource_formatters.py`, asserting the rendered what-if output begins with the exact notice string.

Verified locally that the assertion holds and that the pre-existing `test_resource_changes_stats` `endswith(...)` assertion is unaffected, since the notice is emitted at the top of the output.

### Scope / risk

- The only production change is the string literal in `_format_noise_notice` in `src/azure-cli/azure/cli/command_modules/resource/_formatters.py`, reached solely through `format_what_if_operation_result` for **template deployment** what-if.
- Deployment Stacks what-if output is produced by `DeploymentStacksWhatIfResultFormatter` in `_stacks_formatters.py` and is not touched, so customers already on stacks are not told to move to stacks.
- `https://aka.ms/WhatIfIssues` now has no remaining references under `src/`.
- The literal is split across two source lines via implicit concatenation so no source line exceeds the 120-character limit in `pylintrc` / `.flake8`; the rendered output is a single line.
- The final string is byte-identical to the one in the companion Azure PowerShell PR.
