### PR TITLE
{Compute} az vmss/vm: Update Open Capacity Reservation validation logic

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -2832,7 +2832,7 @@ def validate_edge_zone(cmd, namespace):  # pylint: disable=unused-argument
 
 def _validate_capacity_reservation_group(cmd, namespace):
     if getattr(namespace, 'capacity_reservation_group', None) is not None and \
-            getattr(namespace, 'disable_capacity_reservation_assignment', None) is not None:
+            getattr(namespace, 'disable_capacity_reservation_assignment', None) is True:
         raise MutuallyExclusiveArgumentError(
             "You can only specify one of --capacity-reservation-group and "
             "--disable-capacity-reservation-assignment")


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az vm create/update`
`az vmss create/update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Current validation:
Not allow `--capacity-reservation-group` + `--disable-capacity-reservation-assignment`

Change:
Only allow `--capacity-reservation-group` + `--disable-capacity-reservation-assignment False`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
