### PR TITLE
{Docs} Fix extension installation command in documentation

### DIFF
--- a/doc/extensions/README.md
+++ b/doc/extensions/README.md
@@ -28,7 +28,7 @@ How to find and install an Extension
 
 - List all available extensions: `az extension list-available`
 
-- Install an extension: `az extension install --name <extension-name>`
+- Install an extension: `az extension add --name <extension-name>`
 
 More details on usage in [Extensions for Azure CLI 2.0](https://learn.microsoft.com/cli/azure/azure-cli-extensions-overview#install-extensions)
 


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

Correct the extension installation example to use the supported `az extension add` command instead of the invalid `az extension install` command. The `install` command does not exist per the help message:

```
>az extension --help

Group
    az extension : Manage and update CLI extensions.

Commands:
    add            : Add an extension.
    list           : List the installed extensions.
    list-available : List publicly available extensions.
    list-versions  : List available versions for an extension.
    remove         : Remove an extension.
    show           : Show an extension.
    update         : Update an extension.
```