### PR TITLE
{AKS} Add force-location override for live tests

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/custom_preparers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/custom_preparers.py
@@ -18,6 +18,9 @@ from azure.cli.testsdk.utilities import GraphClientPasswordReplacer
 from azure.cli.command_modules.acs.tests.latest.recording_processors import MOCK_GUID, MOCK_SECRET
 
 
+ENV_VAR_FORCE_RESOURCE_GROUP_LOCATION = "AZURE_CLI_TEST_FORCE_RESOURCE_GROUP_LOCATION"
+
+
 def _normalize_optional_live_test_setting(value):
     if value is None:
         return None
@@ -55,9 +58,16 @@ class AKSCustomResourceGroupPreparer(ResourceGroupPreparer):
             key,
         )
 
-        # use environment variable to modify the default value of location
+        # A force location is used by managed live-test environments that must
+        # keep every resource group in one compliance-approved region.
+        force_location = _normalize_optional_live_test_setting(
+            os.environ.get(ENV_VAR_FORCE_RESOURCE_GROUP_LOCATION)
+        )
         self.dev_setting_location = os.environ.get(dev_setting_location, None)
-        if not preserve_default_location and self.dev_setting_location:
+        if force_location:
+            self.location = force_location
+            self.dev_setting_location = force_location
+        elif not preserve_default_location and self.dev_setting_location:
             self.location = self.dev_setting_location
         else:
             self.dev_setting_location = location

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom_preparers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom_preparers.py
@@ -8,7 +8,9 @@ import unittest
 from unittest.mock import patch
 
 from azure.cli.command_modules.acs.tests.latest.custom_preparers import (
+    AKSCustomResourceGroupPreparer,
     AKSCustomRoleBasedServicePrincipalPreparer,
+    ENV_VAR_FORCE_RESOURCE_GROUP_LOCATION,
     _normalize_optional_live_test_setting,
 )
 
@@ -38,6 +40,53 @@ class TestNormalizeOptionalLiveTestSetting(unittest.TestCase):
 
         skipped_test_case = preparer(test_case)
         self.assertTrue(skipped_test_case.__unittest_skip__)
+
+
+class TestAKSCustomResourceGroupPreparer(unittest.TestCase):
+
+    def _create_preparer(self, preserve_default_location):
+        return AKSCustomResourceGroupPreparer(
+            location="westus2",
+            preserve_default_location=preserve_default_location,
+        )
+
+    @patch.dict(os.environ, {
+        "AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION": "eastus",
+    }, clear=True)
+    def test_default_location_override_is_used(self):
+        preparer = self._create_preparer(preserve_default_location=False)
+
+        self.assertEqual(preparer.location, "eastus")
+        self.assertEqual(preparer.dev_setting_location, "eastus")
+
+    @patch.dict(os.environ, {
+        "AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION": "eastus",
+    }, clear=True)
+    def test_preserved_location_wins_over_default_override(self):
+        preparer = self._create_preparer(preserve_default_location=True)
+
+        self.assertEqual(preparer.location, "westus2")
+        self.assertEqual(preparer.dev_setting_location, "westus2")
+
+    @patch.dict(os.environ, {
+        ENV_VAR_FORCE_RESOURCE_GROUP_LOCATION: "westcentralus",
+        "AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION": "eastus",
+    }, clear=True)
+    def test_force_location_wins_over_default_override(self):
+        preparer = self._create_preparer(preserve_default_location=False)
+
+        self.assertEqual(preparer.location, "westcentralus")
+        self.assertEqual(preparer.dev_setting_location, "westcentralus")
+
+    @patch.dict(os.environ, {
+        ENV_VAR_FORCE_RESOURCE_GROUP_LOCATION: "westcentralus",
+        "AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION": "eastus",
+    }, clear=True)
+    def test_force_location_wins_over_preserved_location(self):
+        preparer = self._create_preparer(preserve_default_location=True)
+
+        self.assertEqual(preparer.location, "westcentralus")
+        self.assertEqual(preparer.dev_setting_location, "westcentralus")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ❌ 1 | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Failed" summary="1" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>❌AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>❌backup</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |backup restore restore-azurefileshare|cmd `backup restore restore-azurefileshare` removed parameter `use_secondary_region`|please add back parameter `use_secondary_region` for cmd `backup restore restore-azurefileshare`|
>
></details>
</details>


**Please submit your Breaking Change Pre-announcement ASAP** if you haven't already. Please note:

- Breaking changes can **only** be merged during the designated breaking change window
- A pre-announcement **must** be released at least one month in advance

> For more details on how to introduce breaking changes, refer to the documentation: [azure-cli/doc/how_to_introduce_breaking_changes.md](https://github.com/Azure/azure-cli/blob/dev/doc/how_to_introduce_breaking_changes.md)
<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

`az aks create`

**Description**

Adds `AZURE_CLI_TEST_FORCE_RESOURCE_GROUP_LOCATION` to the AKS custom resource-group preparer. When set, the force location takes precedence over both `AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION` and `preserve_default_location=True`. When unset, existing live-test behavior is unchanged.

This resolves an internal issue in a managed live-test environment that needs to keep all AKS test resources in one configured region.

**Testing Guide**

```sh
PYTHONPATH=src/azure-cli:src/azure-cli-core:src/azure-cli-testsdk \
  python -m unittest azure.cli.command_modules.acs.tests.latest.test_custom_preparers
```

All 7 tests pass, including the four default, preserved, and forced-location precedence combinations.

**History Notes**

---

- [x] The PR title and description have followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).