### PR TITLE
[Network] Fix #33981: `az network application-gateway show`: Bump parent Application Gateway API version to 2025-07-01 so Managed HSM SSL certificate fields are preserved

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_create.py
@@ -16,9 +16,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-10-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2024-10-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -1651,7 +1651,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -3268,6 +3268,7 @@ class Create(AAZCommand):
 
             properties = cls._schema_on_200_201.properties.ssl_certificates.Element.properties
             properties.data = AAZStrType()
+            properties.hsm = AAZObjectType()
             properties.key_vault_secret_id = AAZStrType(
                 serialized_name="keyVaultSecretId",
             )
@@ -3279,6 +3280,14 @@ class Create(AAZCommand):
             properties.public_cert_data = AAZStrType(
                 serialized_name="publicCertData",
                 flags={"read_only": True},
+            )
+
+            hsm = cls._schema_on_200_201.properties.ssl_certificates.Element.properties.hsm
+            hsm.key_id = AAZStrType(
+                serialized_name="keyId",
+            )
+            hsm.public_cert_data = AAZStrType(
+                serialized_name="publicCertData",
             )
 
             ssl_profiles = cls._schema_on_200_201.properties.ssl_profiles

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_show.py
@@ -19,9 +19,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-10-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2024-10-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -117,7 +117,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -1062,6 +1062,7 @@ class Show(AAZCommand):
 
             properties = cls._schema_on_200.properties.ssl_certificates.Element.properties
             properties.data = AAZStrType()
+            properties.hsm = AAZObjectType()
             properties.key_vault_secret_id = AAZStrType(
                 serialized_name="keyVaultSecretId",
             )
@@ -1073,6 +1074,14 @@ class Show(AAZCommand):
             properties.public_cert_data = AAZStrType(
                 serialized_name="publicCertData",
                 flags={"read_only": True},
+            )
+
+            hsm = cls._schema_on_200.properties.ssl_certificates.Element.properties.hsm
+            hsm.key_id = AAZStrType(
+                serialized_name="keyId",
+            )
+            hsm.public_cert_data = AAZStrType(
+                serialized_name="publicCertData",
             )
 
             ssl_profiles = cls._schema_on_200.properties.ssl_profiles

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/_update.py
@@ -19,9 +19,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-10-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2024-10-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -452,7 +452,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -551,7 +551,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-10-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -1864,6 +1864,7 @@ class _UpdateHelper:
 
         properties = _schema_application_gateway_read.properties.ssl_certificates.Element.properties
         properties.data = AAZStrType()
+        properties.hsm = AAZObjectType()
         properties.key_vault_secret_id = AAZStrType(
             serialized_name="keyVaultSecretId",
         )
@@ -1875,6 +1876,14 @@ class _UpdateHelper:
         properties.public_cert_data = AAZStrType(
             serialized_name="publicCertData",
             flags={"read_only": True},
+        )
+
+        hsm = _schema_application_gateway_read.properties.ssl_certificates.Element.properties.hsm
+        hsm.key_id = AAZStrType(
+            serialized_name="keyId",
+        )
+        hsm.public_cert_data = AAZStrType(
+            serialized_name="publicCertData",
         )
 
         ssl_profiles = _schema_application_gateway_read.properties.ssl_profiles

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
@@ -125,5 +125,51 @@ class TestVpnConnectionCertAuthNoSharedKey(unittest.TestCase):
         self.assertIn('--shared-key is required', str(ctx.exception))
 
 
+    def test_application_gateway_parent_api_version(self):
+        """Parent application-gateway operations must use API version 2025-07-01 so that
+        Managed HSM SSL certificate fields (hsm.keyId / hsm.publicCertData) are preserved."""
+        from azure.cli.command_modules.network.aaz.latest.network.application_gateway import _show, _create, _update
+
+        for module, name in [(_show, "Show"), (_create, "Create"), (_update, "Update")]:
+            cls = getattr(module, name)
+            self.assertEqual(
+                cls._aaz_info["version"],
+                "2025-07-01",
+                msg=f"application-gateway {name}._aaz_info['version'] must be 2025-07-01",
+            )
+            for resource in cls._aaz_info["resources"]:
+                self.assertEqual(
+                    resource[-1],
+                    "2025-07-01",
+                    msg=f"application-gateway {name} resources entry must reference 2025-07-01",
+                )
+
+    def test_application_gateway_show_ssl_cert_hsm_schema(self):
+        """The parent application-gateway show response schema must include the
+        sslCertificates[].properties.hsm object with keyId and publicCertData."""
+        from azure.cli.command_modules.network.aaz.latest.network.application_gateway._show import Show
+
+        inner_cls = Show.ApplicationGatewaysGet
+        inner_cls._build_schema_on_200()
+        ssl_cert_props = inner_cls._schema_on_200.properties.ssl_certificates.Element.properties
+        fields = ssl_cert_props._fields
+        self.assertIn(
+            "hsm",
+            fields,
+            "ssl_certificates.Element.properties must contain 'hsm'",
+        )
+        hsm_fields = fields["hsm"]._fields
+        self.assertIn(
+            "key_id",
+            hsm_fields,
+            "ssl_certificates.Element.properties.hsm must contain 'key_id'",
+        )
+        self.assertIn(
+            "public_cert_data",
+            hsm_fields,
+            "ssl_certificates.Element.properties.hsm must contain 'public_cert_data'",
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Fixes https://github.com/Azure/azure-cli/issues/33981.

**Related command**
`az network application-gateway show` / `az network application-gateway create` / `az network application-gateway update`

**Description**

The parent `application_gateway` AAZ operations (`show`, `create`, `update`) were using API version `2024-10-01`, while the `ssl_cert` sub-group already used `2025-07-01`. This mismatch caused `sslCertificates[].properties.hsm.keyId` and `hsm.publicCertData` (Managed HSM–backed certificate fields, introduced in `2025-07-01`) to be silently dropped on any GET or PUT round-trip through the parent resource.

- **`_show.py` / `_create.py` / `_update.py`**: Bumped `_aaz_info["version"]`, the resources entry, and all `api-version` query parameters from `2024-10-01` → `2025-07-01`.
- **Response schema** (`_show.py`, `_create.py`, `_update.py`): Added `sslCertificates[].properties.hsm` (`AAZObjectType`) with `hsm.key_id` (`keyId`) and `hsm.public_cert_data` (`publicCertData`) to match the schema already present in the `ssl_cert` sub-group.

**Testing Guide**

New unit tests in `test_network_unit_tests.py`:

- `test_application_gateway_parent_api_version` — asserts all three operations declare `2025-07-01` in `_aaz_info` and resources.
- `test_application_gateway_show_ssl_cert_hsm_schema` — introspects the built `ApplicationGatewaysGet` response schema at runtime, asserting `hsm`, `key_id`, and `public_cert_data` are present under `ssl_certificates.Element.properties`.

**History Notes**

[Network] `az network application-gateway show`: Bump API version to 2025-07-01 so Managed HSM SSL certificate fields (`hsm.keyId` / `hsm.publicCertData`) are preserved on show/create/update

## Generation source
https://github.com/Azure/aaz/pull/1071

## Generation source
https://github.com/Azure/aaz/pull/1071

<!-- azure-client-tools-agent:revision YXp1cmVjbGlib3QuYXp1cmVjci5pby94LWVuZ2luZWVyaW5nLWFnZW50LXdvcmtlcjowLjEuMC0zNDU0NDY= -->