### PR TITLE
{MySQL} Set default value of `auto_scale_iops` to 'Enabled'

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_params.py
@@ -391,7 +391,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         c.argument('version', arg_type=version_arg_type)
         c.argument('iops', arg_type=iops_arg_type)
         c.argument('auto_grow', arg_type=auto_grow_arg_type)
-        c.argument('auto_scale_iops', default='Disabled', arg_type=auto_scale_iops_arg_type)
+        c.argument('auto_scale_iops', default='Enabled', arg_type=auto_scale_iops_arg_type)
         c.argument('backup_retention', arg_type=mysql_backup_retention_arg_type)
         c.argument('backup_byok_identity', arg_type=backup_identity_arg_type)
         c.argument('backup_byok_key', arg_type=backup_key_arg_type)


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ❌ 1 | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Failed" summary="1" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>❌AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>❌mysql</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md) |mysql flexible-server import create|cmd `mysql flexible-server import create` update parameter `auto_scale_iops`: updated property `default` from `Disabled` to `Enabled`|please change property `default` from `Enabled` to `Disabled` for parameter `auto_scale_iops` of cmd `mysql flexible-server import create`|
>
></details>
</details>


**Please submit your Breaking Change Pre-announcement ASAP** if you haven't already. Please note:

- Breaking changes can **only** be merged during the designated breaking change window
- A pre-announcement **must** be released at least one month in advance

> For more details on how to introduce breaking changes, refer to the documentation: [azure-cli/doc/how_to_introduce_breaking_changes.md](https://github.com/Azure/azure-cli/blob/dev/doc/how_to_introduce_breaking_changes.md)
<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az mysql flexible-server import --help`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Addressing #32568.
The issue was introduced in #30852 where the `CLIArgumentType` was left unchanged when the breaking default value changes happened

**Testing Guide**
<!--Example commands with explanations.-->

```
python -m azure.cli mysql flexible-server import create --help 2>&1 |    Select-String -Pattern '--auto-scale-iops' -Context 0,3

>     --auto-scale-iops              : Enable or disable the auto scale iops. Default value is
                                       Enabled.  Allowed values: Disabled, Enabled.  Default: Enabled.
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
