### PR TITLE
[AKS] `az aks update`: Fix bug where autoscale profile boolean values could be incorrectly serialized as strings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -452,7 +452,12 @@ class AKSManagedClusterContext(BaseAKSContext):
             valid_keys = list(
                 k.replace("_", "-") for k in attribute_list(self.models.ManagedClusterPropertiesAutoScalerProfile())
             )
-            for key in cluster_autoscaler_profile.keys():
+            boolean_keys = {
+                "daemonset-eviction-for-empty-nodes",
+                "daemonset-eviction-for-occupied-nodes",
+                "ignore-daemonsets-utilization",
+            }
+            for key, value in cluster_autoscaler_profile.items():
                 if not key:
                     raise InvalidArgumentValueError("Empty key specified for cluster-autoscaler-profile")
                 if key not in valid_keys:
@@ -461,6 +466,13 @@ class AKSManagedClusterContext(BaseAKSContext):
                             key, ", ".join(valid_keys)
                         )
                     )
+                if key in boolean_keys and not isinstance(value, bool):
+                    if not isinstance(value, str) or value.lower() not in ("true", "false"):
+                        raise InvalidArgumentValueError(
+                            "Value '{}' for cluster-autoscaler-profile key '{}' must be either 'true' or 'false'."
+                            .format(value, key)
+                        )
+                    cluster_autoscaler_profile[key] = value.lower() == "true"
         return cluster_autoscaler_profile
 
     # pylint: disable=no-self-use
@@ -4819,7 +4831,10 @@ class AKSManagedClusterContext(BaseAKSContext):
         # this parameter does not need validation
         return node_os_upgrade_channel
 
-    def _get_cluster_autoscaler_profile(self, read_only: bool = False) -> Union[Dict[str, str], None]:
+    def _get_cluster_autoscaler_profile(
+        self,
+        read_only: bool = False
+    ) -> Union[Dict[str, Union[str, bool]], None]:
         """Internal function to dynamically obtain the value of cluster_autoscaler_profile according to the context.
 
         This function will call function "__validate_cluster_autoscaler_profile" to parse and verify the parameter
@@ -4849,7 +4864,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         # dynamic completion for update mode only
         if not read_only and self.decorator_mode == DecoratorMode.UPDATE:
             if cluster_autoscaler_profile and self.mc and self.mc.auto_scaler_profile:
-                # shallow copy should be enough for string-to-string dictionary
+                # shallow copy is enough for a dictionary of scalar values
                 copy_of_raw_dict = dict(self.mc.auto_scaler_profile)
                 new_options_dict = dict(cluster_autoscaler_profile.items())
                 copy_of_raw_dict.update(new_options_dict)
@@ -4858,7 +4873,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         # this parameter does not need validation
         return cluster_autoscaler_profile
 
-    def get_cluster_autoscaler_profile(self) -> Union[Dict[str, str], None]:
+    def get_cluster_autoscaler_profile(self) -> Union[Dict[str, Union[str, bool]], None]:
         """Dynamically obtain the value of cluster_autoscaler_profile according to the context.
 
         This function will call function "__validate_cluster_autoscaler_profile" to parse and verify the parameter

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -249,6 +249,40 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         with self.assertRaises(InvalidArgumentValueError):
             ctx._AKSManagedClusterContext__validate_cluster_autoscaler_profile(s10)
 
+        # SDK boolean values
+        s11 = [
+            "daemonset-eviction-for-empty-nodes=true",
+            "daemonset-eviction-for-occupied-nodes=FALSE",
+            "ignore-daemonsets-utilization=True",
+            "balance-similar-node-groups=true",
+        ]
+        t11 = ctx._AKSManagedClusterContext__validate_cluster_autoscaler_profile(s11)
+        g11 = {
+            "daemonset-eviction-for-empty-nodes": True,
+            "daemonset-eviction-for-occupied-nodes": False,
+            "ignore-daemonsets-utilization": True,
+            "balance-similar-node-groups": "true",
+        }
+        self.assertEqual(t11, g11)
+
+        # already-normalized SDK boolean values
+        s12 = {
+            "daemonset-eviction-for-empty-nodes": False,
+            "daemonset-eviction-for-occupied-nodes": True,
+            "ignore-daemonsets-utilization": False,
+        }
+        t12 = ctx._AKSManagedClusterContext__validate_cluster_autoscaler_profile(s12)
+        self.assertEqual(t12, s12)
+
+        # invalid SDK boolean value
+        for key in (
+            "daemonset-eviction-for-empty-nodes",
+            "daemonset-eviction-for-occupied-nodes",
+            "ignore-daemonsets-utilization",
+        ):
+            with self.subTest(key=key), self.assertRaises(InvalidArgumentValueError):
+                ctx._AKSManagedClusterContext__validate_cluster_autoscaler_profile({key: "yes"})
+
     def test_validate_gmsa_options(self):
         # default
         ctx = AKSManagedClusterContext(


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**
az aks update
az aks create

**Description**<!--Mandatory-->
Fix a bug in az aks update where string flags were not getting translated to booleans properly

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
