### PR TITLE
[Containerapp] az containerapp logs show: Use replica log stream endpoint

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -68,7 +68,6 @@ Release History
 **Container app**
 
 * `az containerapp job update`: Fix crash for `--no-wait` parameter (#33807)
-* `az containerapp logs show`: Use the replica log stream endpoint for console logs
 
 **Key Vault**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -68,6 +68,7 @@ Release History
 **Container app**
 
 * `az containerapp job update`: Fix crash for `--no-wait` parameter (#33807)
+* `az containerapp logs show`: Use the replica log stream endpoint for console logs
 
 **Key Vault**
 

--- a/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
@@ -3573,18 +3573,20 @@ def stream_containerapp_logs(cmd, resource_group_name, name, container=None, rev
         if output_format and output_format != "json":
             raise MutuallyExclusiveArgumentError("--type: only json logs supported for system logs")
 
-    sub = get_subscription_id(cmd.cli_ctx)
     token_response = ContainerAppClient.get_auth_token(cmd, resource_group_name, name)
     token = token_response["properties"]["token"]
 
-    base_url = ContainerAppClient.show(cmd, resource_group_name, name)["properties"]["eventStreamEndpoint"]
-    base_url = base_url[:base_url.index("/subscriptions/")]
-
     if kind == LOG_TYPE_CONSOLE:
-        url = (f"{base_url}/subscriptions/{sub}/resourceGroups/{resource_group_name}/containerApps/{name}"
-               f"/revisions/{revision}/replicas/{replica}/containers/{container}/logstream")
+        replica_payload = ContainerAppClient.get_replica(cmd, resource_group_name, name, revision, replica)
+        containers = safe_get(replica_payload, "properties", "containers", default=[])
+        container_name = container or ""
+        container_info = next((c for c in containers if c["name"].lower() == container_name.lower()), None)
+        if not container_info:
+            raise ResourceNotFoundError(f"Could not find container '{container}' in replica '{replica}'")
+        url = container_info["logStreamEndpoint"]
     else:
-        url = f"{base_url}/subscriptions/{sub}/resourceGroups/{resource_group_name}/containerApps/{name}/eventstream"
+        container_app = ContainerAppClient.show(cmd, resource_group_name, name)
+        url = container_app["properties"]["eventStreamEndpoint"]
 
     logger.info("connecting to : %s", url)
     request_params = {"follow": str(follow).lower(),


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ❌ 128/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Failed" summary="128/130" -->
<details>
<summary>❌AzureCLI-FullTest</summary>

><details>
> <summary>️✔️acr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️acs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️advisor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️ams</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️apim</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appconfig</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️aro</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️backup</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batch</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batchai</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️billing</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️botservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cloud</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cognitiveservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️compute_recommender</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️computefleet</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️config</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️configure</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️consumption</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️container</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>❌containerapp</summary>
>
>><details>
>> <summary>❌latest</summary>
>>
>>><details>
>>> <summary>❌3.12</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_containerapp_scale_revision_copy|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f1e537ef200><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f1e55dc0680><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-g&nbsp;clitest.rg000001&nbsp;--name&nbsp;aca000002&nbsp;--container&nbsp;aca000002&nbsp;--revision&nbsp;aca000002--42y9avo&nbsp;--replica&nbsp;aca000002--42y9avo-549bcddb4d-dm9vm'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.12/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.12/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:362:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;show_exception_handler(ex)<br>src/azure-cli-core/azure/cli/core/commands/arm.py:476:&nbsp;in&nbsp;show_exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:360:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/custom.py:3580:&nbsp;in&nbsp;stream_containerapp_logs<br>&nbsp;&nbsp;&nbsp;&nbsp;replica_payload&nbsp;=&nbsp;ContainerAppClient.get_replica(cmd,&nbsp;resource_group_name,&nbsp;name,&nbsp;revision,&nbsp;replica)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/_clients.py:424:&nbsp;in&nbsp;get_replica<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;send_raw_request(cmd.cli_ctx,&nbsp;"GET",&nbsp;request_url)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/util.py:1094:&nbsp;in&nbsp;send_raw_request<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;s.send(prepped,&nbsp;**settings)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_scale_revision_copy.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7f1e53940ad0><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_scale_revision_copy.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;3&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>env/lib/python3.12/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.containerapp.tests.latest.test_containerapp_commands.ContainerappScaleTests&nbsp;testMethod=test_containerapp_scale_revision_copy><br>resource_group&nbsp;=&nbsp;'clitest.rg000001'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@AllowLargeResponse(8192)<br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(location="westeurope")<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_containerapp_scale_revision_copy(self,&nbsp;resource_group):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd('configure&nbsp;--defaults&nbsp;location={}'.format(TEST_LOCATION))<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;app&nbsp;=&nbsp;self.create_random_name(prefix='aca',&nbsp;length=24)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env_id&nbsp;=&nbsp;prepare_containerapp_env_for_app_e2e_tests(self)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env_rg&nbsp;=&nbsp;parse_resource_id(env_id).get('resource_group')<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env_name&nbsp;=&nbsp;parse_resource_id(env_id).get('name')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;create&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--image&nbsp;nginx&nbsp;--ingress&nbsp;external&nbsp;--target-port&nbsp;80&nbsp;--environment&nbsp;{env_id}&nbsp;--scale-rule-name&nbsp;http-scale-rule&nbsp;--scale-rule-http-concurrency&nbsp;50&nbsp;--scale-rule-auth&nbsp;trigger=secretref&nbsp;--scale-rule-metadata&nbsp;key=value')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].name",&nbsp;"http-scale-rule"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.metadata.concurrentRequests",&nbsp;"50"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.metadata.key",&nbsp;"value"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.auth[0].triggerParameter",&nbsp;"trigger"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.auth[0].secretRef",&nbsp;"secretref"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;copy&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--image&nbsp;nginx&nbsp;--scale-rule-name&nbsp;my-datadog-rule&nbsp;--scale-rule-type&nbsp;datadog&nbsp;--scale-rule-metadata&nbsp;"queryValue=7"&nbsp;"age=120"&nbsp;"metricUnavailableValue=0"&nbsp;&nbsp;--scale-rule-auth&nbsp;"apiKey=api-key"&nbsp;"appKey=app-key"')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].name",&nbsp;"my-datadog-rule"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.type",&nbsp;"datadog"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.queryValue",&nbsp;"7"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.age",&nbsp;"120"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.metricUnavailableValue",&nbsp;"0"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].triggerParameter",&nbsp;"apiKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].secretRef",&nbsp;"api-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].triggerParameter",&nbsp;"appKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].secretRef",&nbsp;"app-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;revisions_list&nbsp;=&nbsp;self.cmd('containerapp&nbsp;revision&nbsp;list&nbsp;-g&nbsp;{}&nbsp;-n&nbsp;{}'.format(resource_group,&nbsp;app),&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck('length(@)',&nbsp;2),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].name",&nbsp;"my-datadog-rule"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.type",&nbsp;"datadog"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.metadata.queryValue",&nbsp;"7"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.metadata.age",&nbsp;"120"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.metadata.metricUnavailableValue",&nbsp;"0"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[0].triggerParameter",&nbsp;"apiKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[0].secretRef",&nbsp;"api-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[1].triggerParameter",&nbsp;"appKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[1].secretRef",&nbsp;"app-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;restart&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;deactivate&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;activate&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;restart_result&nbsp;=&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;restart&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.assertTrue(restart_result&nbsp;==&nbsp;"Restart&nbsp;succeeded")<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;copy&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--from-revision&nbsp;{revisions_list[1]["name"]}&nbsp;--scale-rule-name&nbsp;my-datadog-rule2&nbsp;--scale-rule-type&nbsp;datadog&nbsp;--scale-rule-metadata&nbsp;"queryValue=7"&nbsp;"age=120"&nbsp;"metricUnavailableValue=0"&nbsp;&nbsp;--scale-rule-auth&nbsp;"apiKey=api-key"&nbsp;"appKey=app-key"',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].name",&nbsp;"my-datadog-rule2"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.type",&nbsp;"datadog"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.queryValue",&nbsp;"7"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.age",&nbsp;"120"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.metricUnavailableValue",&nbsp;"0"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].triggerParameter",&nbsp;"apiKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].secretRef",&nbsp;"api-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].triggerParameter",&nbsp;"appKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].secretRef",&nbsp;"app-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;replica_list&nbsp;=&nbsp;self.cmd(f'containerapp&nbsp;replica&nbsp;list&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;replica&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;--name&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}&nbsp;--replica&nbsp;{replica_list[0]["name"]}',&nbsp;expect_failure=False).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;logs&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;--name&nbsp;{app}&nbsp;--container&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}&nbsp;--replica&nbsp;{replica_list[0]["name"]}',&nbsp;expect_failure=False)<br><br>src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/test_containerapp_commands.py:1551:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f1e537ef200><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f1e55dc0680><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-g&nbsp;clitest.rg000001&nbsp;--name&nbsp;aca000002&nbsp;--container&nbsp;aca000002&nbsp;--revision&nbsp;aca000002--42y9avo&nbsp;--replica&nbsp;aca000002--42y9avo-549bcddb4d-dm9vm'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_scale_revision_copy.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;3&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/containerapp/tests/latest/test_containerapp_commands.py:1479|
>>>|Failed|test_containerapp_logstream|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f1e53ddad50><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f1e54da1370><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-n&nbsp;capp000002&nbsp;-g&nbsp;clitest.rg000001&nbsp;--follow&nbsp;false&nbsp;--format&nbsp;json&nbsp;--tail&nbsp;10'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.12/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.12/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:362:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;show_exception_handler(ex)<br>src/azure-cli-core/azure/cli/core/commands/arm.py:476:&nbsp;in&nbsp;show_exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:360:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/custom.py:3580:&nbsp;in&nbsp;stream_containerapp_logs<br>&nbsp;&nbsp;&nbsp;&nbsp;replica_payload&nbsp;=&nbsp;ContainerAppClient.get_replica(cmd,&nbsp;resource_group_name,&nbsp;name,&nbsp;revision,&nbsp;replica)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/_clients.py:424:&nbsp;in&nbsp;get_replica<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;send_raw_request(cmd.cli_ctx,&nbsp;"GET",&nbsp;request_url)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/util.py:1094:&nbsp;in&nbsp;send_raw_request<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;s.send(prepped,&nbsp;**settings)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.12/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.12/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_logstream.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7f1e53a51cd0><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_logstream.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;2&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>env/lib/python3.12/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.containerapp.tests.latest.test_containerapp_scenario.ContainerappScenarioTest&nbsp;testMethod=test_containerapp_logstream><br>resource_group&nbsp;=&nbsp;'clitest.rg000001'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(location="northeurope")<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_containerapp_logstream(self,&nbsp;resource_group):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;containerapp_name&nbsp;=&nbsp;self.create_random_name(prefix='capp',&nbsp;length=24)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env&nbsp;=&nbsp;prepare_containerapp_env_for_app_e2e_tests(self)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;create&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{containerapp_name}&nbsp;--environment&nbsp;{env}&nbsp;--min-replicas&nbsp;1&nbsp;--ingress&nbsp;external&nbsp;--target-port&nbsp;80')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;logs&nbsp;show&nbsp;-n&nbsp;{containerapp_name}&nbsp;-g&nbsp;{resource_group}&nbsp;--follow&nbsp;false&nbsp;--format&nbsp;json&nbsp;--tail&nbsp;10',&nbsp;expect_failure=False)<br><br>src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/test_containerapp_scenario.py:474:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f1e53ddad50><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f1e54da1370><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-n&nbsp;capp000002&nbsp;-g&nbsp;clitest.rg000001&nbsp;--follow&nbsp;false&nbsp;--format&nbsp;json&nbsp;--tail&nbsp;10'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_logstream.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;2&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/containerapp/tests/latest/test_containerapp_scenario.py:466|
>>>
>>></details>
>>><details>
>>> <summary>❌3.14</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_containerapp_scale_revision_copy|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f6b73569490><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f6b76442210><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-g&nbsp;clitest.rg000001&nbsp;--name&nbsp;aca000002&nbsp;--container&nbsp;aca000002&nbsp;--revision&nbsp;aca000002--42y9avo&nbsp;--replica&nbsp;aca000002--42y9avo-549bcddb4d-dm9vm'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.14/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.14/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:362:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;show_exception_handler(ex)<br>src/azure-cli-core/azure/cli/core/commands/arm.py:476:&nbsp;in&nbsp;show_exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:360:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/custom.py:3580:&nbsp;in&nbsp;stream_containerapp_logs<br>&nbsp;&nbsp;&nbsp;&nbsp;replica_payload&nbsp;=&nbsp;ContainerAppClient.get_replica(cmd,&nbsp;resource_group_name,&nbsp;name,&nbsp;revision,&nbsp;replica)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/_clients.py:424:&nbsp;in&nbsp;get_replica<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;send_raw_request(cmd.cli_ctx,&nbsp;"GET",&nbsp;request_url)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/util.py:1094:&nbsp;in&nbsp;send_raw_request<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;s.send(prepped,&nbsp;**settings)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_scale_revision_copy.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7f6b735ffa10><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_scale_revision_copy.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;3&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>env/lib/python3.14/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.containerapp.tests.latest.test_containerapp_commands.ContainerappScaleTests&nbsp;testMethod=test_containerapp_scale_revision_copy><br>resource_group&nbsp;=&nbsp;'clitest.rg000001'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@AllowLargeResponse(8192)<br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(location="westeurope")<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_containerapp_scale_revision_copy(self,&nbsp;resource_group):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd('configure&nbsp;--defaults&nbsp;location={}'.format(TEST_LOCATION))<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;app&nbsp;=&nbsp;self.create_random_name(prefix='aca',&nbsp;length=24)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env_id&nbsp;=&nbsp;prepare_containerapp_env_for_app_e2e_tests(self)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env_rg&nbsp;=&nbsp;parse_resource_id(env_id).get('resource_group')<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env_name&nbsp;=&nbsp;parse_resource_id(env_id).get('name')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;create&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--image&nbsp;nginx&nbsp;--ingress&nbsp;external&nbsp;--target-port&nbsp;80&nbsp;--environment&nbsp;{env_id}&nbsp;--scale-rule-name&nbsp;http-scale-rule&nbsp;--scale-rule-http-concurrency&nbsp;50&nbsp;--scale-rule-auth&nbsp;trigger=secretref&nbsp;--scale-rule-metadata&nbsp;key=value')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].name",&nbsp;"http-scale-rule"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.metadata.concurrentRequests",&nbsp;"50"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.metadata.key",&nbsp;"value"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.auth[0].triggerParameter",&nbsp;"trigger"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].http.auth[0].secretRef",&nbsp;"secretref"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;copy&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--image&nbsp;nginx&nbsp;--scale-rule-name&nbsp;my-datadog-rule&nbsp;--scale-rule-type&nbsp;datadog&nbsp;--scale-rule-metadata&nbsp;"queryValue=7"&nbsp;"age=120"&nbsp;"metricUnavailableValue=0"&nbsp;&nbsp;--scale-rule-auth&nbsp;"apiKey=api-key"&nbsp;"appKey=app-key"')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].name",&nbsp;"my-datadog-rule"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.type",&nbsp;"datadog"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.queryValue",&nbsp;"7"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.age",&nbsp;"120"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.metricUnavailableValue",&nbsp;"0"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].triggerParameter",&nbsp;"apiKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].secretRef",&nbsp;"api-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].triggerParameter",&nbsp;"appKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].secretRef",&nbsp;"app-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;revisions_list&nbsp;=&nbsp;self.cmd('containerapp&nbsp;revision&nbsp;list&nbsp;-g&nbsp;{}&nbsp;-n&nbsp;{}'.format(resource_group,&nbsp;app),&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck('length(@)',&nbsp;2),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].name",&nbsp;"my-datadog-rule"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.type",&nbsp;"datadog"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.metadata.queryValue",&nbsp;"7"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.metadata.age",&nbsp;"120"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.metadata.metricUnavailableValue",&nbsp;"0"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[0].triggerParameter",&nbsp;"apiKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[0].secretRef",&nbsp;"api-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[1].triggerParameter",&nbsp;"appKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("[1].properties.template.scale.rules[0].custom.auth[1].secretRef",&nbsp;"app-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;restart&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;deactivate&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;activate&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;restart_result&nbsp;=&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;restart&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.assertTrue(restart_result&nbsp;==&nbsp;"Restart&nbsp;succeeded")<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;revision&nbsp;copy&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--from-revision&nbsp;{revisions_list[1]["name"]}&nbsp;--scale-rule-name&nbsp;my-datadog-rule2&nbsp;--scale-rule-type&nbsp;datadog&nbsp;--scale-rule-metadata&nbsp;"queryValue=7"&nbsp;"age=120"&nbsp;"metricUnavailableValue=0"&nbsp;&nbsp;--scale-rule-auth&nbsp;"apiKey=api-key"&nbsp;"appKey=app-key"',&nbsp;checks=[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].name",&nbsp;"my-datadog-rule2"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.type",&nbsp;"datadog"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.queryValue",&nbsp;"7"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.age",&nbsp;"120"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.metadata.metricUnavailableValue",&nbsp;"0"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].triggerParameter",&nbsp;"apiKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[0].secretRef",&nbsp;"api-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].triggerParameter",&nbsp;"appKey"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JMESPathCheck("properties.template.scale.rules[0].custom.auth[1].secretRef",&nbsp;"app-key"),<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;])<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;replica_list&nbsp;=&nbsp;self.cmd(f'containerapp&nbsp;replica&nbsp;list&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}',&nbsp;expect_failure=False).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;replica&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;--name&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}&nbsp;--replica&nbsp;{replica_list[0]["name"]}',&nbsp;expect_failure=False).get_output_in_json()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;logs&nbsp;show&nbsp;-g&nbsp;{resource_group}&nbsp;--name&nbsp;{app}&nbsp;--container&nbsp;{app}&nbsp;--revision&nbsp;{revisions_list[0]["name"]}&nbsp;--replica&nbsp;{replica_list[0]["name"]}',&nbsp;expect_failure=False)<br><br>src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/test_containerapp_commands.py:1551:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f6b73569490><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f6b76442210><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-g&nbsp;clitest.rg000001&nbsp;--name&nbsp;aca000002&nbsp;--container&nbsp;aca000002&nbsp;--revision&nbsp;aca000002--42y9avo&nbsp;--replica&nbsp;aca000002--42y9avo-549bcddb4d-dm9vm'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_scale_revision_copy.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;3&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/aca000002/revisions/aca000002--42y9avo/replicas/aca000002--42y9avo-549bcddb4d-dm9vm/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/containerapp/tests/latest/test_containerapp_commands.py:1479|
>>>|Failed|test_containerapp_logstream|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f6b73db5e50><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f6b7562dd10><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-n&nbsp;capp000002&nbsp;-g&nbsp;clitest.rg000001&nbsp;--follow&nbsp;false&nbsp;--format&nbsp;json&nbsp;--tail&nbsp;10'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.14/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:33:&nbsp;in&nbsp;_handle_main_exception<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>env/lib/python3.14/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:362:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;show_exception_handler(ex)<br>src/azure-cli-core/azure/cli/core/commands/arm.py:476:&nbsp;in&nbsp;show_exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:360:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/custom.py:3580:&nbsp;in&nbsp;stream_containerapp_logs<br>&nbsp;&nbsp;&nbsp;&nbsp;replica_payload&nbsp;=&nbsp;ContainerAppClient.get_replica(cmd,&nbsp;resource_group_name,&nbsp;name,&nbsp;revision,&nbsp;replica)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/containerapp/_clients.py:424:&nbsp;in&nbsp;get_replica<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;send_raw_request(cmd.cli_ctx,&nbsp;"GET",&nbsp;request_url)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/util.py:1094:&nbsp;in&nbsp;send_raw_request<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;s.send(prepped,&nbsp;**settings)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/sessions.py:706:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;r&nbsp;=&nbsp;adapter.send(request,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>env/lib/python3.14/site-packages/requests/adapters.py:645:&nbsp;in&nbsp;send<br>&nbsp;&nbsp;&nbsp;&nbsp;resp&nbsp;=&nbsp;conn.urlopen(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:788:&nbsp;in&nbsp;urlopen<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self._make_request(<br>env/lib/python3.14/site-packages/urllib3/connectionpool.py:534:&nbsp;in&nbsp;_make_request<br>&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;conn.getresponse()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<VCRRequestsHTTPSConnection/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_logstream.yaml(host='management.azure.com',&nbsp;port=443)&nbsp;at&nbsp;0x7f6b73c1dac0><br>_&nbsp;=&nbsp;False,&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;getresponse(self,&nbsp;_=False,&nbsp;**kwargs):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"""Retrieve&nbsp;the&nbsp;response"""<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;Check&nbsp;to&nbsp;see&nbsp;if&nbsp;the&nbsp;cassette&nbsp;has&nbsp;a&nbsp;response&nbsp;for&nbsp;this&nbsp;request.&nbsp;If&nbsp;so,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;then&nbsp;return&nbsp;it<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.can_play_response_for(self._vcr_request):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log.info(f"Playing&nbsp;response&nbsp;for&nbsp;{self._vcr_request}&nbsp;from&nbsp;cassette")<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response&nbsp;=&nbsp;self.cassette.play_response(self._vcr_request)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;VCRHTTPResponse(response,&nbsp;self._vcr_request.uri)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;else:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;self.cassette.write_protected&nbsp;and&nbsp;self.cassette.filter_request(self._vcr_request):<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CannotOverwriteExistingCassetteException(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cassette=self.cassette,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failed_request=self._vcr_request,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vcr.errors.CannotOverwriteExistingCassetteException:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_logstream.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;2&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>env/lib/python3.14/site-packages/vcr/stubs/__init__.py:279:&nbsp;CannotOverwriteExistingCassetteException<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br><br>self&nbsp;=&nbsp;<azure.cli.command_modules.containerapp.tests.latest.test_containerapp_scenario.ContainerappScenarioTest&nbsp;testMethod=test_containerapp_logstream><br>resource_group&nbsp;=&nbsp;'clitest.rg000001'<br><br>&nbsp;&nbsp;&nbsp;&nbsp;@ResourceGroupPreparer(location="northeurope")<br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;test_containerapp_logstream(self,&nbsp;resource_group):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;containerapp_name&nbsp;=&nbsp;self.create_random_name(prefix='capp',&nbsp;length=24)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;env&nbsp;=&nbsp;prepare_containerapp_env_for_app_e2e_tests(self)<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;create&nbsp;-g&nbsp;{resource_group}&nbsp;-n&nbsp;{containerapp_name}&nbsp;--environment&nbsp;{env}&nbsp;--min-replicas&nbsp;1&nbsp;--ingress&nbsp;external&nbsp;--target-port&nbsp;80')<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.cmd(f'containerapp&nbsp;logs&nbsp;show&nbsp;-n&nbsp;{containerapp_name}&nbsp;-g&nbsp;{resource_group}&nbsp;--follow&nbsp;false&nbsp;--format&nbsp;json&nbsp;--tail&nbsp;10',&nbsp;expect_failure=False)<br><br>src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/test_containerapp_scenario.py:474:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:177:&nbsp;in&nbsp;cmd<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;execute(self.cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure).assert_with_checks(checks)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f6b73db5e50><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f6b7562dd10><br>command&nbsp;=&nbsp;'containerapp&nbsp;logs&nbsp;show&nbsp;-n&nbsp;capp000002&nbsp;-g&nbsp;clitest.rg000001&nbsp;--follow&nbsp;false&nbsp;--format&nbsp;json&nbsp;--tail&nbsp;10'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.output&nbsp;=&nbsp;stdout_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.applog&nbsp;=&nbsp;logging_buf.getvalue()<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;except&nbsp;CannotOverwriteExistingCassetteException&nbsp;as&nbsp;ex:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;AssertionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AssertionError:&nbsp;Can't&nbsp;overwrite&nbsp;existing&nbsp;cassette&nbsp;('/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_logstream.yaml')&nbsp;in&nbsp;your&nbsp;current&nbsp;record&nbsp;mode&nbsp;(<RecordMode.ONCE:&nbsp;'once'>).<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No&nbsp;match&nbsp;for&nbsp;the&nbsp;request&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;was&nbsp;found.<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Found&nbsp;2&nbsp;recorded&nbsp;request(s)&nbsp;matching&nbsp;(<Request&nbsp;(GET)&nbsp;https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/capp000002/revisions/capp000002--06gt4fk/replicas/capp000002--06gt4fk-55955c9b88-b455l/?api-version=2025-07-01>)&nbsp;but&nbsp;they&nbsp;have&nbsp;already&nbsp;been&nbsp;consumed.<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:308:&nbsp;AssertionError|azure/cli/command_modules/containerapp/tests/latest/test_containerapp_scenario.py:466|
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️core</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cosmosdb</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️databoxedge</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dls</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventgrid</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventhubs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️feedback</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️find</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️hdinsight</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️identity</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️iot</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️keyvault</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️lab</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️managedservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️maps</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️marketplaceordering</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️monitor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️mysql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️netappfiles</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️network</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️policyinsights</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️postgresql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️privatedns</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️profile</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️rdbms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️redis</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️relay</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️resource</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️role</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️search</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️security</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicebus</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️serviceconnector</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicefabric</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️signalr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sqlvm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️storage</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️synapse</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️telemetry</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️util</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️vm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Use the replica container logStreamEndpoint for console logs so express apps do not depend on eventStreamEndpoint. Continue using the container app eventStreamEndpoint for system logs and document the fix.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
