### PR TITLE
[Core] Remove AzureGermanCloud from hard-coded cloud list

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -519,7 +519,7 @@ AZURE_BLEU_CLOUD = Cloud(
         mariadb_server_endpoint='.mariadb.database.sovcloud-api.fr',
         synapse_analytics_endpoint='.dev.azuresynapse.sovcloud-api.fr'))
 
-HARD_CODED_CLOUD_LIST = [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_GERMAN_CLOUD, AZURE_BLEU_CLOUD]
+HARD_CODED_CLOUD_LIST = [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_BLEU_CLOUD]
 
 
 def retrieve_arm_cloud_metadata():

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -223,8 +223,8 @@ class TestCloud(unittest.TestCase):
     @mock.patch('azure.cli.core.cloud._set_active_subscription', autospec=True)
     def test_switch_active_cloud(self, subscription_setter):
         cli = mock.MagicMock()
-        switch_active_cloud(cli, 'AzureGermanCloud')
-        self.assertEqual(cli.cloud.name, 'AzureGermanCloud')
+        switch_active_cloud(cli, 'AzureUSGovernment')
+        self.assertEqual(cli.cloud.name, 'AzureUSGovernment')
 
         switch_active_cloud(cli, 'AzureChinaCloud')
         self.assertEqual(cli.cloud.name, 'AzureChinaCloud')


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

Azure Germany has been closed. This PR removes the `AzureGermanCloud` entry from the hard-coded cloud list in `cloud.py`:

- Removed `AzureGermanCloud` from `CloudNameEnum`
- Removed the `AZURE_GERMAN_CLOUD` `Cloud` definition
- Removed it from `HARD_CODED_CLOUD_LIST`
- Updated `test_switch_active_cloud` to use `AzureUSGovernment` instead of the removed `AzureGermanCloud`

## Testing

`test_cloud.py` passes (14 passed, 1 skipped).