### PR TITLE
{MySQL} Update advanced threat protection payload structure to use pr…

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -47,7 +47,9 @@ def flexible_server_advanced_threat_protection_update(cmd, client, resource_grou
     Updates an advanced threat protection setting. Custom update function to apply parameters to instance.
     '''
     parameters = {
-        'state': state
+        'properties': {
+            'state': state
+        }
     }
     return client.begin_update(resource_group_name, server_name, models.AdvancedThreatProtectionName.DEFAULT.value, parameters)
 

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_custom.py
@@ -34,12 +34,44 @@ class MysqlFlexibleServerFirewallRuleCustomTest(unittest.TestCase):
         }, client.parameters.as_dict())
 
 
+class MysqlFlexibleServerAdvancedThreatProtectionCustomTest(unittest.TestCase):
+
+    def test_update_uses_properties_payload(self):
+        client = _FakeAdvancedThreatProtectionClient()
+
+        custom.flexible_server_advanced_threat_protection_update(
+            cmd=None,
+            client=client,
+            resource_group_name='rg',
+            server_name='server',
+            state='Enabled')
+
+        self.assertEqual('rg', client.resource_group_name)
+        self.assertEqual('server', client.server_name)
+        self.assertEqual('Default', client.advanced_threat_protection_name)
+        self.assertEqual({
+            'properties': {
+                'state': 'Enabled'
+            }
+        }, client.parameters)
+
+
 class _FakeFirewallRulesClient:
 
     def begin_create_or_update(self, resource_group_name, server_name, firewall_rule_name, parameters):
         self.resource_group_name = resource_group_name
         self.server_name = server_name
         self.firewall_rule_name = firewall_rule_name
+        self.parameters = parameters
+        return parameters
+
+
+class _FakeAdvancedThreatProtectionClient:
+
+    def begin_update(self, resource_group_name, server_name, advanced_threat_protection_name, parameters):
+        self.resource_group_name = resource_group_name
+        self.server_name = server_name
+        self.advanced_threat_protection_name = advanced_threat_protection_name
         self.parameters = parameters
         return parameters
 


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

…operties object

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az mysql flexible-server advanced-threat-protection-setting update --state`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Addressing #33836.

The issue was introduced in #33774 when payload structure changed but ATP command still passes a flat dictionary
```
{"state": "Enabled"}

```

The new b2 SDK schema-serialized that dictionary into the required ARM shape:

```
{"properties": {"state": "Enabled"}}
```


**Testing Guide**
<!--Example commands with explanations.-->

````
azdev test test_mysql_custom --series
````

```
az mysql flexible-server advanced-threat-protection-setting update -g xxxxx -n xxxxxx --state Enabled --debug
```



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
