### PR TITLE
[Network] `az network virtual-appliance migration`: `--migration-type` is optional

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/migration/_commit.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/migration/_commit.py
@@ -22,7 +22,7 @@ class Commit(AAZCommand):
     cannot be reversed with `abort`.
 
     :example: Commit the migration of a Network Virtual Appliance to the new internal load balancer (ILB) architecture.
-        az network virtual-appliance migration commit -n MyName -g MyRG --migration-type MigrateToNewILBArchitecture
+        az network virtual-appliance migration commit -n MyName -g MyRG
     """
 
     _aaz_info = {
@@ -65,8 +65,7 @@ class Commit(AAZCommand):
         _args_schema.migration_type = AAZStrArg(
             options=["--migration-type"],
             arg_group="Properties",
-            help="The type of migration workflow to commit for the Network Virtual Appliance. Must match the type used in the prepare and execute phases.",
-            required=True,
+            help="The type of migration workflow to commit for the Network Virtual Appliance. If omitted, the migration defaults to MigrateToNewILBArchitecture. Otherwise, it must match the type used in the prepare and execute phases.",
             enum={"MigrateToNewILBArchitecture": "MigrateToNewILBArchitecture", "MigrateToNewOSVersion": "MigrateToNewOSVersion"},
         )
         return cls._args_schema
@@ -177,7 +176,7 @@ class Commit(AAZCommand):
 
             properties = _builder.get(".properties")
             if properties is not None:
-                properties.set_prop("migrationType", AAZStrType, ".migration_type", typ_kwargs={"flags": {"required": True}})
+                properties.set_prop("migrationType", AAZStrType, ".migration_type")
 
             return self.serialize_content(_content_value)
 

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/migration/_execute.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/migration/_execute.py
@@ -22,7 +22,7 @@ class Execute(AAZCommand):
     completes, run `commit` to finalize the migration or `abort` to roll it back.
 
     :example: Execute the migration of a Network Virtual Appliance to the new internal load balancer (ILB) architecture.
-        az network virtual-appliance migration execute -n MyName -g MyRG --migration-type MigrateToNewILBArchitecture
+        az network virtual-appliance migration execute -n MyName -g MyRG
     """
 
     _aaz_info = {
@@ -65,8 +65,7 @@ class Execute(AAZCommand):
         _args_schema.migration_type = AAZStrArg(
             options=["--migration-type"],
             arg_group="Properties",
-            help="The type of migration workflow to execute for the Network Virtual Appliance. Must match the type used in the prepare phase.",
-            required=True,
+            help="The type of migration workflow to execute for the Network Virtual Appliance. If omitted, the migration defaults to MigrateToNewILBArchitecture. Otherwise, it must match the type used in the prepare phase.",
             enum={"MigrateToNewILBArchitecture": "MigrateToNewILBArchitecture", "MigrateToNewOSVersion": "MigrateToNewOSVersion"},
         )
         return cls._args_schema
@@ -177,7 +176,7 @@ class Execute(AAZCommand):
 
             properties = _builder.get(".properties")
             if properties is not None:
-                properties.set_prop("migrationType", AAZStrType, ".migration_type", typ_kwargs={"flags": {"required": True}})
+                properties.set_prop("migrationType", AAZStrType, ".migration_type")
 
             return self.serialize_content(_content_value)
 

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/migration/_prepare.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/migration/_prepare.py
@@ -22,7 +22,7 @@ class Prepare(AAZCommand):
     stages the resources required to perform it.
 
     :example: Prepare a Network Virtual Appliance for migration to the new internal load balancer (ILB) architecture.
-        az network virtual-appliance migration prepare -n MyName -g MyRG --migration-type MigrateToNewILBArchitecture
+        az network virtual-appliance migration prepare -n MyName -g MyRG
     """
 
     _aaz_info = {
@@ -65,8 +65,7 @@ class Prepare(AAZCommand):
         _args_schema.migration_type = AAZStrArg(
             options=["--migration-type"],
             arg_group="Properties",
-            help="The type of migration workflow to prepare for the Network Virtual Appliance.",
-            required=True,
+            help="The type of migration workflow to prepare for the Network Virtual Appliance. If omitted, the migration defaults to MigrateToNewILBArchitecture.",
             enum={"MigrateToNewILBArchitecture": "MigrateToNewILBArchitecture", "MigrateToNewOSVersion": "MigrateToNewOSVersion"},
         )
         _args_schema.marketplace_version = AAZStrArg(
@@ -183,7 +182,7 @@ class Prepare(AAZCommand):
             properties = _builder.get(".properties")
             if properties is not None:
                 properties.set_prop("marketPlaceVersion", AAZStrType, ".marketplace_version")
-                properties.set_prop("migrationType", AAZStrType, ".migration_type", typ_kwargs={"flags": {"required": True}})
+                properties.set_prop("migrationType", AAZStrType, ".migration_type")
 
             return self.serialize_content(_content_value)
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -8859,7 +8859,6 @@ class NetworkVirtualApplianceMigrationScenarioTest(ScenarioTest):
             'nva_name': 'clivirtualappliancemigration',  # NVA name
             'rg': resource_group,
             'subscription': subscriptionId,
-            'migration_type': 'MigrateToNewILBArchitecture',
         })
 
         # Add the required extension
@@ -8895,7 +8894,7 @@ class NetworkVirtualApplianceMigrationScenarioTest(ScenarioTest):
                  ])
 
         # Phase 1: prepare the migration to the new ILB architecture
-        self.cmd('network virtual-appliance migration prepare -g {rg} -n {nva_name} --migration-type {migration_type}')
+        self.cmd('network virtual-appliance migration prepare -g {rg} -n {nva_name}')
 
         provisioning_state = self.cmd('network virtual-appliance show -g {rg} -n {nva_name}').get_output_in_json()['provisioningState']
         retry_count = 0
@@ -8907,7 +8906,7 @@ class NetworkVirtualApplianceMigrationScenarioTest(ScenarioTest):
             provisioning_state = self.cmd('network virtual-appliance show -g {rg} -n {nva_name}').get_output_in_json()['provisioningState']
 
         # Phase 2: execute the migration
-        self.cmd('network virtual-appliance migration execute -g {rg} -n {nva_name} --migration-type {migration_type}')
+        self.cmd('network virtual-appliance migration execute -g {rg} -n {nva_name}')
 
         provisioning_state = self.cmd('network virtual-appliance show -g {rg} -n {nva_name}').get_output_in_json()['provisioningState']
         retry_count = 0
@@ -8919,7 +8918,7 @@ class NetworkVirtualApplianceMigrationScenarioTest(ScenarioTest):
             provisioning_state = self.cmd('network virtual-appliance show -g {rg} -n {nva_name}').get_output_in_json()['provisioningState']
 
         # Phase 3: commit the migration to finalize the new ILB architecture
-        self.cmd('network virtual-appliance migration commit -g {rg} -n {nva_name} --migration-type {migration_type}')
+        self.cmd('network virtual-appliance migration commit -g {rg} -n {nva_name}')
 
         # Ensure that the provisioning state is 'Succeeded' after committing the migration
         provisioning_state = self.cmd('network virtual-appliance show -g {rg} -n {nva_name}').get_output_in_json()['provisioningState']

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
@@ -24,6 +24,39 @@ class TestNetworkUnitTests(unittest.TestCase):
             self.assertIsNotNone(hsm.key_id)
             self.assertIsNotNone(hsm.public_cert_data)
 
+    def test_virtual_appliance_ilb_migration_allows_null_body(self):
+        from azure.cli.core.aaz._command_ctx import AAZCommandCtx
+        from azure.cli.core.mock import DummyCli
+        from azure.cli.command_modules.network.aaz.latest.network.virtual_appliance.migration import (
+            Commit, Execute, Prepare)
+
+        commands = (
+            (Prepare, Prepare.NetworkVirtualAppliancesPrepareMigration),
+            (Execute, Execute.NetworkVirtualAppliancesExecuteMigration),
+            (Commit, Commit.NetworkVirtualAppliancesCommitMigration),
+        )
+        for command, operation_type in commands:
+            schema = command._build_arguments_schema()
+            self.assertFalse(schema.migration_type.to_cmd_arg('migration_type').type.settings['required'])
+
+            with self.subTest(command=command.__name__, body='null'):
+                ctx = AAZCommandCtx(DummyCli(), schema, {})
+                operation = object.__new__(operation_type)
+                operation.ctx = ctx
+                self.assertIsNone(operation.content)
+
+            with self.subTest(command=command.__name__, body='explicit'):
+                ctx = AAZCommandCtx(DummyCli(), schema, {
+                    'migration_type': 'MigrateToNewOSVersion',
+                })
+                operation = object.__new__(operation_type)
+                operation.ctx = ctx
+                self.assertEqual(operation.content, {
+                    'properties': {
+                        'migrationType': 'MigrateToNewOSVersion',
+                    }
+                })
+
     def test_network_get_nic_ip_config(self):
         from azure.cli.command_modules.network.custom import _get_nic_ip_config
 


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes | Tests |
| :--: | :--: |
| ⚠️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>⚠️AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>⚠️network</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1009 - ParaPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1009.md)|network virtual-appliance migration commit|cmd `network virtual-appliance migration commit` update parameter `migration_type`: removed property `required=True`||
>|⚠️ [1009 - ParaPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1009.md)|network virtual-appliance migration execute|cmd `network virtual-appliance migration execute` update parameter `migration_type`: removed property `required=True`||
>|⚠️ [1009 - ParaPropRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1009.md)|network virtual-appliance migration prepare|cmd `network virtual-appliance migration prepare` update parameter `migration_type`: removed property `required=True`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

**Related command**

`az network virtual-appliance migration prepare`  
`az network virtual-appliance migration execute`  
`az network virtual-appliance migration commit`

**Description**

Updates the Network Virtual Appliance ILB migration flow to support a null request body.

`--migration-type` is now optional for the `prepare`, `execute`, and `commit` commands. When omitted, Azure CLI sends no request body and the service defaults the migration type to `MigrateToNewILBArchitecture`.

Explicitly specifying `--migration-type` remains supported for other workflows such as `MigrateToNewOSVersion`.

Related AAZ PR: https://github.com/Azure/aaz/pull/1088  
Original Azure CLI PR: https://github.com/Azure/azure-cli/pull/33766

**Testing Guide**

Run an ILB migration without specifying `--migration-type`:

```bash
# Phase 1: Prepare the ILB migration
az network virtual-appliance migration prepare \
    --resource-group MyResourceGroup \
    --name MyNva

# Phase 2: Execute the prepared migration
az network virtual-appliance migration execute \
    --resource-group MyResourceGroup \
    --name MyNva

# Phase 3: Commit the migration
az network virtual-appliance migration commit \
    --resource-group MyResourceGroup \
    --name MyNva
```

Verify the provisioning state between phases:

```bash
az network virtual-appliance show \
    --resource-group MyResourceGroup \
    --name MyNva \
    --query provisioningState
```

The existing explicit request-body flow remains supported:

```bash
az network virtual-appliance migration prepare \
    --resource-group MyResourceGroup \
    --name MyNva \
    --migration-type MigrateToNewOSVersion \
    --marketplace-version <version>
```

Automated tests verify that:

- `--migration-type` is optional for all three phases.
- Omitting migration options serializes the request body as `None`.
- Explicit OS migration options continue to serialize the expected request body.
- The live migration scenario exercises the null-body ILB workflow.

**History Notes**

[Network] `az network virtual-appliance migration`: Allow ILB migration commands to omit `--migration-type`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).