### PR TITLE
{CI} Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/env-setup/action.yml
+++ b/.github/actions/env-setup/action.yml
@@ -12,13 +12,13 @@ runs:
       run: |
         echo start azdev env setup
     - name: Checkout CLI repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0 # checkout all branches
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}  # checkout pull request branch
     - name: Set up Python 3.12
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
       with:
         python-version: "3.12"
     - name: Install azdev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/AddIssueComment.yml
+++ b/.github/workflows/AddIssueComment.yml
@@ -10,7 +10,7 @@ jobs:
     name: Say thanks for the Issue
     steps:
       - name: comment on the issue
-        uses: hasura/comment-progress@v2.3.0
+        uses: hasura/comment-progress@146c635f3e325d478025e29e5043ec1c07c0e36c # v2.3.0
         with:
           github-token: ${{ secrets.CLI_BOT }}
           repository: 'Azure/azure-cli'

--- a/.github/workflows/AddIssueCommentWithLabel.yml
+++ b/.github/workflows/AddIssueCommentWithLabel.yml
@@ -12,12 +12,12 @@ jobs:
     name: Comment on issue
     steps:
       - name: Checkout comment message
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           sparse-checkout: |
             .github/template/non-security-comment.md
       - name: Comment on issue with no security label
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
            repo-token: ${{ secrets.GITHUB_TOKEN }}
            message-id: issueNoSecurityCommentBot

--- a/.github/workflows/AzdevLinter.yml
+++ b/.github/workflows/AzdevLinter.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout CLI repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/AzdevStyle.yml
+++ b/.github/workflows/AzdevStyle.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout CLI repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/BlockPRMerge.yml
+++ b/.github/workflows/BlockPRMerge.yml
@@ -15,7 +15,7 @@ jobs:
     permissions: {}
     steps:
       - name: Check blocked labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(label => label.name);

--- a/.github/workflows/CCOA.yml
+++ b/.github/workflows/CCOA.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.date_check.outputs.continue == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/GitHookNotice.yml
+++ b/.github/workflows/GitHookNotice.yml
@@ -15,7 +15,7 @@ jobs:
     name: Introduce git hook in developer env
     steps:
       - name: Checkout git hook notice message
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           sparse-checkout: |
             .github/template/git-hooks-note.md

--- a/.github/workflows/RunIssueSentinel.yml
+++ b/.github/workflows/RunIssueSentinel.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Issue Sentinel
-        uses: Azure/issue-sentinel@v1
+        uses: Azure/issue-sentinel@d1e433f192aa9442d44292b9b6d5d31419639aba # v1.6.1
         with:
           enable-similar-issues-scanning: true
           enable-security-issues-scanning: true

--- a/.github/workflows/TriggerReferenceDocsCI.yml
+++ b/.github/workflows/TriggerReferenceDocsCI.yml
@@ -14,7 +14,7 @@ jobs:
     environment: docs
     steps:
     - name: Azure Login
-      uses: Azure/login@v2.1.0
+      uses: Azure/login@6b2456866fc08b011acb422a92a4aa20e2c4de32 # v2.1.0
       with:
         client-id: ${{ secrets.ADO_DocsReference_SP_ClientID }}
         tenant-id: ${{ secrets.ADO_DocsReference_SP_TenantID }}


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
