### PR TITLE
{SQL} `az sql midb ltr-policy/ltr-backup`: Remove preview status

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -974,8 +974,8 @@ def load_command_table(self, _):
                             managed_database_long_term_retention_policies_operations,
                             client_factory=get_sql_managed_database_long_term_retention_policies_operations) as g:
 
-        g.custom_command('set', 'update_long_term_retention_mi', is_preview=True)
-        g.custom_show_command('show', 'get_long_term_retention_mi', is_preview=True)
+        g.custom_command('set', 'update_long_term_retention_mi')
+        g.custom_show_command('show', 'get_long_term_retention_mi')
 
     managed_database_long_term_retention_backups_operations = CliCommandType(
         operations_tmpl='azure.mgmt.sql.operations#LongTermRetentionManagedInstanceBackupsOperations.{}',
@@ -984,11 +984,11 @@ def load_command_table(self, _):
     with self.command_group('sql midb ltr-backup',
                             managed_database_long_term_retention_backups_operations,
                             client_factory=get_sql_managed_database_long_term_retention_backups_operations) as g:
-        g.custom_show_command('show', 'get_long_term_retention_mi_backup', is_preview=True)
+        g.custom_show_command('show', 'get_long_term_retention_mi_backup')
         g.custom_command(
             'list',
-            'list_long_term_retention_mi_backups', is_preview=True)
-        g.custom_command('delete', 'delete_long_term_retention_mi_backup', confirmation=True, is_preview=True)
+            'list_long_term_retention_mi_backups')
+        g.custom_command('delete', 'delete_long_term_retention_mi_backup', confirmation=True)
 
     with self.command_group('sql midb ltr-backup',
                             managed_databases_operations,
@@ -996,8 +996,7 @@ def load_command_table(self, _):
         g.custom_command(
             'restore',
             'restore_long_term_retention_mi_backup',
-            supports_no_wait=True,
-            is_preview=True)
+            supports_no_wait=True)
         g.wait_command('wait')
 
     with self.command_group('sql midb log-replay',


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes | Tests |
| :--: | :--: |
| ⚠️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>⚠️AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>⚠️sql</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1004 - CmdPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1004.md)|sql midb ltr-backup delete|cmd `sql midb ltr-backup delete` removed property `is_preview`||
>|⚠️ [1004 - CmdPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1004.md)|sql midb ltr-backup list|cmd `sql midb ltr-backup list` removed property `is_preview`||
>|⚠️ [1004 - CmdPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1004.md)|sql midb ltr-backup restore|cmd `sql midb ltr-backup restore` removed property `is_preview`||
>|⚠️ [1004 - CmdPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1004.md)|sql midb ltr-backup show|cmd `sql midb ltr-backup show` removed property `is_preview`||
>|⚠️ [1004 - CmdPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1004.md)|sql midb ltr-policy set|cmd `sql midb ltr-policy set` removed property `is_preview`||
>|⚠️ [1004 - CmdPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1004.md)|sql midb ltr-policy show|cmd `sql midb ltr-policy show` removed property `is_preview`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

`az sql midb ltr-policy set`
`az sql midb ltr-policy show`
`az sql midb ltr-backup show`
`az sql midb ltr-backup list`
`az sql midb ltr-backup delete`
`az sql midb ltr-backup restore`

**Description**

Remove the preview status from Azure SQL Managed Instance long-term retention policy and backup commands. These commands no longer display the preview warning when invoked.

Related work item: https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/3093099/

**Testing Guide**

Passed local no-build validation in the PR checkout:

- Used a PowerShell source-metadata check to verify stable command registrations for:
  - `az sql midb ltr-policy set`
  - `az sql midb ltr-policy show`
  - `az sql midb ltr-backup show`
  - `az sql midb ltr-backup list`
  - `az sql midb ltr-backup delete`
  - `az sql midb ltr-backup restore`
- Confirmed no `is_preview` metadata remains in the Managed Instance LTR command registration region.
- `git diff --check HEAD^ HEAD` passed with no whitespace errors.

Not run: package build or live invocation using a locally installed development CLI.

---
- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).