### PR TITLE
[Compute] Fix #34063: az vmss update: Clear the stale zone placement filter when switching filters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -5150,9 +5150,11 @@ def update_vmss(cmd, resource_group_name, name, license_type=None, no_wait=False
 
         if include_zones is not None:
             vmss["placement"]["include_zones"] = include_zones
+            vmss["placement"].pop("exclude_zones", None)
 
         if exclude_zones is not None:
             vmss["placement"]["exclude_zones"] = exclude_zones
+            vmss["placement"].pop("include_zones", None)
 
     from .operations.vmss import VMSSCreate
     return VMSSCreate(cli_ctx=cmd.cli_ctx)(command_args=vmss)

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -16,7 +16,7 @@ from azure.cli.command_modules.vm.custom import (enable_boot_diagnostics, disabl
                                                  _get_extension_instance_name,
                                                  get_boot_log)
 from azure.cli.command_modules.vm.custom import \
-    (attach_unmanaged_data_disk, detach_unmanaged_data_disk, get_vmss_instance_view)
+    (attach_unmanaged_data_disk, detach_unmanaged_data_disk, get_vmss_instance_view, update_vmss)
 
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import AzCliCommand
@@ -165,6 +165,37 @@ class TestVmCustom(unittest.TestCase):
 
         # assert
         self.assertEqual(result, 'extension-name')
+
+    @mock.patch('azure.cli.command_modules.vm.operations.vmss.VMSSCreate')
+    def test_update_vmss_switches_zone_placement_filter(self, vmss_create_mock):
+        transitions = (
+            ('includeZones', ['1'], 'exclude_zones', ['2'], 'include_zones'),
+            ('excludeZones', ['2'], 'include_zones', ['1'], 'exclude_zones'),
+        )
+
+        for existing_key, existing_value, new_key, new_value, stale_key in transitions:
+            with self.subTest(existing_key=existing_key, new_key=new_key):
+                vmss_create_mock.reset_mock()
+                parameters = {
+                    'location': 'eastus2',
+                    'placement': {
+                        'zonePlacementPolicy': 'Auto',
+                        existing_key: existing_value,
+                    },
+                }
+
+                update_vmss(
+                    _get_test_cmd(),
+                    'resource-group',
+                    'vmss-name',
+                    parameters=parameters,
+                    **{new_key: new_value}
+                )
+
+                command_args = vmss_create_mock.return_value.call_args.kwargs['command_args']
+                placement = command_args['placement']
+                self.assertEqual(new_value, placement[new_key])
+                self.assertNotIn(stale_key, placement)
 
 
 class TestVMBootLog(unittest.TestCase):


### PR DESCRIPTION
**Related command**

`az vmss update`

**Description**

Fixes #34063

When a VMSS already contains `placement.includeZones` or `placement.excludeZones`, generic update loads and preserves that existing property.

If the user supplies the opposite argument, the existing implementation adds the new filter without removing the old one. The complete model passed to the AAZ VMSS create-or-update operation therefore contains both mutually exclusive properties, which Compute rejects.

This change normalizes placement state in the legacy `update_vmss` customization:

- Supplying `--include-zones` removes a persisted `excludeZones`.
- Supplying `--exclude-zones` removes a persisted `includeZones`.
- Supplying neither continues to preserve the existing filter.
- Supplying both in one invocation remains rejected by the existing validator.

The regression test exercises both transition directions and inspects the exact model passed to `VMSSCreate`.

The fix belongs in the Azure CLI custom update handler because it depends on distinguishing persisted generic-update state from an explicitly supplied CLI argument. The generated AAZ schema and PUT serializer correctly represent both service properties and do not require modification.

Feature-introduction context: #33639.

**Testing Guide**

Focused regression:

```bash
VIRTUAL_ENV="$PWD/.venv" \
AZURE_CONFIG_DIR=/private/tmp/azure-cli-vmss-test \
AZDEV_CONFIG_DIR=/private/tmp/azure-cli-azdev \
.venv/bin/azdev test test_update_vmss_switches_zone_placement_filter --discover
```

Result: `1 passed, 2 subtests passed`.

Relevant unit module:

```bash
VIRTUAL_ENV="$PWD/.venv" \
AZURE_CONFIG_DIR=/private/tmp/azure-cli-vmss-test \
AZDEV_CONFIG_DIR=/private/tmp/azure-cli-azdev \
.venv/bin/azdev test test_custom_vm_commands --discover
```

Result: `8 passed, 2 subtests passed`.

Existing update playback:

```bash
VIRTUAL_ENV="$PWD/.venv" \
AZURE_CONFIG_DIR=/private/tmp/azure-cli-vmss-test \
AZDEV_CONFIG_DIR=/private/tmp/azure-cli-azdev \
.venv/bin/azdev test test_vmss_update_zone_placement_policy --discover
```

Result: `1 passed`.

Related include/exclude/conflict playback tests:

```bash
VIRTUAL_ENV="$PWD/.venv" \
AZURE_CONFIG_DIR=/private/tmp/azure-cli-vmss-test \
AZDEV_CONFIG_DIR=/private/tmp/azure-cli-azdev \
.venv/bin/azdev test \
test_vmss_zone_placement_policy_with_include_zones \
test_vmss_zone_placement_policy_with_exclude_zones \
test_vmss_zone_placement_policy_validation_zones_conflict \
--discover --series
```

Result: `3 passed`.

```bash
VIRTUAL_ENV="$PWD/.venv" \
AZDEV_CONFIG_DIR=/private/tmp/azure-cli-azdev \
.venv/bin/azdev style vm
```

Result: Pylint and Flake8 passed.

```bash
VIRTUAL_ENV="$PWD/.venv" \
AZDEV_CONFIG_DIR=/private/tmp/azure-cli-azdev \
.venv/bin/azdev linter vm
```

Result: passed with no violations.

```bash
git diff --check origin/dev...HEAD
```

Result: passed.

The full `azdev test vm` suite and a live Azure VMSS transition were not run. No recordings were regenerated.

**History Notes**

[Compute] `az vmss update`: Fix switching between `--include-zones` and `--exclude-zones` when the opposite zone placement filter is already configured

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
