### PR TITLE
[DevTest Labs] `az lab vm create`: Fix `--expiration-date` always failing with a datetime comparison error

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/lab/tests/latest/test_lab_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/tests/latest/test_lab_validators.py
@@ -3,10 +3,14 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import datetime
 import unittest
 from azure.mgmt.core.tools import is_valid_resource_id
+from azure.cli.core.aaz import AAZArgumentsSchema, AAZDateTimeArg
+from azure.cli.core.aaz._command_ctx import AAZCommandCtx
 from azure.cli.core.azclierror import ArgumentUsageError
-from azure.cli.command_modules.lab.validators import _update_artifacts
+from azure.cli.core.mock import DummyCli
+from azure.cli.command_modules.lab.validators import _update_artifacts, _validate_expiration_date
 
 
 class ValidatorsCommandTest(unittest.TestCase):
@@ -65,3 +69,31 @@ class ValidatorsCommandTest(unittest.TestCase):
         del invalid_artifact['artifact_id']
         with self.assertRaises(ArgumentUsageError):
             _update_artifacts([invalid_artifact], self.lab_resource_id)
+
+
+class ExpirationDateValidatorTest(unittest.TestCase):
+    @staticmethod
+    def _build_args(expiration_date=None):
+        """ Builds the args `az lab vm create` hands to the validator. """
+        schema = AAZArgumentsSchema()
+        schema.expiration_date = AAZDateTimeArg(options=['--expiration-date'])
+        command_args = {} if expiration_date is None else {'expiration_date': expiration_date}
+        ctx = AAZCommandCtx(cli_ctx=DummyCli(), schema=schema, command_args=command_args)
+        ctx.format_args()
+        return ctx.args
+
+    def test_expiration_date_in_future(self):
+        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=2)
+        # No offset, a Z suffix and an explicit offset all reach the validator as UTC timestamps.
+        for expiration_date in (future.strftime('%Y-%m-%d %H:%M:%S'),
+                                future.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                                future.strftime('%Y-%m-%d %H:%M:%S+00:00')):
+            _validate_expiration_date(self._build_args(expiration_date))
+
+    def test_expiration_date_in_past(self):
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
+        with self.assertRaises(ArgumentUsageError):
+            _validate_expiration_date(self._build_args(past.strftime('%Y-%m-%dT%H:%M:%S.%fZ')))
+
+    def test_expiration_date_not_provided(self):
+        _validate_expiration_date(self._build_args())

--- a/src/azure-cli/azure/cli/command_modules/lab/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/validators.py
@@ -115,7 +115,10 @@ def _validate_expiration_date(args):
     if has_value(args.expiration_date):
         import datetime
         import dateutil.parser
-        if datetime.datetime.utcnow() >= dateutil.parser.parse(args.expiration_date.to_serialized_data()):
+        # AAZDateTimeArg normalizes --expiration-date into an offset-aware UTC timestamp, so "now"
+        # has to be offset-aware too. datetime.utcnow() is naive and the comparison raises TypeError.
+        if datetime.datetime.now(datetime.timezone.utc) >= \
+                dateutil.parser.parse(args.expiration_date.to_serialized_data()):
             raise ArgumentUsageError(
                 "Expiration date '{}' must be in future.".format(args.expiration_date.to_serialized_data()))
 


### PR DESCRIPTION
**Related command**

`az lab vm create --expiration-date`

**Description**

`--expiration-date` is unusable on `az lab vm create`. Every date fails, which is what #31611 reports.

By the time `_validate_expiration_date` runs, `AAZDateTimeArg` has already normalized the argument into a UTC timestamp, since `AAZCommand._handler` calls `format_args()` before `pre_operations`. So the validator always parses an offset aware datetime. It compared that against `datetime.datetime.utcnow()`, which is naive, and Python won't compare the two.

The validator does no I/O, so this reproduces on `dev` with no Azure credentials. The snippet sets the argument up through the same `AAZCommandCtx.format_args()` call the command goes through:

```python
from azure.cli.core.aaz import AAZArgumentsSchema, AAZDateTimeArg
from azure.cli.core.aaz._command_ctx import AAZCommandCtx
from azure.cli.core.mock import DummyCli
from azure.cli.command_modules.lab.validators import _validate_expiration_date

schema = AAZArgumentsSchema()
schema.expiration_date = AAZDateTimeArg(options=['--expiration-date'])
ctx = AAZCommandCtx(cli_ctx=DummyCli(), schema=schema,
                    command_args={'expiration_date': '2030-06-17T22:00:00.000Z'})
ctx.format_args()
_validate_expiration_date(ctx.args)
```

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

Swap in `2030-06-17 22:00:00`, `2030-06-17 22:00:00+00:00` or `2030-06-17 22:00:00.000+00:00` and the traceback is identical. Those are the four date strings from the issue, with the year bumped so the date is still in the future.

I switched the comparison to `datetime.datetime.now(datetime.timezone.utc)`. That drops a `utcnow()` call too, which has been deprecated since Python 3.12.

**Testing Guide**

`ExpirationDateValidatorTest` in `test_lab_validators.py` sets the argument up the same way, then checks that a future date passes, a past date still raises `ArgumentUsageError`, and an omitted date is left alone. Revert `validators.py` and both date tests fail with the `TypeError` above.

The recorded scenario tests never passed `--expiration-date`, which is why none of them caught this. They still pass:

```
python -m pytest src/azure-cli/azure/cli/command_modules/lab/tests/latest/ -q
8 passed, 1 skipped
```