### PR TITLE
[Resource] Fix #34004: `az resource wait`: Raise CLIError on timeout instead of returning it

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -458,7 +458,7 @@ class WaitCommandOperation(BaseCommandOperation):
             time.sleep(interval)
 
         progress_indicator.end()
-        return CLIError('Wait operation timed-out after {} seconds'.format(timeout))
+        raise CLIError('Wait operation timed-out after {} seconds'.format(timeout))
 
     @staticmethod
     def _get_provisioning_state(instance):

--- a/src/azure-cli-core/azure/cli/core/tests/test_wait_command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_wait_command_operation.py
@@ -1,0 +1,63 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+
+from knack.util import CLIError
+
+from azure.cli.core.commands.command_operation import WaitCommandOperation
+from azure.cli.core.mock import DummyCli
+
+
+class TestWaitCommandOperationTimeout(unittest.TestCase):
+
+    def test_wait_raises_on_timeout(self):
+        """wait() should raise CLIError on timeout, not return it."""
+        cli_ctx = DummyCli()
+
+        # A getter that always returns an instance with no satisfied condition
+        instance = mock.MagicMock()
+        instance.provisioning_state = None
+        getter = mock.MagicMock(return_value=instance)
+
+        command_args = {
+            'timeout': 1,
+            'interval': 1,
+            'created': False,
+            'deleted': False,
+            'updated': False,
+            'exists': False,
+            'custom': 'nonExistentProperty',
+        }
+
+        with self.assertRaises(CLIError) as ctx:
+            WaitCommandOperation.wait(command_args, cli_ctx=cli_ctx, getter=getter)
+
+        self.assertIn('timed-out', str(ctx.exception))
+
+    def test_wait_returns_none_on_success(self):
+        """wait() should return None when the condition is satisfied."""
+        cli_ctx = DummyCli()
+
+        # exists=True causes immediate return without inspecting provisioning_state
+        getter = mock.MagicMock(return_value=mock.MagicMock())
+
+        command_args = {
+            'timeout': 30,
+            'interval': 1,
+            'created': False,
+            'deleted': False,
+            'updated': False,
+            'exists': True,
+            'custom': None,
+        }
+
+        result = WaitCommandOperation.wait(command_args, cli_ctx=cli_ctx, getter=getter)
+        self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
Fixes https://github.com/Azure/azure-cli/issues/34004.

**Related command**
`az resource wait` (and all subcommands sharing `WaitCommandOperation`)

**Description**

`WaitCommandOperation.wait` was using `return CLIError(...)` on timeout instead of `raise CLIError(...)`. The return value was silently discarded by callers, causing timed-out waits to exit with code 0 and no error output — indistinguishable from success.

- **`command_operation.py`**: `return CLIError(...)` → `raise CLIError(...)` at timeout path
- **`test_wait_command_operation.py`** (new): unit tests asserting `CLIError` is raised on timeout and `None` is returned on success

**Testing Guide**

```bash
# Timeout path — previously exited 0 with no output, now raises CLIError
az resource wait --ids <resource-id> --custom "nonExistentProperty=='value'" --timeout 5
# Expected: CLIError: Wait operation timed-out after 5 seconds (exit code 1)
```

Unit tests added to `src/azure-cli-core/azure/cli/core/tests/test_wait_command_operation.py`.

**History Notes**

[Core] `az resource wait`: Fix timeout path to raise `CLIError` instead of silently returning it

<!-- azure-client-tools-agent:revision YXp1cmVjbGlib3QuYXp1cmVjci5pby9hZ2VudC1hc3Npc3Q6MC4xLjAtMzQzNTg4 -->