### PR TITLE
(chore): finish removing usage of "six"

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -2435,7 +2435,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('expiry', type=get_datetime_type(True), help='expiration UTC datetime in (Y-m-d\'T\'H:M:S\'Z\')')
         c.ignore('auth_mode')
 
-    from six import u as unicode_string
     for item in ['get', 'peek', 'put', 'update', 'delete', 'clear']:
         with self.argument_context('storage message {}'.format(item)) as c:
             c.extra('queue_name', queue_name_type, required=True)
@@ -2450,7 +2449,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                             'the :func:`~get_messages` or :func:`~update_message` operation.')
 
     with self.argument_context('storage message put') as c:
-        c.argument('content', type=unicode_string, help='Message content, up to 64KB in size.')
+        c.argument('content', type=str, help='Message content, up to 64KB in size.')
         c.extra('time_to_live', type=int,
                 help='Specify the time-to-live interval for the message, in seconds. '
                      'The time-to-live may be any positive number or -1 for infinity. '
@@ -2478,7 +2477,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                      'a maximum of 32. By default, a single message is peeked from the queue with this operation.')
 
     with self.argument_context('storage message update') as c:
-        c.argument('content', type=unicode_string, help='Message content, up to 64KB in size.')
+        c.argument('content', type=str, help='Message content, up to 64KB in size.')
         c.extra('visibility_timeout', type=int,
                 help='If not specified, the default value is 0. Specify the new visibility timeout value, in seconds, '
                      'relative to server time. The new value must be larger than or equal to 0, and cannot be larger '

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -131,7 +131,6 @@ requests-oauthlib==1.2.0
 requests==2.33.0
 scp==0.13.2
 semver==3.0.4
-six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
 urllib3==2.7.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -132,7 +132,6 @@ requests-oauthlib==1.2.0
 requests==2.33.0
 scp==0.13.2
 semver==3.0.4
-six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
 urllib3==2.7.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -133,7 +133,6 @@ requests-oauthlib==1.2.0
 requests==2.33.0
 scp==0.13.2
 semver==3.0.4
-six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
 urllib3==2.7.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -153,7 +153,6 @@ DEPENDENCIES = [
     'PyNaCl~=1.6.2',
     'scp~=0.13.2',
     'semver~=3.0',
-    'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
     # Even though knack already depends on tabulate, profile module directly uses it for interactive subscription
     # selection


### PR DESCRIPTION

**History Notes**

I've be doing this for a while: https://wiki.debian.org/Python3-six-removal , and I'd like to see the end of it.