### PR TITLE
[MySQL] `az mysql flexible-server upgrade`: Fix deserialization problem

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -321,7 +321,7 @@ def flexible_server_version_upgrade(cmd, client, resource_group_name, server_nam
                            "First upgrade {} server version to {} and try again.".format(replica.name, version_mapped))
 
     parameters = {
-        'version': version_mapped
+        'properties': {'version': version_mapped}
     }
 
     return resolve_poller(


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Passing yes to command will cause below error 

az mysql flexible-server upgrade --name meru8upto --resource-group lab --version 8.4 --yes (InvalidRequestContent) The request content was invalid and could not be deserialized: 'Could not find member 'version' on object of type 'ResourceDefinition'. Path 'version', line 1, position 16.'. Code: InvalidRequestContent
Message: The request content was invalid and could not be deserialized: 'Could not find member 'version' on object of type 'ResourceDefinition'. Path 'version', line 1, position 16.'.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
