### PR TITLE
[App Service] Prevent access restriction updates from dropping site config

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
@@ -21,6 +21,12 @@ logger = get_logger(__name__)
 ALLOWED_HTTP_HEADER_NAMES = ['x-forwarded-host', 'x-forwarded-for', 'x-azure-fdid', 'x-fd-healthprobe']
 
 
+def _update_webapp_access_restrictions(cmd, resource_group_name, name, slot, properties):
+    config = {'properties': properties}
+    return _generic_site_operation(
+        cmd.cli_ctx, resource_group_name, name, 'update_configuration', slot, config)
+
+
 def show_webapp_access_restrictions(cmd, resource_group_name, name, slot=None):
     configs = get_site_configs(cmd, resource_group_name, name, slot)
     access_restrictions = [r.as_dict() for r in (configs.ip_security_restrictions or [])]
@@ -100,8 +106,9 @@ def add_webapp_access_restriction(
         logger.info(http_headers)
         rule_instance.headers = _parse_http_headers(http_headers=http_headers)
 
-    result = _generic_site_operation(
-        cmd.cli_ctx, resource_group_name, name, 'update_configuration', slot, configs)
+    property_name = 'scmIpSecurityRestrictions' if scm_site else 'ipSecurityRestrictions'
+    result = _update_webapp_access_restrictions(
+        cmd, resource_group_name, name, slot, {property_name: access_rules})
     return result.scm_ip_security_restrictions if scm_site else result.ip_security_restrictions
 
 
@@ -154,25 +161,25 @@ def remove_webapp_access_restriction(cmd, resource_group_name, name, rule_name=N
 
     access_rules.remove(rule_instance)
 
-    result = _generic_site_operation(
-        cmd.cli_ctx, resource_group_name, name, 'update_configuration', slot, configs)
+    property_name = 'scmIpSecurityRestrictions' if scm_site else 'ipSecurityRestrictions'
+    result = _update_webapp_access_restrictions(
+        cmd, resource_group_name, name, slot, {property_name: access_rules})
     return result.scm_ip_security_restrictions if scm_site else result.ip_security_restrictions
 
 
 def set_webapp_access_restriction(cmd, resource_group_name, name, use_same_restrictions_for_scm_site=None,
                                   default_action=None, scm_default_action=None, slot=None):
-    configs = get_site_configs(cmd, resource_group_name, name, slot)
+    properties = {}
 
     if use_same_restrictions_for_scm_site is not None:
-        setattr(configs, 'scm_ip_security_restrictions_use_main', bool(use_same_restrictions_for_scm_site))
+        properties['scmIpSecurityRestrictionsUseMain'] = bool(use_same_restrictions_for_scm_site)
     if default_action is not None:
-        setattr(configs, 'ip_security_restrictions_default_action', default_action)
+        properties['ipSecurityRestrictionsDefaultAction'] = default_action
     if scm_default_action is not None:
-        setattr(configs, 'scm_ip_security_restrictions_default_action', scm_default_action)
+        properties['scmIpSecurityRestrictionsDefaultAction'] = scm_default_action
 
-    app_config = _generic_site_operation(
-        cmd.cli_ctx, resource_group_name, name, 'update_configuration',
-        slot, configs)
+    app_config = _update_webapp_access_restrictions(
+        cmd, resource_group_name, name, slot, properties)
     app_use_main = app_config.scm_ip_security_restrictions_use_main
     app_default_action = app_config.ip_security_restrictions_default_action
     app_scm_default_action = app_config.scm_ip_security_restrictions_default_action

--- a/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
@@ -127,7 +127,7 @@ def remove_webapp_access_restriction(cmd, resource_group_name, name, rule_name=N
     rule_instance = None
     # get rules list
     access_rules = configs.scm_ip_security_restrictions if scm_site else configs.ip_security_restrictions
-    for rule in list(access_rules):
+    for rule in (list(access_rules) if access_rules is not None else []):
         if rule_name and input_rule_types == 0:
             if rule.name and rule.name.lower() == rule_name.lower() and rule.action == action:
                 rule_instance = rule


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
